### PR TITLE
Add traceId in error snackbars

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -140,7 +140,6 @@ jobs:
           Storage__SupabaseProjectUrl: "http://127.0.0.1:54321"
           Storage__ServiceKey: ${{ env.SB_SERVICE_ROLE_KEY }}
           Turnstile__SecretKey: "1x0000000000000000000000000000000AA"
-          RateLimit__HireMePermitLimit: "20"
           ASPNETCORE_ENVIRONMENT: Development
 
       - name: Wait for backend

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -140,6 +140,7 @@ jobs:
           Storage__SupabaseProjectUrl: "http://127.0.0.1:54321"
           Storage__ServiceKey: ${{ env.SB_SERVICE_ROLE_KEY }}
           Turnstile__SecretKey: "1x0000000000000000000000000000000AA"
+          RateLimit__HireMePermitLimit: "20"
           ASPNETCORE_ENVIRONMENT: Development
 
       - name: Wait for backend

--- a/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
@@ -11,19 +11,21 @@ public static class RateLimitPolicies
 
 public static class RateLimits
 {
-    // Hire-me submissions: 2 per 4 hours per authenticated user. When the
-    // limit is hit, the client must re-render Turnstile in interactive mode
-    // and resend with the X-Interactive-Captcha header.
-    private static readonly SlidingWindowRateLimiterOptions HireMeLimiterOptions = new()
+    public static void Add(IServiceCollection services, IConfiguration configuration)
     {
-        PermitLimit = 2,
-        Window = TimeSpan.FromHours(4),
-        SegmentsPerWindow = 24,
-        QueueLimit = 0,
-    };
+        var permitLimit = configuration.GetValue("RateLimit:HireMePermitLimit", defaultValue: 2);
 
-    public static void Add(IServiceCollection services)
-    {
+        // Hire-me submissions: N per 4 hours per authenticated user. When the
+        // limit is hit, the client must re-render Turnstile in interactive mode
+        // and resend with the X-Interactive-Captcha header.
+        var hireMeLimiterOptions = new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = permitLimit,
+            Window = TimeSpan.FromHours(4),
+            SegmentsPerWindow = 24,
+            QueueLimit = 0,
+        };
+
         services.AddRateLimiter(options =>
         {
             // Per-user limit: named policy applied via [EnableRateLimiting] on the endpoint.
@@ -36,18 +38,23 @@ public static class RateLimits
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: "user:" + currentUser.Id,
-                    factory: _ => HireMeLimiterOptions);
+                    factory: _ => hireMeLimiterOptions);
             });
 
             // Per-IP limit: global limiter that only activates on endpoints
             // carrying the hire-me policy. Both this and the per-user policy
             // must permit the request — a single IP creating multiple accounts
             // will be caught here even though each account has its own user quota.
+            // Unauthenticated requests are skipped — they will be rejected by
+            // auth middleware anyway and should not consume IP quota.
             options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
             {
                 var rlAttribute = httpContext.GetEndpoint()?.Metadata.GetMetadata<EnableRateLimitingAttribute>();
                 if (rlAttribute?.PolicyName != RateLimitPolicies.HireMeCreateUser)
                     return RateLimitPartition.GetNoLimiter("no-ip-limit");
+
+                if (!httpContext.Request.Headers.ContainsKey("Authorization"))
+                    return RateLimitPartition.GetNoLimiter("no-auth");
 
                 if (httpContext.Request.Headers.ContainsKey("X-Interactive-Captcha"))
                     return RateLimitPartition.GetNoLimiter("interactive-captcha-ip");
@@ -56,7 +63,7 @@ public static class RateLimits
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: "ip:" + ip,
-                    factory: _ => HireMeLimiterOptions);
+                    factory: _ => hireMeLimiterOptions);
             });
 
             options.OnRejected = async (context, ct) =>

--- a/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
@@ -1,6 +1,5 @@
 using System.Threading.RateLimiting;
 using Kalandra.Api.Infrastructure.Auth;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Kalandra.Api.Infrastructure;
 
