### PR TITLE
Propagate Sentry trace headers to api.kalandra.tech

### DIFF
--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -14,7 +14,7 @@ export function initSentry(dsn: string): void {
     environment: import.meta.env.PROD ? "production" : "development",
     tracesSampleRate: 1.0,
     integrations: [browserTracingIntegration()],
-    tracePropagationTargets: [/^\//, /kalandra\.tech/],
+    tracePropagationTargets: ["/", "api.kalandra.tech"],
   });
 }
 

--- a/frontend/src/pages/[...lang]/admin/test-errors.astro
+++ b/frontend/src/pages/[...lang]/admin/test-errors.astro
@@ -98,6 +98,7 @@ const c = commons[lang];
 
 <script
   define:vars={{
+    apiUrl: import.meta.env.PUBLIC_API_URL || "",
     triggeredMsg: t.results.triggered,
     unexpectedMsg: t.results.unexpectedSuccess,
     errorServer: c.errors.serverError,
@@ -124,7 +125,7 @@ const c = commons[lang];
     const token = await window.__getAccessToken?.();
     if (!token) return null;
 
-    return fetch(`/api${path}`, {
+    return fetch(`${apiUrl}/api${path}`, {
       method,
       headers: { Authorization: `Bearer ${token}` },
     });


### PR DESCRIPTION
## Summary
- `sentry-trace` / `baggage` weren't being injected on cross-origin fetches to `api.kalandra.tech`, so distributed traces broke at the frontend/backend boundary (e.g. `GET /api/job-offers/mine`). The regex `/kalandra\.tech/` wasn't matching in practice — swapped to a string matcher (`"api.kalandra.tech"`), which Sentry treats as a substring match on the full URL and is more reliable here.
- Fixed `admin/test-errors` to call the API via `PUBLIC_API_URL` like every other page. It previously used a bare `/api/...` path that only resolved because of Vite's local dev proxy.

## Test plan
- [ ] Load `/admin/job-offers` in production, inspect a GET to `api.kalandra.tech` — request carries `sentry-trace` and `baggage` headers
- [ ] Load `/admin/test-errors`, click "Throw error" — request goes to `api.kalandra.tech` (not `www.kalandra.tech/api`) and carries trace headers
- [ ] Verify the resulting trace shows up end-to-end in Sentry / BetterStack