### PR TITLE
Write Supabase__ServiceKey into deploy env file

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -386,6 +386,7 @@ jobs:
             cat > "$HOME/kalandra-api.env" << EOF
             ConnectionStrings__DefaultConnection=${DB_CONNECTION_STRING}
             Supabase__ProjectUrl=${SUPABASE_PROJECT_URL}
+            Supabase__ServiceKey=${SUPABASE_SERVICE_ROLE_KEY}
             Turnstile__SecretKey=${TURNSTILE_SECRET_KEY}
             BetterStack__SourceToken=${BETTERSTACK_SOURCE_TOKEN}
             Sentry__Dsn=${SENTRY_DSN}


### PR DESCRIPTION
## Summary

Prod's `supabase-auth` health probe was still failing after #80 because the service key never actually reached the container. The deploy step exported `SUPABASE_SERVICE_ROLE_KEY` to the SSH session and listed it in `envs:`, but the heredoc that writes `\$HOME/kalandra-api.env` was missing the `Supabase__ServiceKey=…` line. The container fell back to the placeholder key baked into `appsettings.json`.

## Fix

Add the missing line to the heredoc so the secret actually makes it into the env file systemd loads when starting each blue/green slot.

## Test plan

- [ ] After merge, confirm `/health` on prod reports `supabase-auth` as Healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)