@@ -11,24 +10,21 @@ public static class RateLimitPolicies
 
 public static class RateLimits
 {
-    public static void Add(IServiceCollection services, IConfiguration configuration)
+    // Hire-me submissions: 2 per 4 hours per authenticated user. When the
+    // limit is hit, the client must re-render Turnstile in interactive mode
+    // and resend with the X-Interactive-Captcha header.
+    private static readonly SlidingWindowRateLimiterOptions HireMeLimiterOptions = new()
     {
-        var permitLimit = configuration.GetValue("RateLimit:HireMePermitLimit", defaultValue: 2);
+        PermitLimit = 2,
+        Window = TimeSpan.FromHours(4),
+        SegmentsPerWindow = 24,
+        QueueLimit = 0,
+    };
 
-        // Hire-me submissions: N per 4 hours per authenticated user. When the
-        // limit is hit, the client must re-render Turnstile in interactive mode
-        // and resend with the X-Interactive-Captcha header.
-        var hireMeLimiterOptions = new SlidingWindowRateLimiterOptions
-        {
-            PermitLimit = permitLimit,
-            Window = TimeSpan.FromHours(4),
-            SegmentsPerWindow = 24,
-            QueueLimit = 0,
-        };
-
+    public static void Add(IServiceCollection services)
+    {
         services.AddRateLimiter(options =>
         {
-            // Per-user limit: named policy applied via [EnableRateLimiting] on the endpoint.
             options.AddPolicy(RateLimitPolicies.HireMeCreateUser, httpContext =>
             {
                 if (httpContext.Request.Headers.ContainsKey("X-Interactive-Captcha"))
@@ -38,32 +34,7 @@ public static class RateLimits
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: "user:" + currentUser.Id,
-                    factory: _ => hireMeLimiterOptions);
-            });
-
-            // Per-IP limit: global limiter that only activates on endpoints
-            // carrying the hire-me policy. Both this and the per-user policy
-            // must permit the request — a single IP creating multiple accounts
-            // will be caught here even though each account has its own user quota.
-            // Unauthenticated requests are skipped — they will be rejected by
-            // auth middleware anyway and should not consume IP quota.
-            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
-            {
-                var rlAttribute = httpContext.GetEndpoint()?.Metadata.GetMetadata<EnableRateLimitingAttribute>();
-                if (rlAttribute?.PolicyName != RateLimitPolicies.HireMeCreateUser)
-                    return RateLimitPartition.GetNoLimiter("no-ip-limit");
-
-                if (!httpContext.Request.Headers.ContainsKey("Authorization"))
-                    return RateLimitPartition.GetNoLimiter("no-auth");
-
-                if (httpContext.Request.Headers.ContainsKey("X-Interactive-Captcha"))
-                    return RateLimitPartition.GetNoLimiter("interactive-captcha-ip");
-
-                var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-
-                return RateLimitPartition.GetSlidingWindowLimiter(
-                    partitionKey: "ip:" + ip,
-                    factory: _ => hireMeLimiterOptions);
+                    factory: _ => HireMeLimiterOptions);
             });
 
             options.OnRejected = async (context, ct) =>

--- a/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
@@ -10,19 +10,21 @@ public static class RateLimitPolicies
 
 public static class RateLimits
 {
-    // Hire-me submissions: 2 per 4 hours per authenticated user. When the
-    // limit is hit, the client must re-render Turnstile in interactive mode
-    // and resend with the X-Interactive-Captcha header.
-    private static readonly SlidingWindowRateLimiterOptions HireMeLimiterOptions = new()
+    public static void Add(IServiceCollection services, IConfiguration configuration)
     {
-        PermitLimit = 2,
-        Window = TimeSpan.FromHours(4),
-        SegmentsPerWindow = 24,
-        QueueLimit = 0,
-    };
+        var permitLimit = configuration.GetValue("RateLimit:HireMePermitLimit", defaultValue: 2);
 
-    public static void Add(IServiceCollection services)
-    {
+        // Hire-me submissions: N per 4 hours per authenticated user. When the
+        // limit is hit, the client must re-render Turnstile in interactive mode
+        // and resend with the X-Interactive-Captcha header.
+        var hireMeLimiterOptions = new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = permitLimit,
+            Window = TimeSpan.FromHours(4),
+            SegmentsPerWindow = 24,
+            QueueLimit = 0,
+        };
+
         services.AddRateLimiter(options =>
         {
             options.AddPolicy(RateLimitPolicies.HireMeCreateUser, httpContext =>
@@ -34,7 +36,7 @@ public static class RateLimits
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: "user:" + currentUser.Id,
-                    factory: _ => HireMeLimiterOptions);
+                    factory: _ => hireMeLimiterOptions);
             });
 
             options.OnRejected = async (context, ct) =>

--- a/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Kalandra.Api.Infrastructure.Auth;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Kalandra.Api.Infrastructure;
 
@@ -25,6 +26,7 @@ public static class RateLimits
     {
         services.AddRateLimiter(options =>
         {
+            // Per-user limit: named policy applied via [EnableRateLimiting] on the endpoint.
             options.AddPolicy(RateLimitPolicies.HireMeCreateUser, httpContext =>
             {
                 if (httpContext.Request.Headers.ContainsKey("X-Interactive-Captcha"))
@@ -34,6 +36,26 @@ public static class RateLimits
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: "user:" + currentUser.Id,
+                    factory: _ => HireMeLimiterOptions);
+            });
+
+            // Per-IP limit: global limiter that only activates on endpoints
+            // carrying the hire-me policy. Both this and the per-user policy
+            // must permit the request — a single IP creating multiple accounts
+            // will be caught here even though each account has its own user quota.
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+            {
+                var rlAttribute = httpContext.GetEndpoint()?.Metadata.GetMetadata<EnableRateLimitingAttribute>();
+                if (rlAttribute?.PolicyName != RateLimitPolicies.HireMeCreateUser)
+                    return RateLimitPartition.GetNoLimiter("no-ip-limit");
+
+                if (httpContext.Request.Headers.ContainsKey("X-Interactive-Captcha"))
+                    return RateLimitPartition.GetNoLimiter("interactive-captcha-ip");
+
+                var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                return RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey: "ip:" + ip,
                     factory: _ => HireMeLimiterOptions);
             });
 

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddTurnstile();
 builder.Services.AddAuthAdminServices();
 builder.Services.AddApiServices();
 builder.Services.AddJobOffersDomain();
-RateLimits.Add(builder.Services, builder.Configuration);
+RateLimits.Add(builder.Services);
 
 builder.Services.AddResponseCompression(options =>
 {

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddTurnstile();
 builder.Services.AddAuthAdminServices();
 builder.Services.AddApiServices();
 builder.Services.AddJobOffersDomain();
-RateLimits.Add(builder.Services);
+RateLimits.Add(builder.Services, builder.Configuration);
 
 builder.Services.AddResponseCompression(options =>
 {

--- a/backend/src/Kalandra.Api/appsettings.Development.json.template
+++ b/backend/src/Kalandra.Api/appsettings.Development.json.template
@@ -1,0 +1,8 @@
+{
+  "RateLimit": {
+    "HireMePermitLimit": 20
+  },
+  "Turnstile": {
+    "SecretKey": "1x0000000000000000000000000000000AA"
+  }
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,6 +64,17 @@ Both configurations run `npm install` as a before-launch step, so dependencies a
 
 > The remaining configurations in `.run/` (`Backend`, `Frontend`, `Watch Backend`) are building blocks used by the compound configs above.
 
+### 1.3.1 Backend Development Config
+
+Copy the template to create your local config (gitignored, never committed):
+
+```bash
+cp backend/src/Kalandra.Api/appsettings.Development.json.template \
+   backend/src/Kalandra.Api/appsettings.Development.json
+```
+
+This overrides `appsettings.json` when `ASPNETCORE_ENVIRONMENT=Development` and sets a higher rate limit for local E2E tests. Add any real secrets (Turnstile keys, etc.) here — the file is in `.gitignore`.
+
 ### 1.4 CLI Alternative
 
 ```bash

--- a/frontend/src/components/Snackbar.astro
+++ b/frontend/src/components/Snackbar.astro
@@ -1,0 +1,104 @@
+<!-- Global snackbar -->
+<div id="snackbar" role="status" aria-live="polite"
+  class="fixed top-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none opacity-0 transition-all duration-300 -translate-y-4">
+  <div class="flex flex-col gap-1 px-5 py-3 rounded-2xl shadow-lg border border-outline-variant/10 font-body text-sm max-w-md">
+    <div class="flex items-center gap-3">
+      <span id="snackbar-icon" class="material-symbols-outlined text-lg flex-shrink-0" aria-hidden="true"></span>
+      <span id="snackbar-message" class="flex-1"></span>
+      <button id="snackbar-close" type="button" class="hidden material-symbols-outlined text-lg flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Close">close</button>
+    </div>
+    <div id="snackbar-trace" class="hidden flex items-center gap-2 pl-8 text-xs opacity-70">
+      <span id="snackbar-trace-text" class="truncate"></span>
+      <button id="snackbar-trace-copy" type="button" class="material-symbols-outlined text-sm flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Copy trace ID">content_copy</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  window.__showSnackbar = function(message: string, type: 'success' | 'error' | 'info' = 'info', duration = 8000, traceId?: string) {
+    const snackbar = document.getElementById('snackbar');
+    const icon = document.getElementById('snackbar-icon');
+    const msg = document.getElementById('snackbar-message');
+    if (!snackbar || !icon || !msg) return;
+
+    const inner = snackbar.firstElementChild as HTMLElement;
+
+    // Reset classes
+    inner.classList.remove('bg-tertiary-container', 'text-on-surface', 'bg-error-container', 'bg-surface-container-high');
+    icon.classList.remove('text-tertiary', 'text-error', 'text-primary');
+
+    if (type === 'success') {
+      inner.classList.add('bg-tertiary-container', 'text-on-surface');
+      icon.classList.add('text-tertiary');
+      icon.textContent = 'check_circle';
+    } else if (type === 'error') {
+      inner.classList.add('bg-error-container', 'text-on-surface');
+      icon.classList.add('text-error');
+      icon.textContent = 'error';
+    } else {
+      inner.classList.add('bg-surface-container-high', 'text-on-surface');
+      icon.classList.add('text-primary');
+      icon.textContent = 'info';
+    }
+
+    msg.textContent = message;
+
+    // Show/hide traceId section
+    const traceEl = document.getElementById('snackbar-trace');
+    const traceText = document.getElementById('snackbar-trace-text');
+    if (traceEl && traceText) {
+      if (traceId) {
+        traceText.textContent = 'Trace: ' + traceId;
+        traceEl.classList.remove('hidden');
+      } else {
+        traceEl.classList.add('hidden');
+      }
+    }
+
+    // Show/hide close button for persistent snackbars
+    const closeBtn = document.getElementById('snackbar-close');
+    if (closeBtn) {
+      if (duration === 0) { closeBtn.classList.remove('hidden'); } else { closeBtn.classList.add('hidden'); }
+    }
+
+    // Show
+    snackbar.classList.remove('opacity-0', '-translate-y-4', 'pointer-events-none');
+    snackbar.classList.add('opacity-100', 'translate-y-0', 'pointer-events-auto');
+
+    // Auto-hide (0 = persistent, dismissed via close button or by next snackbar)
+    clearTimeout((window as any).__snackbarTimer);
+    if (duration > 0) {
+      (window as any).__snackbarTimer = setTimeout(() => {
+        snackbar.classList.remove('opacity-100', 'translate-y-0', 'pointer-events-auto');
+        snackbar.classList.add('opacity-0', '-translate-y-4', 'pointer-events-none');
+      }, duration);
+    }
+  };
+
+  // Copy traceId to clipboard
+  document.getElementById('snackbar-trace-copy')?.addEventListener('click', () => {
+    const traceText = document.getElementById('snackbar-trace-text')?.textContent;
+    if (traceText) {
+      const traceId = traceText.replace(/^Trace:\s*/, '');
+      navigator.clipboard.writeText(traceId);
+    }
+  });
+
+  document.getElementById('snackbar-close')?.addEventListener('click', () => {
+    const snackbar = document.getElementById('snackbar');
+    if (snackbar) {
+      snackbar.classList.remove('opacity-100', 'translate-y-0', 'pointer-events-auto');
+      snackbar.classList.add('opacity-0', '-translate-y-4', 'pointer-events-none');
+    }
+  });
+
+  // Show snackbar from sessionStorage (for cross-page messages like form submission redirects)
+  try {
+    const pending = sessionStorage.getItem('snackbar');
+    if (pending) {
+      sessionStorage.removeItem('snackbar');
+      const { message, type } = JSON.parse(pending);
+      (window as any).__showSnackbar(message, type);
+    }
+  } catch {}
+</script>

--- a/frontend/src/components/Snackbar.astro
+++ b/frontend/src/components/Snackbar.astro
@@ -7,8 +7,8 @@
       <span id="snackbar-message" class="flex-1"></span>
       <button id="snackbar-close" type="button" class="hidden material-symbols-outlined text-lg flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Close">close</button>
     </div>
-    <div id="snackbar-trace" class="hidden flex items-center gap-2 pl-8 text-xs opacity-70">
-      <span id="snackbar-trace-text" class="truncate"></span>
+    <div id="snackbar-trace" class="hidden flex items-start gap-2 pl-8 text-xs opacity-70">
+      <span id="snackbar-trace-text" class="break-all"></span>
       <button id="snackbar-trace-copy" type="button" class="material-symbols-outlined text-sm flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Copy trace ID">content_copy</button>
     </div>
   </div>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css'
 import AuthDialog from '../components/AuthDialog.astro';
+import Snackbar from '../components/Snackbar.astro';
 import IconEmail from '../components/icons/IconEmail.astro';
 import IconGitHub from '../components/icons/IconGitHub.astro';
 import IconLinkedIn from '../components/icons/IconLinkedIn.astro';
@@ -595,110 +596,9 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
     };
   </script>
 
-  <!-- Global snackbar -->
-  <div id="snackbar" role="status" aria-live="polite"
-    class="fixed top-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none opacity-0 transition-all duration-300 -translate-y-4">
-    <div class="flex flex-col gap-1 px-5 py-3 rounded-2xl shadow-lg border border-outline-variant/10 font-body text-sm max-w-md">
-      <div class="flex items-center gap-3">
-        <span id="snackbar-icon" class="material-symbols-outlined text-lg flex-shrink-0" aria-hidden="true"></span>
-        <span id="snackbar-message" class="flex-1"></span>
-        <button id="snackbar-close" type="button" class="hidden material-symbols-outlined text-lg flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Close">close</button>
-      </div>
-      <div id="snackbar-trace" class="hidden flex items-center gap-2 pl-8 text-xs opacity-70">
-        <span id="snackbar-trace-text" class="truncate"></span>
-        <button id="snackbar-trace-copy" type="button" class="material-symbols-outlined text-sm flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Copy trace ID">content_copy</button>
-      </div>
-    </div>
-  </div>
+  <Snackbar />
 
   <script>
-    window.__showSnackbar = function(message: string, type: 'success' | 'error' | 'info' = 'info', duration = 8000, traceId?: string) {
-      const snackbar = document.getElementById('snackbar');
-      const icon = document.getElementById('snackbar-icon');
-      const msg = document.getElementById('snackbar-message');
-      if (!snackbar || !icon || !msg) return;
-
-      const inner = snackbar.firstElementChild as HTMLElement;
-
-      // Reset classes
-      inner.classList.remove('bg-tertiary-container', 'text-on-surface', 'bg-error-container', 'bg-surface-container-high');
-      icon.classList.remove('text-tertiary', 'text-error', 'text-primary');
-
-      if (type === 'success') {
-        inner.classList.add('bg-tertiary-container', 'text-on-surface');
-        icon.classList.add('text-tertiary');
-        icon.textContent = 'check_circle';
-      } else if (type === 'error') {
-        inner.classList.add('bg-error-container', 'text-on-surface');
-        icon.classList.add('text-error');
-        icon.textContent = 'error';
-      } else {
-        inner.classList.add('bg-surface-container-high', 'text-on-surface');
-        icon.classList.add('text-primary');
-        icon.textContent = 'info';
-      }
-
-      msg.textContent = message;
-
-      // Show/hide traceId section
-      const traceEl = document.getElementById('snackbar-trace');
-      const traceText = document.getElementById('snackbar-trace-text');
-      if (traceEl && traceText) {
-        if (traceId) {
-          traceText.textContent = 'Trace: ' + traceId;
-          traceEl.classList.remove('hidden');
-        } else {
-          traceEl.classList.add('hidden');
-        }
-      }
-
-      // Show/hide close button for persistent snackbars
-      const closeBtn = document.getElementById('snackbar-close');
-      if (closeBtn) {
-        if (duration === 0) { closeBtn.classList.remove('hidden'); } else { closeBtn.classList.add('hidden'); }
-      }
-
-      // Show
-      snackbar.classList.remove('opacity-0', '-translate-y-4', 'pointer-events-none');
-      snackbar.classList.add('opacity-100', 'translate-y-0', 'pointer-events-auto');
-
-      // Auto-hide (0 = persistent, dismissed via close button or by next snackbar)
-      clearTimeout((window as any).__snackbarTimer);
-      if (duration > 0) {
-        (window as any).__snackbarTimer = setTimeout(() => {
-          snackbar.classList.remove('opacity-100', 'translate-y-0', 'pointer-events-auto');
-          snackbar.classList.add('opacity-0', '-translate-y-4', 'pointer-events-none');
-        }, duration);
-      }
-    };
-
-    // Copy traceId to clipboard
-    document.getElementById('snackbar-trace-copy')?.addEventListener('click', () => {
-      const traceText = document.getElementById('snackbar-trace-text')?.textContent;
-      if (traceText) {
-        const traceId = traceText.replace(/^Trace:\s*/, '');
-        navigator.clipboard.writeText(traceId);
-      }
-    });
-
-    document.getElementById('snackbar-close')?.addEventListener('click', () => {
-      const snackbar = document.getElementById('snackbar');
-      if (snackbar) {
-        snackbar.classList.remove('opacity-100', 'translate-y-0', 'pointer-events-auto');
-        snackbar.classList.add('opacity-0', '-translate-y-4', 'pointer-events-none');
-      }
-    });
-
-    // Show snackbar from sessionStorage (for cross-page messages like form submission redirects)
-    try {
-      const pending = sessionStorage.getItem('snackbar');
-      if (pending) {
-        sessionStorage.removeItem('snackbar');
-        const { message, type } = JSON.parse(pending);
-        (window as any).__showSnackbar(message, type);
-      }
-    } catch {}
-
     // Handle auth error/callback fragments in the URL (e.g. expired confirmation links).
     // Sign out any existing session — the person clicking the link is the one who signed up.
     const hashParams = new URLSearchParams(window.location.hash.substring(1));

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -598,15 +598,21 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
   <!-- Global snackbar -->
   <div id="snackbar" role="status" aria-live="polite"
     class="fixed top-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none opacity-0 transition-all duration-300 -translate-y-4">
-    <div class="flex items-center gap-3 px-5 py-3 rounded-2xl shadow-lg border border-outline-variant/10 font-body text-sm max-w-md">
-      <span id="snackbar-icon" class="material-symbols-outlined text-lg flex-shrink-0" aria-hidden="true"></span>
-      <span id="snackbar-message" class="flex-1"></span>
-      <button id="snackbar-close" type="button" class="hidden material-symbols-outlined text-lg flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Close">close</button>
+    <div class="flex flex-col gap-1 px-5 py-3 rounded-2xl shadow-lg border border-outline-variant/10 font-body text-sm max-w-md">
+      <div class="flex items-center gap-3">
+        <span id="snackbar-icon" class="material-symbols-outlined text-lg flex-shrink-0" aria-hidden="true"></span>
+        <span id="snackbar-message" class="flex-1"></span>
+        <button id="snackbar-close" type="button" class="hidden material-symbols-outlined text-lg flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Close">close</button>
+      </div>
+      <div id="snackbar-trace" class="hidden flex items-center gap-2 pl-8 text-xs opacity-70">
+        <span id="snackbar-trace-text" class="truncate"></span>
+        <button id="snackbar-trace-copy" type="button" class="material-symbols-outlined text-sm flex-shrink-0 opacity-60 hover:opacity-100 transition-opacity cursor-pointer" aria-label="Copy trace ID">content_copy</button>
+      </div>
     </div>
   </div>
 
   <script>
-    window.__showSnackbar = function(message: string, type: 'success' | 'error' | 'info' = 'info', duration = 8000) {
+    window.__showSnackbar = function(message: string, type: 'success' | 'error' | 'info' = 'info', duration = 8000, traceId?: string) {
       const snackbar = document.getElementById('snackbar');
       const icon = document.getElementById('snackbar-icon');
       const msg = document.getElementById('snackbar-message');
@@ -634,6 +640,18 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
 
       msg.textContent = message;
 
+      // Show/hide traceId section
+      const traceEl = document.getElementById('snackbar-trace');
+      const traceText = document.getElementById('snackbar-trace-text');
+      if (traceEl && traceText) {
+        if (traceId) {
+          traceText.textContent = 'Trace: ' + traceId;
+          traceEl.classList.remove('hidden');
+        } else {
+          traceEl.classList.add('hidden');
+        }
+      }
+
       // Show/hide close button for persistent snackbars
       const closeBtn = document.getElementById('snackbar-close');
       if (closeBtn) {
@@ -653,6 +671,15 @@ const canonicalUrl = lang === 'cs' ? csUrl : enUrl;
         }, duration);
       }
     };
+
+    // Copy traceId to clipboard
+    document.getElementById('snackbar-trace-copy')?.addEventListener('click', () => {
+      const traceText = document.getElementById('snackbar-trace-text')?.textContent;
+      if (traceText) {
+        const traceId = traceText.replace(/^Trace:\s*/, '');
+        navigator.clipboard.writeText(traceId);
+      }
+    });
 
     document.getElementById('snackbar-close')?.addEventListener('click', () => {
       const snackbar = document.getElementById('snackbar');

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -1,28 +1,39 @@
 /** Nested error map: field name → error code → localized message. */
 export type ApiErrorMap = Record<string, Record<string, string>>;
 
+/** Result from parsing a ProblemDetails API error response. */
+export type ApiErrorResult = {
+  message: string | null;
+  traceId?: string;
+};
+
 /**
- * Extracts the first localized error from a ValidationProblemDetails response.
- * Returns the translated message if found, or null if the response doesn't
- * contain a recognized error code.
+ * Extracts the first localized error and traceId from a ProblemDetails response.
+ * Returns an object with the translated message (if found) and traceId (if present),
+ * or null if the response doesn't contain either.
  *
  * Expected response shape (RFC 7807):
- * { "errors": { "fieldName": ["ErrorCode"] } }
+ * { "errors": { "fieldName": ["ErrorCode"] }, "traceId": "00-..." }
  */
 export async function getApiError(
   response: Response,
   errorMap: ApiErrorMap,
-): Promise<string | null> {
-  if (response.status < 400 || response.status >= 500) return null;
+): Promise<ApiErrorResult | null> {
+  if (response.status < 400) return null;
   try {
     const body = await response.json();
-    if (body?.errors) {
+    const traceId: string | undefined = body?.traceId ?? undefined;
+    let message: string | null = null;
+
+    if (body?.errors && response.status < 500) {
       for (const field in body.errors) {
         const code = body.errors[field]?.[0];
         const msg = errorMap?.[field]?.[code];
-        if (msg) return msg;
+        if (msg) { message = msg; break; }
       }
     }
+
+    if (message || traceId) return { message, traceId };
   } catch {}
   return null;
 }

--- a/frontend/src/pages/[...lang]/admin/job-offers.astro
+++ b/frontend/src/pages/[...lang]/admin/job-offers.astro
@@ -126,18 +126,18 @@ const c = commonTranslations[lang];
     // Wake up the database
     fetch(apiUrl + '/health').catch(function() {});
 
-    function showError(status) {
+    function showError(status, traceId) {
       var msg = !status ? errorNetwork : status === 404 ? errorNotFound : status >= 500 ? errorServer : errorText;
-      window.__showSnackbar?.(msg, 'error');
+      window.__showSnackbar?.(msg, 'error', 8000, traceId);
     }
 
     async function showApiError(res) {
-      var msg = await window.__getApiError?.(res, apiErrorMap);
-      if (msg) {
-        window.__showSnackbar?.(msg, 'error');
-        return msg;
+      var result = await window.__getApiError?.(res, apiErrorMap);
+      if (result?.message) {
+        window.__showSnackbar?.(result.message, 'error', 8000, result.traceId);
+        return result.message;
       }
-      showError(res.status);
+      showError(res.status, result?.traceId);
     }
 
     var currentOfferId = null;

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -379,7 +379,7 @@ const t = translations[lang];
         });
 
         if (response.status === 429) {
-          var body = await response.clone().json().catch(function() { return {}; });
+          var body = await response.json().catch(function() { return {}; });
           if (body && body.error === 'captcha_required') {
             // Rate limit hit — force visible Turnstile checkbox on next attempt.
             interactiveCaptchaMode = true;

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -391,8 +391,10 @@ const t = translations[lang];
         }
 
         if (!response.ok) {
-          var apiMsg = await window.__getApiError?.(response, apiErrorMap);
-          throw new Error(apiMsg || errorText);
+          var result = await window.__getApiError?.(response, apiErrorMap);
+          window.__showSnackbar?.(result?.message || errorText, 'error', 8000, result?.traceId);
+          if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }
+          return;
         }
 
         var offer = await response.json();

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -379,7 +379,7 @@ const t = translations[lang];
         });
 
         if (response.status === 429) {
-          var body = await response.json().catch(function() { return {}; });
+          var body = await response.clone().json().catch(function() { return {}; });
           if (body && body.error === 'captcha_required') {
             // Rate limit hit — force visible Turnstile checkbox on next attempt.
             interactiveCaptchaMode = true;

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -378,19 +378,19 @@ const t = translations[lang];
           body: formData
         });
 
-        if (!response.ok) {
-          if (response.status === 429) {
-            // Clone before reading — getApiError needs the body if this check doesn't match.
-            var body = await response.clone().json().catch(function() { return {}; });
-            if (body && body.error === 'captcha_required') {
-              // Rate limit hit — force visible Turnstile checkbox on next attempt.
-              interactiveCaptchaMode = true;
-              renderTurnstile('always');
-              window.__showSnackbar?.(captchaRequiredError, 'error');
-              if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }
-              return;
-            }
+        if (response.status === 429) {
+          var body = await response.json().catch(function() { return {}; });
+          if (body && body.error === 'captcha_required') {
+            // Rate limit hit — force visible Turnstile checkbox on next attempt.
+            interactiveCaptchaMode = true;
+            renderTurnstile('always');
+            window.__showSnackbar?.(captchaRequiredError, 'error');
+            if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }
+            return;
           }
+        }
+
+        if (!response.ok) {
           var result = await window.__getApiError?.(response, apiErrorMap);
           window.__showSnackbar?.(result?.message || errorText, 'error', 8000, result?.traceId);
           if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -378,19 +378,19 @@ const t = translations[lang];
           body: formData
         });
 
-        if (response.status === 429) {
-          var body = await response.json().catch(function() { return {}; });
-          if (body && body.error === 'captcha_required') {
-            // Rate limit hit — force visible Turnstile checkbox on next attempt.
-            interactiveCaptchaMode = true;
-            renderTurnstile('always');
-            window.__showSnackbar?.(captchaRequiredError, 'error');
-            if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }
-            return;
-          }
-        }
-
         if (!response.ok) {
+          if (response.status === 429) {
+            // Clone before reading — getApiError needs the body if this check doesn't match.
+            var body = await response.clone().json().catch(function() { return {}; });
+            if (body && body.error === 'captcha_required') {
+              // Rate limit hit — force visible Turnstile checkbox on next attempt.
+              interactiveCaptchaMode = true;
+              renderTurnstile('always');
+              window.__showSnackbar?.(captchaRequiredError, 'error');
+              if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }
+              return;
+            }
+          }
           var result = await window.__getApiError?.(response, apiErrorMap);
           window.__showSnackbar?.(result?.message || errorText, 'error', 8000, result?.traceId);
           if (submitBtn) { submitBtn.textContent = submitText; submitBtn.disabled = false; }

--- a/frontend/src/pages/[...lang]/job-offers.astro
+++ b/frontend/src/pages/[...lang]/job-offers.astro
@@ -138,18 +138,18 @@ const c = commonTranslations[lang];
     // Wake up the database (see hire-me.astro for details).
     fetch(apiUrl + '/health').catch(function() {});
 
-    function showError(status) {
+    function showError(status, traceId) {
       var msg = !status ? errorNetwork : status === 404 ? errorNotFound : status >= 500 ? errorServer : errorText;
-      window.__showSnackbar?.(msg, 'error');
+      window.__showSnackbar?.(msg, 'error', 8000, traceId);
     }
 
     async function showApiError(res) {
-      var msg = await window.__getApiError?.(res, apiErrorMap);
-      if (msg) {
-        window.__showSnackbar?.(msg, 'error');
-        return msg;
+      var result = await window.__getApiError?.(res, apiErrorMap);
+      if (result?.message) {
+        window.__showSnackbar?.(result.message, 'error', 8000, result.traceId);
+        return result.message;
       }
-      showError(res.status);
+      showError(res.status, result?.traceId);
     }
 
     var currentOfferId = null;

--- a/frontend/src/pages/[...lang]/profile.astro
+++ b/frontend/src/pages/[...lang]/profile.astro
@@ -473,11 +473,16 @@ const t = translations[lang];
 
         if (updateError) throw updateError;
 
-        // Refresh session and update UI
+        // Update preview immediately — avatarUrl is already confirmed by the
+        // successful upload + metadata update above, so we don't need to wait
+        // for getUser() to reflect it.
+        var displayName = currentUser.user_metadata?.full_name || currentUser.email?.split('@')[0] || 'User';
+        updateAvatarPreview(avatarUrl, displayName);
+
+        // Refresh session so future pages see the new avatar URL in the token
         await supabase.auth.refreshSession();
         var { data: userData } = await supabase.auth.getUser();
         if (userData?.user) {
-          updateAvatarPreview(avatarUrl, userData.user.user_metadata?.full_name || userData.user.email?.split('@')[0] || 'User');
           window.dispatchEvent(new CustomEvent('auth-change', { detail: { user: userData.user } }));
         }
 


### PR DESCRIPTION
## Summary

- **TraceId in error snackbar (fixes #30):** Extend `__showSnackbar` with an optional `traceId` parameter displayed as muted text with a copy-to-clipboard button below the error message. Update `__getApiError` to extract `traceId` from ProblemDetails responses (both 4xx and 5xx). Update all callers (hire-me, job-offers, admin/job-offers) to pass traceId through.
- **Configurable rate limit:** Make `HireMePermitLimit` configurable via appsettings (default: 2) so E2E tests can raise the quota and avoid cross-test exhaustion.
- **Avatar preview fix:** Move `updateAvatarPreview()` before `getUser()` so the preview updates immediately after upload, fixing a flaky E2E test.

## Test plan

- [ ] Trigger a 400 validation error on hire-me — verify snackbar shows error message with traceId and copy button
- [ ] Trigger a 500 server error — verify snackbar shows generic error message with traceId
- [ ] Trigger a network error — verify snackbar shows error without traceId section
- [ ] Click the copy button next to traceId — verify it copies to clipboard
- [ ] Verify non-error snackbars (success, info) do not show a traceId section

🤖 Generated with [Claude Code](https://claude.com/claude-code)