### PR TITLE
Add Supabase auth + storage health checks

### DIFF
--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Supabase;
+
+namespace Kalandra.Api.Infrastructure;
+
+/// <summary>
+/// Verifies that the Supabase Auth admin API is reachable with the configured
+/// service key by issuing a lightweight ListUsers call (per-page=1). A missing
+/// or revoked service key surfaces as Unhealthy instead of a runtime 401 the
+/// first time a user touches auth-admin functionality.
+/// </summary>
+internal sealed class SupabaseAuthHealthCheck(
+    Client supabase,
+    Kalandra.Infrastructure.Configuration.SupabaseConfig supabaseConfig) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken ct = default)
+    {
+        try
+        {
+            var adminClient = supabase.AdminAuth(supabaseConfig.ServiceKey.Value);
+            // perPage=1 keeps the round-trip minimal; we only need to confirm the key is accepted.
+            await adminClient.ListUsers(filter: null, sortBy: null, sortOrder: Supabase.Gotrue.Constants.SortOrder.Descending, page: null, perPage: 1);
+            return HealthCheckResult.Healthy("Supabase Auth admin API reachable with the configured service key.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Supabase Auth admin API rejected the request. Verify Supabase:ProjectUrl and Supabase:ServiceKey.",
+                ex);
+        }
+    }
+}

--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Kalandra.Infrastructure.Storage;
+using Supabase.Storage;
+
+namespace Kalandra.Api.Infrastructure;
+
+/// <summary>
+/// Verifies that the Supabase Storage bucket used for job-offer attachments is
+/// reachable with the configured service key. Catches misconfigured project
+/// URLs, revoked service keys, and missing buckets at /health rather than on
+/// the first upload attempt.
+/// </summary>
+internal sealed class SupabaseStorageHealthCheck(Supabase.Client supabase) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken ct = default)
+    {
+        try
+        {
+            var searchOptions = new SearchOptions { Limit = 1 };
+            await supabase.Storage.From(SupabaseStorageService.BucketName).List(path: "", options: searchOptions);
+            return HealthCheckResult.Healthy($"Supabase Storage bucket '{SupabaseStorageService.BucketName}' reachable.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Supabase Storage bucket '{SupabaseStorageService.BucketName}' unreachable. Verify Supabase:ProjectUrl, Supabase:ServiceKey, and that the bucket exists.",
+                ex);
+        }
+    }
+}

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -54,7 +54,9 @@ builder.Services.AddResponseCompression(options =>
 
 builder.Services.AddHealthChecks()
     .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)
-    .AddCheck<CommitHashHealthCheck>("version");
+    .AddCheck<CommitHashHealthCheck>("version")
+    .AddCheck<SupabaseAuthHealthCheck>("supabase-auth")
+    .AddCheck<SupabaseStorageHealthCheck>("supabase-storage");
 
 var app = builder.Build();
 

--- a/backend/src/Kalandra.Infrastructure/Storage/SupabaseStorageService.cs
+++ b/backend/src/Kalandra.Infrastructure/Storage/SupabaseStorageService.cs
@@ -8,7 +8,7 @@ public class SupabaseStorageService(
     Supabase.Client supabase,
     ILogger<SupabaseStorageService> logger) : IStorageService
 {
-    private const string BucketName = "job-offer-attachments";
+    public const string BucketName = "job-offer-attachments";
 
     public async Task<IReadOnlyList<StorageFileInfo>> UploadAsync(
         string folderPrefix,

--- a/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Testcontainers.PostgreSql;
@@ -40,6 +41,15 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
             services.AddSingleton<IUserInfoService, NoOpUserInfoService>();
 
             services.RemoveAll<Supabase.Client>();
+
+            // The Supabase auth/storage health checks depend on the real Supabase.Client,
+            // which we removed above. Drop them from the /health endpoint so tests stay green;
+            // production wiring still registers them in Program.cs.
+            services.Configure<HealthCheckServiceOptions>(options =>
+            {
+                options.Registrations.Remove(options.Registrations.Single(r => r.Name == "supabase-auth"));
+                options.Registrations.Remove(options.Registrations.Single(r => r.Name == "supabase-storage"));
+            });
 
             services.PostConfigure<JwtBearerOptions>(
                 JwtBearerDefaults.AuthenticationScheme,


### PR DESCRIPTION
## Summary
- `/health` now includes `supabase-auth` and `supabase-storage` checks that exercise the configured service key against the Admin API and the `job-offer-attachments` bucket.
- A missing, revoked, or mis-scoped service key — which previously surfaced only on the first user-facing action (profile page, avatar upload, hire-me with attachment) — now shows up as Unhealthy at the health endpoint, matching how Sentry and BetterStack already fail fast on misconfiguration.
- Lifts `SupabaseStorageService.BucketName` from `private` to `public const` so the health check reuses the exact same literal.

## Test plan
- [x] `dotnet build`
- [x] Backend + integration tests (`npm run test:backend`) — 61 passed, 0 failed
- [x] Frontend tests (`npm run test:frontend`) — 10 passed
- [ ] Manually hit `/health` with a bad `Supabase:ServiceKey` and confirm 503 with the descriptive reason