### PR TITLE
Add Playwright screenshots and traces for E2E failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,12 +173,13 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ env.SB_SERVICE_ROLE_KEY }}
 
       - name: Upload Playwright traces
-        if: failure()
+        if: '!cancelled()'
         uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
           path: frontend/test-results/
           retention-days: 7
+          if-no-files-found: ignore
 
   backend-test:
     if: github.event_name != 'workflow_dispatch'

--- a/frontend/playwright.e2e.config.ts
+++ b/frontend/playwright.e2e.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'html',
   use: {
     baseURL: 'http://localhost:4321',
-    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },


### PR DESCRIPTION
## Summary
- Add `screenshot: 'only-on-failure'` to `playwright.e2e.config.ts` so each failing test captures a PNG
- Change `trace: 'on-first-retry'` → `'retain-on-failure'` — the old setting never fired locally because `retries: 0`
- CI artifact upload now uses `if: !cancelled()` (was `if: failure()`) so test results are always available
- Added `if-no-files-found: ignore` to prevent the upload step from failing when all tests pass

## Verified locally
Both screenshots (`test-failed-1.png`) and traces (`trace.zip`) are captured for failing tests in `test-results/`.

## Test plan
- [x] Run E2E tests locally with intentional failures — screenshots and traces appear in `test-results/`
- [ ] CI pipeline uploads `playwright-traces` artifact on test failure
- [ ] Traces viewable at trace.playwright.dev

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)