### PR TITLE
Build Docker image for ARM64 (Oracle Cloud)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,6 +237,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -252,6 +258,7 @@ jobs:
           context: backend
           file: backend/src/Kalandra.Api/Dockerfile
           push: true
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Summary
- Add QEMU + Docker Buildx to CI for cross-platform builds
- Set `platforms: linux/arm64` on the Docker build step
- Fixes deploy failure: image was `linux/amd64` but Oracle Cloud instance is ARM64

## Test plan
- [ ] Verify CI builds the image successfully for `linux/arm64`
- [ ] Verify deploy pulls and runs without the platform mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)