### PR TITLE
Add Dependabot coverage for root package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,13 @@ updates:
       npm:
         patterns:
           - "*"
+
+  # Root — npm packages from the repo-root package.json (dev tooling, hooks, etc.).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Root `package.json` (dev tooling, hooks) was not covered by Dependabot, leaving root-level npm vulnerabilities unmonitored (surfaced as a critical in `npm audit` but no Dependabot PR).
- Adds a third `npm` entry pointing at `/` alongside the existing `/frontend` entry.

## Test plan
- [ ] Dependabot picks up root `package.json` on next weekly run and opens PRs for outstanding advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)