### PR TITLE
Add response compression (Brotli + Gzip)

### DIFF
--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -3,6 +3,7 @@ using Kalandra.Api.Infrastructure;
 using Kalandra.Api.Infrastructure.Auth;
 using Kalandra.Infrastructure.Configuration;
 using Kalandra.JobOffers;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.OpenApi;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -43,11 +44,20 @@ builder.Services.AddApiServices();
 builder.Services.AddJobOffersDomain();
 RateLimits.Add(builder.Services);
 
+builder.Services.AddResponseCompression(options =>
+{
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+    options.EnableForHttps = true;
+});
+
 builder.Services.AddHealthChecks()
     .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)
     .AddCheck<CommitHashHealthCheck>("version");
 
 var app = builder.Build();
+
+app.UseResponseCompression();
 
 // Yes, even for production.
 app.UseSwagger();


### PR DESCRIPTION
## Summary

- Register Brotli and Gzip response compression providers in `Program.cs` to reduce API payload sizes, especially for JSON-heavy endpoints like job offer lists
- Brotli is preferred for modern clients (~15-20% better than Gzip for JSON); Gzip serves as fallback for older clients
- `UseResponseCompression()` placed at the top of the middleware pipeline so all responses flow through compression

Closes #35

## Test plan

- [ ] Verify backend builds successfully
- [ ] Send a request with `Accept-Encoding: br` and confirm response has `Content-Encoding: br`
- [ ] Send a request with `Accept-Encoding: gzip` and confirm response has `Content-Encoding: gzip`
- [ ] Send a request without `Accept-Encoding` and confirm uncompressed response
- [ ] Verify existing endpoints (health check, job offers) still return correct data

https://claude.ai/code/session_012iHLrWpbvq7A9Z85Z8s73w