### PR TITLE
Replace rate limit config template with environment-based defaults

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,7 +138,6 @@ jobs:
           ConnectionStrings__DefaultConnection: "Host=localhost;Database=kalandra;Username=kalandra;Password=kalandra_dev"
           Supabase__ProjectUrl: "http://127.0.0.1:54321"
           Turnstile__SecretKey: "1x0000000000000000000000000000000AA"
-          RateLimit__HireMePermitLimit: "20"
           ASPNETCORE_ENVIRONMENT: Development
 
       - name: Wait for backend

--- a/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/RateLimits.cs
@@ -10,9 +10,9 @@ public static class RateLimitPolicies
 
 public static class RateLimits
 {
-    public static void Add(IServiceCollection services, IConfiguration configuration)
+    public static void Add(IServiceCollection services, IHostEnvironment environment)
     {
-        var permitLimit = configuration.GetValue("RateLimit:HireMePermitLimit", defaultValue: 2);
+        var permitLimit = environment.IsDevelopment() ? 50 : 2;
 
         // Hire-me submissions: N per 4 hours per authenticated user. When the
         // limit is hit, the client must re-render Turnstile in interactive mode

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -41,7 +41,7 @@ builder.Services.AddTurnstile();
 builder.Services.AddAuthAdminServices();
 builder.Services.AddApiServices();
 builder.Services.AddJobOffersDomain();
-RateLimits.Add(builder.Services, builder.Configuration);
+RateLimits.Add(builder.Services, builder.Environment);
 
 builder.Services.AddResponseCompression(options =>
 {

--- a/backend/src/Kalandra.Api/appsettings.Development.json.template
+++ b/backend/src/Kalandra.Api/appsettings.Development.json.template
@@ -1,8 +1,0 @@
-{
-  "RateLimit": {
-    "HireMePermitLimit": 20
-  },
-  "Turnstile": {
-    "SecretKey": "1x0000000000000000000000000000000AA"
-  }
-}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,17 +64,6 @@ Both configurations run `npm install` as a before-launch step, so dependencies a
 
 > The remaining configurations in `.run/` (`Backend`, `Frontend`, `Watch Backend`) are building blocks used by the compound configs above.
 
-### 1.3.1 Backend Development Config
-
-Copy the template to create your local config (gitignored, never committed):
-
-```bash
-cp backend/src/Kalandra.Api/appsettings.Development.json.template \
-   backend/src/Kalandra.Api/appsettings.Development.json
-```
-
-This overrides `appsettings.json` when `ASPNETCORE_ENVIRONMENT=Development` and sets a higher rate limit for local E2E tests. Add any real secrets (Turnstile keys, etc.) here — the file is in `.gitignore`.
-
 ### 1.4 CLI Alternative
 
 ```bash
@@ -118,7 +107,7 @@ PUBLIC_TURNSTILE_SITE_KEY=your-real-site-key
 
 The committed `.env` uses Cloudflare's [always-pass test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) so the form works locally without a real Turnstile widget. The backend `appsettings.json` uses the matching always-pass test secret (`1x0000000000000000000000000000000AA`).
 
-To test with a real widget locally, override in `.env.local` (frontend) and `appsettings.Development.json` or user-secrets (backend):
+To test with a real widget locally, override in `.env.local` (frontend) and user-secrets (backend):
 ```
 # frontend/.env.local
 PUBLIC_TURNSTILE_SITE_KEY=your-real-site-key


### PR DESCRIPTION
## Summary
- Rate limit permit count is now determined by `IHostEnvironment.IsDevelopment()`: **50** in Development, **2** in Production
- Deleted `appsettings.Development.json.template` — no longer needed
- Removed `RateLimit__HireMePermitLimit` env var from CI/CD (e2e already runs with `ASPNETCORE_ENVIRONMENT=Development`)
- Cleaned up SETUP.md references to the template

## Test plan
- [x] `dotnet build` succeeds
- [x] `npm test` passes (61/61 backend, 9/10 frontend — 1 pre-existing flaky test)
- [ ] CI pipeline passes with no rate limit env var override
- [ ] Production deploy uses `Release` config (Dockerfile already has `-c Release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)