### PR TITLE
Fix sitemap-index.xml showing empty page in browsers

### DIFF
--- a/frontend/public/sitemap.xsl
+++ b/frontend/public/sitemap.xsl
@@ -24,28 +24,50 @@
         </style>
       </head>
       <body>
-        <h1>XML Sitemap</h1>
-        <p class="meta">
-          <xsl:value-of select="count(s:urlset/s:url)"/> URLs. This file is for search engines; the styling is just for human readability.
-        </p>
-        <table>
-          <thead>
-            <tr><th>URL</th><th>Last modified</th><th>Alternates</th></tr>
-          </thead>
-          <tbody>
-            <xsl:for-each select="s:urlset/s:url">
-              <tr>
-                <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
-                <td><xsl:value-of select="s:lastmod"/></td>
-                <td class="alt">
-                  <xsl:for-each select="xhtml:link">
-                    <xsl:value-of select="@hreflang"/>: <a href="{@href}"><xsl:value-of select="@href"/></a><br/>
-                  </xsl:for-each>
-                </td>
-              </tr>
-            </xsl:for-each>
-          </tbody>
-        </table>
+        <xsl:choose>
+          <xsl:when test="s:sitemapindex">
+            <h1>XML Sitemap Index</h1>
+            <p class="meta">
+              <xsl:value-of select="count(s:sitemapindex/s:sitemap)"/> sitemap(s). This file is for search engines; the styling is just for human readability.
+            </p>
+            <table>
+              <thead>
+                <tr><th>Sitemap</th></tr>
+              </thead>
+              <tbody>
+                <xsl:for-each select="s:sitemapindex/s:sitemap">
+                  <tr>
+                    <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
+                  </tr>
+                </xsl:for-each>
+              </tbody>
+            </table>
+          </xsl:when>
+          <xsl:otherwise>
+            <h1>XML Sitemap</h1>
+            <p class="meta">
+              <xsl:value-of select="count(s:urlset/s:url)"/> URLs. This file is for search engines; the styling is just for human readability.
+            </p>
+            <table>
+              <thead>
+                <tr><th>URL</th><th>Last modified</th><th>Alternates</th></tr>
+              </thead>
+              <tbody>
+                <xsl:for-each select="s:urlset/s:url">
+                  <tr>
+                    <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
+                    <td><xsl:value-of select="s:lastmod"/></td>
+                    <td class="alt">
+                      <xsl:for-each select="xhtml:link">
+                        <xsl:value-of select="@hreflang"/>: <a href="{@href}"><xsl:value-of select="@href"/></a><br/>
+                      </xsl:for-each>
+                    </td>
+                  </tr>
+                </xsl:for-each>
+              </tbody>
+            </table>
+          </xsl:otherwise>
+        </xsl:choose>
       </body>
     </html>
   </xsl:template>

--- a/frontend/public/sitemap.xsl
+++ b/frontend/public/sitemap.xsl
@@ -4,71 +4,85 @@
                 xmlns:s="http://www.sitemaps.org/schemas/sitemap/0.9"
                 xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <xsl:output method="html" encoding="UTF-8" indent="yes"/>
-  <xsl:template match="/">
+
+  <!-- Sitemap index (lists child sitemaps) -->
+  <xsl:template match="/s:sitemapindex">
     <html lang="en">
       <head>
         <meta charset="UTF-8"/>
