### PR TITLE
Fix Core Web Vitals: accessibility and performance

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -51,6 +51,9 @@ function getPageLastmod(url) {
 // https://astro.build/config
 export default defineConfig({
   site,
+  build: {
+    inlineStylesheets: "always",
+  },
   integrations: [
     icon(),
     sitemap({

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -64,6 +64,13 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/manrope-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin />
+    {lang !== "en" && (
+      <>
+        <link rel="preload" href="/fonts/inter-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="/fonts/manrope-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="/fonts/space-grotesk-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+      </>
+    )}
     <!-- Flag icons: loaded non-render-blocking via the media swap trick.
          The browser fetches the stylesheet at low priority because it thinks it's
          for print, then the onload handler switches it to `media="all"` so styles

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -64,13 +64,15 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/manrope-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin />
-    {lang !== "en" && (
-      <>
-        <link rel="preload" href="/fonts/inter-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="/fonts/manrope-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="/fonts/space-grotesk-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
-      </>
-    )}
+    {
+      lang !== "en" && (
+        <>
+          <link rel="preload" href="/fonts/inter-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+          <link rel="preload" href="/fonts/manrope-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+          <link rel="preload" href="/fonts/space-grotesk-latin-ext.woff2" as="font" type="font/woff2" crossorigin />
+        </>
+      )
+    }
     <!-- Flag icons: loaded non-render-blocking via the media swap trick.
          The browser fetches the stylesheet at low priority because it thinks it's
          for print, then the onload handler switches it to `media="all"` so styles

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -118,7 +118,7 @@ const t = translations[lang];
                     aria-hidden="true"
                   />
                   <div>
-                    <h5 class="font-bold text-xl mb-2">{pillar.title}</h5>
+                    <h3 class="font-bold text-xl mb-2">{pillar.title}</h3>
                     <p class="text-on-surface-variant leading-relaxed">{pillar.description}</p>
                   </div>
                 </li>

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -36,10 +36,10 @@ const t = translations[lang];
             </p>
           </div>
           <div class="md:col-span-4 bg-surface-container p-8 rounded-xl border border-outline-variant/40 shadow-sm">
-            <h3 class="font-headline font-bold text-xl mb-6 flex items-center gap-2 text-on-surface">
+            <h2 class="font-headline font-bold text-xl mb-6 flex items-center gap-2 text-on-surface">
               <Icon name="material-symbols:bolt" class="size-6 text-tertiary" aria-hidden="true" />
               {t.quickStats.title}
-            </h3>
+            </h2>
             <div class="space-y-6">
               <div>
                 <div class="font-label text-xs text-on-surface-variant uppercase mb-1">
@@ -51,7 +51,7 @@ const t = translations[lang];
                 <div class="font-label text-xs text-on-surface-variant uppercase mb-1 flex items-center gap-1">
                   {t.quickStats.timeLabel}
                   <span class="relative group cursor-help">
-                    <Icon name="material-symbols:info" class="size-3.5 text-on-surface-variant/50" aria-hidden="true" />
+                    <Icon name="material-symbols:info" class="size-3.5 text-on-surface-variant" aria-hidden="true" />
                     <span
                       class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-surface-container-highest text-on-surface text-xs rounded-lg shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none w-48 text-center normal-case tracking-normal font-normal"
                       role="tooltip">{t.quickStats.timeTooltip}</span
@@ -59,7 +59,7 @@ const t = translations[lang];
                   </span>
                 </div>
                 <a href="#roadmap" class="font-body font-semibold text-primary hover:underline">{t.quickStats.timeValue}</a>
-                <div class="font-body text-xs text-on-surface-variant/60 italic mt-1">
+                <div class="font-body text-xs text-on-surface-variant italic mt-1">
                   {t.quickStats.timeNote}
                 </div>
               </div>
@@ -376,13 +376,13 @@ const t = translations[lang];
                         ]}
                       >
                         {version.time}
-                        {hasDates && <span class="text-on-surface-variant/60"> · {version.dates}</span>}
+                        {hasDates && <span class="text-on-surface-variant"> · {version.dates}</span>}
                       </p>
                     )}
                     {"nextTime" in version && version.nextTime && (
                       <p
                         class:list={[
-                          "font-label text-xs text-on-surface-variant/60 italic",
+                          "font-label text-xs text-on-surface-variant italic",
                           "timeNote" in version && version.timeNote ? "mb-1" : "mb-4",
                         ]}
                       >
@@ -390,7 +390,7 @@ const t = translations[lang];
                       </p>
                     )}
                     {"timeNote" in version && version.timeNote && (
-                      <p class="font-label text-xs text-on-surface-variant/60 italic mb-4">{version.timeNote}</p>
+                      <p class="font-label text-xs text-on-surface-variant italic mb-4">{version.timeNote}</p>
                     )}
                     <p class:list={["font-body text-on-surface-variant leading-relaxed", (hasPricing || hasDetails) && "mb-4"]}>
                       {version.description}
@@ -461,7 +461,7 @@ const t = translations[lang];
                 );
 
                 return (
-                  <div class:list={["relative grid grid-cols-1 md:grid-cols-2 gap-8 items-start", isFaded && "opacity-60"]}>
+                  <div class:list={["relative grid grid-cols-1 md:grid-cols-2 gap-8 items-start", isFaded && "opacity-75"]}>
                     {isLeft ? (
                       <>
                         <div class="md:text-right md:pr-16">{versionContent}</div>
@@ -573,7 +573,7 @@ const t = translations[lang];
       aria-label={t.toc.title}
     >
       <div class="flex overflow-x-auto gap-1 px-3 py-2 scrollbar-hide items-center">
-        <span class="shrink-0 font-label text-[10px] uppercase tracking-widest text-on-surface-variant/60 pr-1">{t.toc.title}</span>
+        <span class="shrink-0 font-label text-[10px] uppercase tracking-widest text-on-surface-variant pr-1">{t.toc.title}</span>
         <span class="shrink-0 w-px h-4 bg-outline-variant/40" aria-hidden="true"></span>
         <a
           href="#hero"


### PR DESCRIPTION
## Summary

Fixes Lighthouse accessibility and performance audit findings on the project page (Czech locale):

**Accessibility (score 95 → targeting 100):**
- **Heading hierarchy**: Fix `h5` used after `h2` on about page (skipped h3/h4) → changed to `h3`. Fix `h3` appearing before any `h2` on project page Quick Stats → changed to `h2`.
- **Color contrast**: Remove `/50` and `/60` Tailwind opacity modifiers from `text-on-surface-variant` that dropped contrast below WCAG AA 4.5:1 threshold. Increase faded roadmap item opacity from 60% to 75% to maintain contrast compliance.

**Performance:**
- **Render-blocking CSS** (~280ms savings): Configure `build.inlineStylesheets: "always"` in Astro config to inline all CSS into HTML, eliminating the separate `Layout.css` network request.
- **Font loading chain** (411ms critical path): Preload latin-ext font subsets on non-English pages so the browser starts downloading them immediately on HTML parse, rather than waiting for CSS to discover the `@font-face` rules.

**Not changed — forced reflow (38ms):** The only `offsetHeight` reads in our code are intentional (theme toggle flush, details animation on click). The "[unattributed]" 38ms is from third-party scripts (Cloudflare Turnstile, email-decode) and not actionable.

## Test plan

- [x] All 10 Playwright E2E tests pass
- [x] Frontend build succeeds with no errors
- [x] Built HTML has no external CSS files (styles inlined)
- [x] Czech pages include latin-ext font preloads; English pages do not
- [x] Heading order in built HTML follows proper h1→h2→h3→h4 sequence
- [ ] Run Lighthouse audit on deployed Czech project page to verify score improvement

https://claude.ai/code/session_01V9Nje58M14irSfZdAEMxHV