### PR TITLE
Add dedicated /auth/callback route for OAuth returns

### DIFF
--- a/frontend/src/components/AuthDialog.astro
+++ b/frontend/src/components/AuthDialog.astro
@@ -253,10 +253,16 @@ const t = lang === "cs" ? csCommon : enCommon;
   async function authDialogGoogle() {
     const supabase = await getSupabaseClient();
     if (!supabase) return;
+    // Route OAuth returns through a dedicated callback page so the Supabase
+    // client is loaded eagerly and the session is persisted before any UI
+    // tries to read from localStorage. The current path is preserved in
+    // `next` so the user lands back where they started signing in.
+    const next = window.location.pathname + window.location.search;
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
     await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: window.location.origin + window.location.pathname,
+        redirectTo,
         queryParams: { prompt: "select_account" },
       },
     });

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -26,7 +26,9 @@
     "noAccount": "Nemáte účet?",
     "haveAccount": "Již máte účet?",
     "cancel": "Zrušit",
-    "confirmationSent": "Zkontrolujte svůj e-mail a potvrďte svůj účet."
+    "confirmationSent": "Zkontrolujte svůj e-mail a potvrďte svůj účet.",
+    "signingIn": "Dokončuji přihlášení",
+    "callbackError": "Přihlášení se nepodařilo dokončit. Zkuste to prosím znovu."
   },
   "theme": {
     "switchToDark": "Přepnout na tmavý režim",

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -26,7 +26,9 @@
     "noAccount": "Don't have an account?",
     "haveAccount": "Already have an account?",
     "cancel": "Cancel",
-    "confirmationSent": "Check your email to confirm your account."
+    "confirmationSent": "Check your email to confirm your account.",
+    "signingIn": "Finishing sign-in",
+    "callbackError": "Sign-in could not be completed. Please try again."
   },
   "theme": {
     "switchToDark": "Switch to dark mode",

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -364,13 +364,26 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
     <Snackbar />
 
     <script>
+      import enCommonHash from "../i18n/en/common.json";
+      import csCommonHash from "../i18n/cs/common.json";
+
       // Handle auth error/callback fragments in the URL (e.g. expired confirmation links).
       // Sign out any existing session — the person clicking the link is the one who signed up.
       const hashParams = new URLSearchParams(window.location.hash.substring(1));
       const authError = hashParams.get("error_description");
+      const strayAccessToken = hashParams.get("access_token");
       if (authError) {
         (window as any).__supabaseReady?.then((s: any) => s?.auth.signOut());
         (window as any).__showSnackbar(decodeURIComponent(authError), "error", 0);
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      } else if (strayAccessToken) {
+        // In the normal flow OAuth tokens only ever appear at /auth/callback.
+        // Seeing one on any other page means the user opened an old/reused
+        // link — treat it as a failed sign-in and surface an error.
+        (window as any).__supabaseReady?.then((s: any) => s?.auth.signOut());
+        const lang = document.documentElement.lang === "cs" ? "cs" : "en";
+        const msg = (lang === "cs" ? csCommonHash : enCommonHash).auth.callbackError;
+        (window as any).__showSnackbar(msg, "error", 0);
         history.replaceState(null, "", window.location.pathname + window.location.search);
       }
     </script>

--- a/frontend/src/pages/auth/callback.astro
+++ b/frontend/src/pages/auth/callback.astro
@@ -1,0 +1,128 @@
+---
+/**
+ * OAuth callback landing page.
+ *
+ * Supabase redirects here after a successful OAuth handshake with the URL hash
+ * containing `access_token` and friends. We load the Supabase client eagerly
+ * so `detectSessionInUrl` (default true) parses and persists the session
+ * before any other page-level auth UI tries to read from localStorage — this
+ * avoids the "just signed in but header says signed out" flash that happened
+ * when the redirect landed on a normal page and relied on the lazy-loaded
+ * supabase bundle.
+ *
+ * On success: redirect to `?next=<path>` (or `/`) — the session is already in
+ * localStorage so the destination's pre-paint script picks it up on first
+ * render.
+ * On failure: forward to `/` with an `error_description` in the hash so the
+ * generic handler in Layout.astro surfaces the error snackbar.
+ *
+ * This page is intentionally bare (no Layout) so it renders in a single
+ * paint and processes the hash as fast as possible.
+ */
+import enCommon from "../../i18n/en/common.json";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>{enCommon.auth.signingIn}</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #131313;
+        color: #e5e5e5;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      main {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      p {
+        font-size: 1rem;
+        opacity: 0.8;
+      }
+    </style>
+    <script is:inline>
+      // Pre-paint theme so the interstitial doesn't flash white then black.
+      (function () {
+        var t = localStorage.getItem("theme");
+        if (t === "light" || (!t && !window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+          document.documentElement.style.background = "#f3f1ed";
+          document.documentElement.style.color = "#131313";
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <main>
+      <p id="auth-callback-message">{enCommon.auth.signingIn}…</p>
+    </main>
+
+    <script>
+      import { getSupabaseClient } from "../../lib/supabase";
+      import enCommon from "../../i18n/en/common.json";
+      import csCommon from "../../i18n/cs/common.json";
+
+      (async () => {
+        const url = new URL(window.location.href);
+
+        // Only trust `next` if it's a site-relative path — never an absolute
+        // URL (which could point at an attacker-controlled origin).
+        const nextParam = url.searchParams.get("next");
+        const next = nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//") ? nextParam : "/";
+
+        const hash = new URLSearchParams(window.location.hash.substring(1));
+        const hashErr = hash.get("error_description");
+        const accessToken = hash.get("access_token");
+
+        // Pick locale from the `next` path so errors show in the user's language.
+        const lang = next.startsWith("/cs") ? "cs" : "en";
+        const t = (lang === "cs" ? csCommon : enCommon).auth;
+
+        const failAndRedirect = (reason: string) => {
+          const target = `${next}#error_description=${encodeURIComponent(reason)}`;
+          window.location.replace(target);
+        };
+
+        if (hashErr) {
+          failAndRedirect(decodeURIComponent(hashErr));
+          return;
+        }
+
+        if (!accessToken) {
+          failAndRedirect(t.callbackError);
+          return;
+        }
+
+        const supabase = await getSupabaseClient();
+        if (!supabase) {
+          failAndRedirect(t.callbackError);
+          return;
+        }
+
+        // `detectSessionInUrl` (default true) runs during createClient and
+        // writes the session to localStorage. Wait a tick for it to settle
+        // before we read it back.
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
+        if (!session) {
+          failAndRedirect(t.callbackError);
+          return;
+        }
+
+        window.location.replace(next);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Google OAuth previously redirected straight to the page the user clicked Sign In from, leaving `access_token` in the URL hash before the lazy-loaded Supabase client could parse it — the header briefly showed "signed out" and tokens leaked into history.
- Route OAuth returns through a new bare `/auth/callback` page that loads the Supabase client eagerly, waits for `detectSessionInUrl` to persist the session, then redirects to the original page via `?next=`.
- On callback failure (missing / invalid / expired token), forward to the next page with `error_description` in the hash so the existing Layout snackbar surfaces it.
- Extend the Layout hash handler to show the same error snackbar when a stray `access_token` lands on a non-callback page (e.g. reusing an old sign-in link) — previously silent.
- Add `auth.signingIn` and `auth.callbackError` strings in en + cs.

## Supabase dashboard note
The redirect allowlist already covers `https://www.kalandra.tech/**` and `http://localhost:4321/**`, so no dashboard changes required.

## Test plan
- [x] `npm run build:frontend` — succeeds, `/auth/callback/index.html` generated
- [x] Manual: navigate to `/auth/callback` without a hash → redirects to `/` with error snackbar
- [x] Manual: navigate to `/auth/callback?next=/about#access_token=FAKE…` → redirects to `/about` with error snackbar
- [x] Manual: navigate to `/about#access_token=FAKE…` → URL cleaned to `/about`, error snackbar shown
- [ ] Manual: full Google sign-in flow in local dev (pending user verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)