### PR TITLE
Fix Sentry baggage injection in v10 + cache CORS preflight

### DIFF
--- a/backend/src/Kalandra.Api/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/ServiceCollectionExtensions.cs
@@ -66,7 +66,8 @@ public static class ServiceCollectionExtensions
                 policy
                     .AllowAnyHeader()
                     .AllowAnyMethod()
-                    .AllowCredentials();
+                    .AllowCredentials()
+                    .SetPreflightMaxAge(TimeSpan.FromHours(24));
             });
         });
 

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -13,8 +13,7 @@ export function initSentry(dsn: string): void {
     dsn,
     environment: import.meta.env.PROD ? "production" : "development",
     tracesSampleRate: 1.0,
-    integrations: [browserTracingIntegration()],
-    tracePropagationTargets: ["/", "api.kalandra.tech"],
+    integrations: [browserTracingIntegration({ tracePropagationTargets: ["/", "https://api.kalandra.tech"] })],
   });
 }
 

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -14,7 +14,7 @@ export function initSentry(dsn: string): void {
     environment: import.meta.env.PROD ? "production" : "development",
     tracesSampleRate: 1.0,
     integrations: [browserTracingIntegration()],
-    tracePropagationTargets: ["/", "http://localhost:5000", "https://api.kalandra.tech"],
+    tracePropagationTargets: ["localhost", /^\/api\//, "https://api.kalandra.tech"],
   });
 }
 

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -14,7 +14,7 @@ export function initSentry(dsn: string): void {
     environment: import.meta.env.PROD ? "production" : "development",
     tracesSampleRate: 1.0,
     integrations: [browserTracingIntegration()],
-    tracePropagationTargets: ["/", "https://api.kalandra.tech"],
+    tracePropagationTargets: ["/", "http://localhost:5000", "https://api.kalandra.tech"],
   });
 }
 

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -13,7 +13,8 @@ export function initSentry(dsn: string): void {
     dsn,
     environment: import.meta.env.PROD ? "production" : "development",
     tracesSampleRate: 1.0,
-    integrations: [browserTracingIntegration({ tracePropagationTargets: ["/", "https://api.kalandra.tech"] })],
+    integrations: [browserTracingIntegration()],
+    tracePropagationTargets: ["/", "https://api.kalandra.tech"],
   });
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #82. Verified in production DevTools that \`Sentry.getClient().getOptions().tracePropagationTargets\` returned \`undefined\` even with the option set at \`Sentry.init\` root level — in Sentry v10, \`browserTracingIntegration\` owns this option and the root-level value isn't wired through. Moved it onto the integration directly, which is what actually makes header injection happen.
- Added \`Access-Control-Max-Age: 24h\` to the backend CORS policy via \`SetPreflightMaxAge\`. Can't eliminate preflight for cross-origin requests from \`www.kalandra.tech\` to \`api.kalandra.tech\` (the \`Authorization\` header alone is enough to force one), but caching it means ~1 preflight per 2h per origin (Chrome cap) instead of one per request.

## Test plan
- [ ] Deploy, load \`/admin/test-errors\`, click "Throw error" — POST to \`api.kalandra.tech\` carries \`sentry-trace\` and \`baggage\` headers
- [ ] Load \`/admin/job-offers\` — GET carries the same headers
- [ ] Second request from the same tab within 2h — no preceding \`OPTIONS\` preflight
- [ ] Verify a full trace shows up in Sentry spanning frontend → backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)