-        <title>Sitemap — kalandra.tech</title>
-        <style>
-          :root { color-scheme: light dark; }
-          body { font-family: -apple-system, system-ui, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
-          h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
-          p.meta { color: #666; margin-top: 0; }
-          table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-          th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd; vertical-align: top; }
-          th { background: rgba(127,127,127,0.1); font-weight: 600; }
-          tr:hover td { background: rgba(127,127,127,0.05); }
-          a { color: #2563eb; text-decoration: none; }
-          a:hover { text-decoration: underline; }
-          .alt { font-size: 0.8rem; color: #666; }
-        </style>
+        <title>XML Sitemap Index — kalandra.tech</title>
+        <xsl:call-template name="styles"/>
       </head>
       <body>
-        <xsl:choose>
-          <xsl:when test="s:sitemapindex">
-            <h1>XML Sitemap Index</h1>
-            <p class="meta">
-              <xsl:value-of select="count(s:sitemapindex/s:sitemap)"/> sitemap(s). This file is for search engines; the styling is just for human readability.
-            </p>
-            <table>
-              <thead>
-                <tr><th>Sitemap</th></tr>
-              </thead>
-              <tbody>
-                <xsl:for-each select="s:sitemapindex/s:sitemap">
-                  <tr>
-                    <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
-                  </tr>
-                </xsl:for-each>
-              </tbody>
-            </table>
-          </xsl:when>
-          <xsl:otherwise>
-            <h1>XML Sitemap</h1>
-            <p class="meta">
-              <xsl:value-of select="count(s:urlset/s:url)"/> URLs. This file is for search engines; the styling is just for human readability.
-            </p>
-            <table>
-              <thead>
-                <tr><th>URL</th><th>Last modified</th><th>Alternates</th></tr>
-              </thead>
-              <tbody>
-                <xsl:for-each select="s:urlset/s:url">
-                  <tr>
-                    <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
-                    <td><xsl:value-of select="s:lastmod"/></td>
-                    <td class="alt">
-                      <xsl:for-each select="xhtml:link">
-                        <xsl:value-of select="@hreflang"/>: <a href="{@href}"><xsl:value-of select="@href"/></a><br/>
-                      </xsl:for-each>
-                    </td>
-                  </tr>
-                </xsl:for-each>
-              </tbody>
-            </table>
-          </xsl:otherwise>
-        </xsl:choose>
+        <h1>XML Sitemap Index</h1>
+        <p class="meta">
+          <xsl:value-of select="count(s:sitemap)"/> sitemap(s). This file is for search engines; the styling is just for human readability.
+        </p>
+        <table>
+          <thead>
+            <tr><th>Sitemap</th></tr>
+          </thead>
+          <tbody>
+            <xsl:for-each select="s:sitemap">
+              <tr>
+                <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
+              </tr>
+            </xsl:for-each>
+          </tbody>
+        </table>
       </body>
     </html>
+  </xsl:template>
+
+  <!-- Regular sitemap (lists URLs) -->
+  <xsl:template match="/s:urlset">
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8"/>
+        <title>XML Sitemap — kalandra.tech</title>
+        <xsl:call-template name="styles"/>
+      </head>
+      <body>
+        <h1>XML Sitemap</h1>
+        <p class="meta">
+          <xsl:value-of select="count(s:url)"/> URLs. This file is for search engines; the styling is just for human readability.
+        </p>
+        <table>
+          <thead>
+            <tr><th>URL</th><th>Last modified</th><th>Alternates</th></tr>
+          </thead>
+          <tbody>
+            <xsl:for-each select="s:url">
+              <tr>
+                <td><a href="{s:loc}"><xsl:value-of select="s:loc"/></a></td>
+                <td><xsl:value-of select="s:lastmod"/></td>
+                <td class="alt">
+                  <xsl:for-each select="xhtml:link">
+                    <xsl:value-of select="@hreflang"/>: <a href="{@href}"><xsl:value-of select="@href"/></a><br/>
+                  </xsl:for-each>
+                </td>
+              </tr>
+            </xsl:for-each>
+          </tbody>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+
+  <!-- Shared styles -->
+  <xsl:template name="styles">
+    <style>
+      :root { color-scheme: light dark; }
+      body { font-family: -apple-system, system-ui, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
+      h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+      p.meta { color: #666; margin-top: 0; }
+      table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+      th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #ddd; vertical-align: top; }
+      th { background: rgba(127,127,127,0.1); font-weight: 600; }
+      tr:hover td { background: rgba(127,127,127,0.05); }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .alt { font-size: 0.8rem; color: #666; }
+    </style>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
## Summary

- The XSL stylesheet (`sitemap.xsl`) only handled `<urlset>` documents (used by `sitemap-0.xml`) but not `<sitemapindex>` documents (used by `sitemap-index.xml`)
- When browsers rendered `sitemap-index.xml` with this stylesheet, it matched zero `s:urlset/s:url` nodes and displayed "0 URLs" with an empty table
- Added an `xsl:choose` branch so the stylesheet detects and correctly renders both document types: sitemap index files show child sitemap links, regular sitemaps show URLs with lastmod and hreflang alternates

## Test plan

- [ ] Build frontend (`npm run build` in `frontend/`) and verify `dist/sitemap-index.xml` references `sitemap-0.xml`
- [ ] Open `dist/sitemap-index.xml` in a browser — should show "XML Sitemap Index" with 1 sitemap link
- [ ] Open `dist/sitemap-0.xml` in a browser — should show "XML Sitemap" with 14 URLs (unchanged behavior)
- [ ] Verify https://www.kalandra.tech/sitemap-index.xml renders correctly after deploy

https://claude.ai/code/session_01MDrXEWDbEZNsVJjogR2SJM