### PR TITLE
Use vars.IMAGE_NAME for lowercase Docker image ref

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/api
 
 jobs:
   e2e:
@@ -242,7 +241,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}
           tags: |
             type=sha
             type=raw,value=latest
@@ -265,7 +264,7 @@ jobs:
           username: ${{ vars.OCI_USERNAME }}
           key: ${{ secrets.OCI_SSH_KEY }}
           script: |
-            IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+            IMAGE="${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}:latest"
             MAX_ATTEMPTS=20
 
             # Pull the new image


### PR DESCRIPTION
## Summary
- Remove hardcoded `IMAGE_NAME` env from workflow (was `github.repository`/api which preserves uppercase casing)
- Use `vars.IMAGE_NAME` repo variable instead, which stores the already-lowercased value
- Fixes `repository name must be lowercase` error from ghcr.io/podman

## Test plan
- [ ] Verify `IMAGE_NAME` repo variable is set to `kalicz/demopage/api`
- [ ] Merge and confirm `backend-deploy` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)