### PR TITLE
Add Lessons Learned section to project page

### DIFF
--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -212,7 +212,7 @@
         "verdict": "Asi bych to udělal znovu pro jednoduchost nastavení u osobních projektů. Ne u komerčních projektů se skutečným rozpočtem.",
         "observations": [
           "PostgreSQL zdarma je super a samo o sobě stojí za to",
-          "Auth má některé hrubé hrany — např. problémy s email providerem",
+          { "text": "Auth má některé hrubé hrany — např. problémy s email providerem", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "viz diskuze" },
           "File storage je levný, takže to není rozhodující faktor pro nebo proti Supabase",
           "Použití Supabase zpomaluje dev CLI oproti prostému PostgreSQL Docker image",
           "Není žádný skutečný tlak používat přibalený file storage a auth — ale připadáte si hloupě, když to nepoužijete, když už to tam je"

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -227,7 +227,7 @@
           "Nepsal bych 100% čistý event sourcing — místo toho by každý update také uložil záznam o změně obsahující předchozí hodnoty",
           "Ukládání předchozích hodnot jde proti filozofii ES, ale umožňuje stránkování záznamů historie — což je praktičtější",
           "Pro projekce bych použil standardní SQL úložiště místo JSONu — to také umožňuje jemnější řízení souběžnosti. Marten nabízí jen dva extrémy: připojit vše bez kontrol, nebo spadnout pokud se cokoliv změnilo. Žádná střední cesta",
-          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern"
+          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern, až by velikost SQL začala vadit"
         ]
       },
       {

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -226,9 +226,8 @@
         "observations": [
           "Nepsal bych 100% čistý event sourcing — místo toho by každý update také uložil záznam o změně obsahující předchozí hodnoty",
           "Ukládání předchozích hodnot jde proti filozofii ES, ale umožňuje stránkování záznamů historie — což je praktičtější",
-          "Pro projekce bych použil standardní SQL úložiště místo JSONu",
-          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern",
-          "Vlastní action log eventy by umožnily jemnější řízení souběžnosti — Marten nabízí jen dva extrémy: připojit vše bez kontrol, nebo spadnout pokud se cokoliv změnilo. Žádná střední cesta"
+          "Pro projekce bych použil standardní SQL úložiště místo JSONu — to také umožňuje jemnější řízení souběžnosti. Marten nabízí jen dva extrémy: připojit vše bez kontrol, nebo spadnout pokud se cokoliv změnilo. Žádná střední cesta",
+          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern"
         ]
       },
       {

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -227,7 +227,8 @@
           "Nepsal bych 100% čistý event sourcing — místo toho by každý update také uložil záznam o změně obsahující předchozí hodnoty",
           "Ukládání předchozích hodnot jde proti filozofii ES, ale umožňuje stránkování záznamů historie — což je praktičtější",
           "Pro projekce bych použil standardní SQL úložiště místo JSONu",
-          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern"
+          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern",
+          "Vlastní action log eventy by umožnily jemnější řízení souběžnosti — Marten nabízí jen dva extrémy: připojit vše bez kontrol, nebo spadnout pokud se cokoliv změnilo. Žádná střední cesta"
         ]
       },
       {

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -34,6 +34,7 @@
     "architecture": "Architektura",
     "decisions": "Architektonická rozhodnutí",
     "roadmap": "Plán vývoje",
+    "lessonsLearned": "Poučení z projektu",
     "openQuestions": "Otevřené otázky"
   },
   "techStack": {
@@ -196,6 +197,47 @@
           "Frontend page testy: Playwright — builduje statický web, ověřuje renderování, navigaci, i18n a dark mode",
           "E2E testy: Playwright proti celé běžící aplikaci — fungující auth, fungující DB, vše reálné. Pouze externí systémy jako Slack a email nelze ověřit",
           "CI/CD: Všechny tři testovací sady běží paralelně, všechny blokují deployment při selhání"
+        ]
+      }
+    ]
+  },
+  "lessonsLearned": {
+    "title": "Poučení z projektu",
+    "subtitle": "Názory utvořené po stavbě a nasazení s těmito technologiemi.",
+    "items": [
+      {
+        "id": "supabase",
+        "icon": "cloud",
+        "title": "Použití Supabase",
+        "verdict": "Asi bych to udělal znovu pro jednoduchost nastavení u osobních projektů. Ne u komerčních projektů se skutečným rozpočtem.",
+        "observations": [
+          "PostgreSQL zdarma je super a samo o sobě stojí za to",
+          "Auth má některé hrubé hrany — např. problémy s email providerem",
+          "File storage je levný, takže to není rozhodující faktor pro nebo proti Supabase",
+          "Použití Supabase zpomaluje dev CLI oproti prostému PostgreSQL Docker image",
+          "Není žádný skutečný tlak používat přibalený file storage a auth — ale připadáte si hloupě, když to nepoužijete, když už to tam je"
+        ]
+      },
+      {
+        "id": "event-sourcing",
+        "icon": "history",
+        "title": "Použití Event Sourcingu / Marten",
+        "verdict": "Příště bych asi napsal něco vlastního místo použití Martenu tak jak je.",
+        "observations": [
+          "Nepsal bych 100% čistý event sourcing — místo toho by každý update také uložil záznam o změně obsahující předchozí hodnoty",
+          "Ukládání předchozích hodnot jde proti filozofii ES, ale umožňuje stránkování záznamů historie — což je praktičtější",
+          "Pro projekce bych použil standardní SQL úložiště místo JSONu",
+          "Eventy by se ukládaly ve stejné transakci do jiné tabulky, pak přesouvaly do levnějšího úložiště (např. Azure Table Storage) přes outbox pattern"
+        ]
+      },
+      {
+        "id": "astro-ssg",
+        "icon": "rocket_launch",
+        "title": "Astro SSG",
+        "verdict": "Příště bych asi zvolil SSR framework.",
+        "observations": [
+          "Už teď byly místa, kde by pomohl router — např. sdílený header, footer a auth status napříč stránkami",
+          "SSG je jednodušší pro nastavení deploye, ale v reálných podmínkách prostě zaplatíte za infrastrukturu a neřešíte to"
         ]
       }
     ]

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -213,7 +213,7 @@
         "observations": [
           "PostgreSQL zdarma je super a samo o sobě stojí za to",
           { "text": "Auth má některé hrubé hrany — např. problémy s email providerem", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "viz diskuze" },
-          "File storage je levný, takže to není rozhodující faktor pro nebo proti Supabase",
+          "File storage je levný všude — S3 nebo Azure Blobs stojí stejně a věřil bych jim víc než Supabase Storage",
           "Použití Supabase zpomaluje dev CLI oproti prostému PostgreSQL Docker image",
           "Není žádný skutečný tlak používat přibalený file storage a auth — ale připadáte si hloupě, když to nepoužijete, když už to tam je"
         ]

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -213,7 +213,7 @@
         "observations": [
           "PostgreSQL zdarma je super a samo o sobě stojí za to",
           { "text": "Auth má některé hrubé hrany — např. problémy s email providerem", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "viz diskuze" },
-          "File storage je levný všude — S3 nebo Azure Blobs stojí stejně a věřil bych jim víc než Supabase Storage",
+          "File storage je levný všude — S3 nebo Azure Blobs jsou stejně levné a věřil bych jim víc než Supabase Storage",
           "Použití Supabase zpomaluje dev CLI oproti prostému PostgreSQL Docker image",
           "Není žádný skutečný tlak používat přibalený file storage a auth — ale připadáte si hloupě, když to nepoužijete, když už to tam je"
         ]

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -226,9 +226,8 @@
         "observations": [
           "Wouldn't write 100% clean event sourcing — instead, every update would also store a change record containing the previous values",
           "Storing previous values goes against ES philosophy, but allows pagination of history records — which is more practical",
-          "Would use standard SQL storage for projections rather than JSON",
-          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern",
-          "Custom action log events would allow more granular concurrency controls — Marten only offers two extremes: append everything without checks, or crash if anything has changed. No middle ground"
+          "Would use standard SQL storage for projections rather than JSON — this also enables more granular concurrency controls. Marten only offers two extremes: append everything without checks, or crash if anything has changed. No middle ground",
+          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern"
         ]
       },
       {

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -212,7 +212,7 @@
         "verdict": "Would probably do it again just for the setup simplicity on personal projects. Not on commercial projects with real budgets.",
         "observations": [
           "Free PostgreSQL is cool and worth it on its own",
-          "Auth has some rough edges — e.g. email provider issues",
+          { "text": "Auth has some rough edges — e.g. email provider issues", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "see discussion" },
           "File storage is cheap, so that's not the deciding factor for or against Supabase",
           "Using Supabase slows down the dev CLI compared to just using a plain PostgreSQL Docker image",
           "There's no real pressure to use the bundled file storage and auth — but you kinda feel like an idiot if you don't, since it's right there"

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -227,7 +227,8 @@
           "Wouldn't write 100% clean event sourcing — instead, every update would also store a change record containing the previous values",
           "Storing previous values goes against ES philosophy, but allows pagination of history records — which is more practical",
           "Would use standard SQL storage for projections rather than JSON",
-          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern"
+          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern",
+          "Custom action log events would allow more granular concurrency controls — Marten only offers two extremes: append everything without checks, or crash if anything has changed. No middle ground"
         ]
       },
       {

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -227,7 +227,7 @@
           "Wouldn't write 100% clean event sourcing — instead, every update would also store a change record containing the previous values",
           "Storing previous values goes against ES philosophy, but allows pagination of history records — which is more practical",
           "Would use standard SQL storage for projections rather than JSON — this also enables more granular concurrency controls. Marten only offers two extremes: append everything without checks, or crash if anything has changed. No middle ground",
-          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern"
+          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern once SQL size becomes an issue"
         ]
       },
       {

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -34,6 +34,7 @@
     "architecture": "Architecture",
     "decisions": "Architecture Decisions",
     "roadmap": "Roadmap",
+    "lessonsLearned": "Lessons Learned",
     "openQuestions": "Open Questions"
   },
   "techStack": {
@@ -196,6 +197,47 @@
           "Frontend page tests: Playwright — builds the static site, verifies rendering, navigation, i18n, and dark mode",
           "E2E tests: Playwright against the full running application — working auth, working DB, everything real. Only external systems like Slack and email can't be asserted",
           "CI/CD: All three test suites run in parallel, all block deployment on failure"
+        ]
+      }
+    ]
+  },
+  "lessonsLearned": {
+    "title": "Lessons Learned",
+    "subtitle": "Opinions formed after building and shipping with these technologies.",
+    "items": [
+      {
+        "id": "supabase",
+        "icon": "cloud",
+        "title": "Using Supabase",
+        "verdict": "Would probably do it again just for the setup simplicity on personal projects. Not on commercial projects with real budgets.",
+        "observations": [
+          "Free PostgreSQL is cool and worth it on its own",
+          "Auth has some rough edges — e.g. email provider issues",
+          "File storage is cheap, so that's not the deciding factor for or against Supabase",
+          "Using Supabase slows down the dev CLI compared to just using a plain PostgreSQL Docker image",
+          "There's no real pressure to use the bundled file storage and auth — but you kinda feel like an idiot if you don't, since it's right there"
+        ]
+      },
+      {
+        "id": "event-sourcing",
+        "icon": "history",
+        "title": "Using Event Sourcing / Marten",
+        "verdict": "Would probably write some custom stuff next time rather than using Marten as-is.",
+        "observations": [
+          "Wouldn't write 100% clean event sourcing — instead, every update would also store a change record containing the previous values",
+          "Storing previous values goes against ES philosophy, but allows pagination of history records — which is more practical",
+          "Would use standard SQL storage for projections rather than JSON",
+          "Events would be stored in the same transaction into another table, then moved to cheaper storage (e.g. Azure Table Storage) via an outbox pattern"
+        ]
+      },
+      {
+        "id": "astro-ssg",
+        "icon": "rocket_launch",
+        "title": "Astro SSG",
+        "verdict": "Would probably go for an SSR framework next time.",
+        "observations": [
+          "Already had places where a router would help — e.g. shared header, footer, and auth status across pages",
+          "SSG is simpler for deploy setup, but in real circumstances you just pay for the infrastructure and don't worry about it"
         ]
       }
     ]

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -213,7 +213,7 @@
         "observations": [
           "Free PostgreSQL is cool and worth it on its own",
           { "text": "Auth has some rough edges — e.g. email provider issues", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "see discussion" },
-          "File storage is cheap, so that's not the deciding factor for or against Supabase",
+          "File storage is cheap everywhere — S3 or Azure Blobs cost the same and I'd trust them more than Supabase Storage",
           "Using Supabase slows down the dev CLI compared to just using a plain PostgreSQL Docker image",
           "There's no real pressure to use the bundled file storage and auth — but you kinda feel like an idiot if you don't, since it's right there"
         ]

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -213,7 +213,7 @@
         "observations": [
           "Free PostgreSQL is cool and worth it on its own",
           { "text": "Auth has some rough edges — e.g. email provider issues", "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605", "linkText": "see discussion" },
-          "File storage is cheap everywhere — S3 or Azure Blobs cost the same and I'd trust them more than Supabase Storage",
+          "File storage is cheap everywhere — S3 or Azure Blobs are just as cheap and I'd trust them more than Supabase Storage",
           "Using Supabase slows down the dev CLI compared to just using a plain PostgreSQL Docker image",
           "There's no real pressure to use the bundled file storage and auth — but you kinda feel like an idiot if you don't, since it's right there"
         ]

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -380,6 +380,42 @@ const t = translations[lang];
     </div>
   </section>
 
+  <!-- Lessons Learned -->
+  <section id="lessons-learned" class="max-w-7xl mx-auto px-8 mt-32 mb-32">
+    <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">{t.lessonsLearned.title}</h2>
+    <p class="font-body text-on-surface-variant mb-12 max-w-2xl">{t.lessonsLearned.subtitle}</p>
+    <div class="space-y-4">
+      {t.lessonsLearned.items.map((item) => (
+        <details class="group bg-surface-container rounded-xl border border-outline-variant/40 shadow-sm">
+          <summary class="p-6 cursor-pointer flex items-center justify-between select-none">
+            <div class="flex items-center gap-3">
+              <span class="material-symbols-outlined text-tertiary text-2xl" aria-hidden="true">{item.icon}</span>
+              <h3 class="font-headline font-bold text-on-surface">{item.title}</h3>
+            </div>
+            <span class="material-symbols-outlined text-primary transition-transform group-open:rotate-180 shrink-0 ml-4" aria-hidden="true">expand_more</span>
+          </summary>
+          <div class="px-6 pb-6 space-y-4 border-t border-outline-variant/20 pt-4">
+            <div class="bg-surface-container-high rounded-lg p-4 border-l-4 border-tertiary">
+              <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-1">Verdict</h4>
+              <p class="font-body text-sm text-on-surface font-medium">{item.verdict}</p>
+            </div>
+            <div>
+              <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-2">Observations</h4>
+              <ul class="space-y-2">
+                {item.observations.map((obs) => (
+                  <li class="font-body text-sm text-on-surface-variant flex items-start gap-2">
+                    <span class="w-1.5 h-1.5 rounded-full bg-tertiary shrink-0 mt-1.5"></span>
+                    {obs}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </details>
+      ))}
+    </div>
+  </section>
+
   <!-- CTA Section -->
   <section class="max-w-7xl mx-auto px-8 mt-32">
     <div class="bg-linear-to-br from-primary-container to-surface-container-low p-12 rounded-2xl relative overflow-hidden border border-primary/10 shadow-lg">
@@ -419,6 +455,7 @@ const t = translations[lang];
       <a href="#architecture" class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap" data-toc-target="architecture">{t.toc.architecture}</a>
       <a href="#decisions" class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap" data-toc-target="decisions">{t.toc.decisions}</a>
       <a href="#roadmap" class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap" data-toc-target="roadmap">{t.toc.roadmap}</a>
+      <a href="#lessons-learned" class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap" data-toc-target="lessons-learned">{t.toc.lessonsLearned}</a>
     </div>
   </nav>
 
@@ -432,6 +469,7 @@ const t = translations[lang];
       <a href="#architecture" class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors" data-toc-target="architecture">{t.toc.architecture}</a>
       <a href="#decisions" class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors" data-toc-target="decisions">{t.toc.decisions}</a>
       <a href="#roadmap" class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors" data-toc-target="roadmap">{t.toc.roadmap}</a>
+      <a href="#lessons-learned" class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors" data-toc-target="lessons-learned">{t.toc.lessonsLearned}</a>
     </nav>
   </aside>
 </div>

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -405,7 +405,9 @@ const t = translations[lang];
                 {item.observations.map((obs) => (
                   <li class="font-body text-sm text-on-surface-variant flex items-start gap-2">
                     <span class="w-1.5 h-1.5 rounded-full bg-tertiary shrink-0 mt-1.5"></span>
-                    {obs}
+                    {typeof obs === 'string' ? obs : (
+                      <span>{obs.text} (<a href={obs.link} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">{obs.linkText}</a>)</span>
+                    )}
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary

- Adds a new **Lessons Learned** section to the project page with reflections on Supabase, Event Sourcing/Marten, and Astro SSG
- Each topic is an expandable accordion card with a verdict and observations, matching the existing Decisions section style
- Includes full Czech translations
- Adds TOC entries for both mobile sticky bar and desktop rail

## Test plan

- [ ] Verify the section renders correctly on `/project` (EN) and `/cs/project` (CZ)
- [ ] Expand/collapse each accordion card
- [ ] Check TOC highlights the section when scrolled into view (both mobile and desktop)
- [ ] Verify dark mode styling looks correct
- [ ] Confirm frontend build passes (`npm run build:frontend`)

https://claude.ai/code/session_01CiDD7GpiT5m2jPXJ4NaPYU