### PR TITLE
Add smooth collapsible animations and sticky footer

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -126,7 +126,7 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
     html.dark .dark-visible { display: inline-block !important; }
   </style>
 </head>
-<body>
+<body class="min-h-screen flex flex-col">
 
   <!-- Skip to content (accessibility) -->
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:bg-primary focus:text-on-primary focus:px-4 focus:py-2 focus:rounded-lg focus:font-bold">
@@ -435,7 +435,7 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
   </script>
 
   <!-- Main content -->
-  <main id="main-content" class="pt-32 pb-24">
+  <main id="main-content" class="pt-32 pb-24 flex-1">
     <slot />
   </main>
 
@@ -681,6 +681,50 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
       (window as any).__showSnackbar(decodeURIComponent(authError), 'error', 0);
       history.replaceState(null, '', window.location.pathname + window.location.search);
     }
+  </script>
+
+  <script>
+    // Smooth open/close animation for <details> elements
+    document.querySelectorAll('details').forEach((details) => {
+      const content = details.querySelector<HTMLElement>(':scope > :not(summary)');
+      if (!content) return;
+
+      let animation: Animation | null = null;
+
+      details.querySelector('summary')!.addEventListener('click', (e) => {
+        e.preventDefault();
+        animation?.cancel();
+
+        if (details.open) {
+          // Closing: animate from current height to 0
+          const startHeight = details.offsetHeight;
+          const summaryHeight = details.querySelector('summary')!.offsetHeight;
+
+          animation = details.animate(
+            { height: [`${startHeight}px`, `${summaryHeight}px`] },
+            { duration: 250, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+          );
+          animation.onfinish = () => {
+            details.open = false;
+            animation = null;
+          };
+        } else {
+          // Opening: set open, then animate from summary height to full height
+          details.open = true;
+          const endHeight = details.offsetHeight;
+          const summaryHeight = details.querySelector('summary')!.offsetHeight;
+
+          animation = details.animate(
+            { height: [`${summaryHeight}px`, `${endHeight}px`] },
+            { duration: 250, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+          );
+          animation.onfinish = () => {
+            details.style.height = '';
+            animation = null;
+          };
+        }
+      });
+    });
   </script>
 
 </body>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -90,6 +90,15 @@ body {
   background-clip: text;
 }
 
+/* Details/accordion smooth animation */
+details {
+  overflow: hidden;
+}
+
+details > summary + * {
+  will-change: opacity;
+}
+
 /* Suppress transitions during theme toggle to prevent flash */
 .no-transitions,
 .no-transitions *,


### PR DESCRIPTION
## Summary
- Smooth open/close animation for all `<details>` elements using the Web Animations API (250ms cubic-bezier ease)
- Sticky footer via flexbox so the footer stays at the viewport bottom on short-content pages (e.g. hire-me when logged out)

## Test plan
- [ ] Open About page, expand/collapse manifesto accordions — should animate smoothly
- [ ] Open Project page, expand/collapse ADR and roadmap details — should animate smoothly
- [ ] Visit Hire Me page without logging in — footer should be at the bottom of the viewport, not floating mid-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)