### PR TITLE
Send apikey header on Gotrue AdminClient requests

### DIFF
--- a/backend/src/Kalandra.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -92,8 +92,17 @@ public static class ServiceCollectionExtensions
         {
             var config = sp.GetRequiredService<Kalandra.Infrastructure.Configuration.SupabaseConfig>();
             var projectUrl = config.ProjectUrl.Value.TrimEnd('/');
-            var options = new Supabase.Gotrue.ClientOptions { Url = $"{projectUrl}/auth/v1" };
-            return new Supabase.Gotrue.AdminClient(config.ServiceKey.Value, options);
+            var serviceKey = config.ServiceKey.Value;
+            var options = new Supabase.Gotrue.ClientOptions
+            {
+                Url = $"{projectUrl}/auth/v1",
+                // Supabase's auth gateway requires the `apikey` header on every request.
+                // AdminClient only sends `Authorization: Bearer <serviceKey>` by default,
+                // so we inject apikey here. For `sb_secret_…` keys the Authorization header
+                // is accepted as an opaque token rather than JWT-verified.
+                Headers = { ["apikey"] = serviceKey },
+            };
+            return new Supabase.Gotrue.AdminClient(serviceKey, options);
         });
 
         services.AddSingleton<IStorageService, SupabaseStorageService>();


### PR DESCRIPTION
## Summary

- Fixes `No API key found in request` on the `supabase-auth` health probe after PR #79, which still blocks auth-admin calls (user info lookup, etc.) when using the new `sb_secret_…` API keys.
- Keeps the `Supabase.Gotrue` NuGet SDK — no revert to raw `HttpClient`.

## Why it was still broken

`Supabase.Gotrue.AdminClient` only sends `Authorization: Bearer <key>`. Supabase's auth gateway additionally requires an `apikey` header on every request. Legacy `service_role` JWTs tolerated the missing header on some paths; the new opaque `sb_secret_…` keys are always rejected with `No 'apikey' request header or url param was found`.

`Supabase.Storage.Client` already worked because PR #79 wired it up with an explicit headers dictionary containing both `apikey` and `Authorization`. The Gotrue side never got the same treatment.

## Fix

Pass `apikey` via `ClientOptions.Headers` when constructing `AdminClient` — `AdminClient` merges those headers into every outgoing request. Mirrors the explicit headers dict already used for `Supabase.Storage.Client`.

## Test plan

- [x] `dotnet build` clean
- [x] `/health` returns 200 with `supabase-auth` and `supabase-storage` both Healthy against a real `sb_secret_…` key (verified locally before and after the change — auth went from `Unhealthy` → `Healthy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)