### PR TITLE
Remove SSH passphrase from deploy step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -264,7 +264,6 @@ jobs:
           host: ${{ vars.OCI_HOST }}
           username: ${{ vars.OCI_USERNAME }}
           key: ${{ secrets.OCI_SSH_KEY }}
-          passphrase: ${{ secrets.OCI_SSH_PASSPHRASE }}
           script: |
             IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
             MAX_ATTEMPTS=20


### PR DESCRIPTION
## Summary
- Remove the `passphrase` parameter from the `appleboy/ssh-action` step since the OCI SSH key was re-exported without a passphrase

## Test plan
- [ ] Merge and verify the `backend-deploy` step succeeds on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)