### PR TITLE
Click the QR card to share (mobile) or copy (desktop)

### DIFF
--- a/frontend/src/components/QrCodeCard.astro
+++ b/frontend/src/components/QrCodeCard.astro
@@ -43,16 +43,16 @@ const path = rects.join("");
 const feedbackJson = JSON.stringify(t);
 ---
 
-<figure class="qr-card">
-  <button
-    type="button"
-    class="qr-face"
-    aria-label={buttonAriaLabel}
-    data-qr-trigger
-    data-qr-share-title={shareTitle}
-    data-qr-share-text={shareText}
-    data-qr-feedback={feedbackJson}
-  >
+<button
+  type="button"
+  class="qr-card"
+  aria-label={buttonAriaLabel}
+  data-qr-trigger
+  data-qr-share-title={shareTitle}
+  data-qr-share-text={shareText}
+  data-qr-feedback={feedbackJson}
+>
+  <span class="qr-face">
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox={`0 0 ${size} ${size}`}
@@ -75,9 +75,9 @@ const feedbackJson = JSON.stringify(t);
       decoding="async"
       data-qr-portrait
     />
-  </button>
-  <figcaption class="qr-caption">{label}</figcaption>
-</figure>
+  </span>
+  <span class="qr-caption">{label}</span>
+</button>
 
 <style>
   .qr-card {
@@ -90,6 +90,9 @@ const feedbackJson = JSON.stringify(t);
     border: 1px solid color-mix(in srgb, var(--color-outline-variant) 40%, transparent);
     border-radius: 1rem;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
     transition:
       transform 0.3s ease,
       box-shadow 0.3s ease,
@@ -100,6 +103,11 @@ const feedbackJson = JSON.stringify(t);
     transform: translateY(-2px);
     border-color: color-mix(in srgb, var(--color-primary) 40%, transparent);
     box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.2);
+  }
+
+  .qr-card:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 3px;
   }
 
   /* The inner face is kept on a fixed light background so the QR always has the
@@ -115,14 +123,6 @@ const feedbackJson = JSON.stringify(t);
     border-radius: 0.5rem;
     color: #1a1a1a;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
-    border: none;
-    cursor: pointer;
-    font: inherit;
-  }
-
-  .qr-face:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 3px;
   }
 
   .qr-svg {

--- a/frontend/src/components/QrCodeCard.astro
+++ b/frontend/src/components/QrCodeCard.astro
@@ -4,10 +4,18 @@ import QRCode from "qrcode";
 interface Props {
   url: string;
   label: string;
-  ariaLabel: string;
+  buttonAriaLabel: string;
+  shareTitle: string;
+  shareText: string;
+  t: {
+    copied: string;
+    copyFailed: string;
+    shareFailed: string;
+    unsupported: string;
+  };
 }
 
-const { url, label, ariaLabel } = Astro.props;
+const { url, label, buttonAriaLabel, shareTitle, shareText, t } = Astro.props;
 
 // Error correction level "H" tolerates up to ~30% obscurement, giving us
 // headroom to punch a portrait into the center of the code.
@@ -31,10 +39,20 @@ for (let y = 0; y < size; y++) {
   }
 }
 const path = rects.join("");
+
+const feedbackJson = JSON.stringify(t);
 ---
 
 <figure class="qr-card">
-  <a href={url} aria-label={ariaLabel} class="qr-face">
+  <button
+    type="button"
+    class="qr-face"
+    aria-label={buttonAriaLabel}
+    data-qr-trigger
+    data-qr-share-title={shareTitle}
+    data-qr-share-text={shareText}
+    data-qr-feedback={feedbackJson}
+  >
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox={`0 0 ${size} ${size}`}
@@ -42,6 +60,7 @@ const path = rects.join("");
       shape-rendering="crispEdges"
       class="qr-svg"
       aria-hidden="true"
+      data-qr-svg
     >
       <path d={path} fill="currentColor"></path>
     </svg>
@@ -54,8 +73,9 @@ const path = rects.join("");
       class="qr-portrait"
       loading="lazy"
       decoding="async"
+      data-qr-portrait
     />
-  </a>
+  </button>
   <figcaption class="qr-caption">{label}</figcaption>
 </figure>
 
@@ -95,6 +115,14 @@ const path = rects.join("");
     border-radius: 0.5rem;
     color: #1a1a1a;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+    border: none;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .qr-face:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 3px;
   }
 
   .qr-svg {
@@ -142,3 +170,140 @@ const path = rects.join("");
       0 0 64px -20px color-mix(in srgb, var(--color-primary) 70%, transparent);
   }
 </style>
+
+<script>
+  type Feedback = {
+    copied: string;
+    copyFailed: string;
+    shareFailed: string;
+    unsupported: string;
+  };
+
+  function loadImage(src: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+      img.src = src;
+    });
+  }
+
+  // Re-renders the on-screen QR face (SVG + circular portrait overlay) into a
+  // PNG blob. Drawing from the live SVG keeps the exported image in sync with
+  // whatever the component happens to render — no duplicated layout math.
+  async function buildQrImage(face: HTMLElement): Promise<Blob> {
+    const svg = face.querySelector<SVGSVGElement>("[data-qr-svg]");
+    const portrait = face.querySelector<HTMLImageElement>("[data-qr-portrait]");
+    if (!svg || !portrait) throw new Error("QR face is missing expected children");
+
+    const exportSize = 640;
+    const canvas = document.createElement("canvas");
+    canvas.width = exportSize;
+    canvas.height = exportSize;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+
+    // Match the on-screen .qr-face background so scanners see the expected
+    // high-contrast cream field around the code.
+    ctx.fillStyle = "#fdfcf9";
+    ctx.fillRect(0, 0, exportSize, exportSize);
+
+    // Inner padding mirrors 0.75rem on a 12rem face (6.25%).
+    const pad = exportSize * 0.0625;
+    const inner = exportSize - pad * 2;
+
+    // currentColor doesn't resolve when an SVG is loaded as an <img>, so bake
+    // the fill into the serialized copy before rasterizing.
+    const svgClone = svg.cloneNode(true) as SVGSVGElement;
+    svgClone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    svgClone.querySelectorAll('[fill="currentColor"]').forEach((el) => el.setAttribute("fill", "#1a1a1a"));
+    const svgStr = new XMLSerializer().serializeToString(svgClone);
+    const svgUrl = URL.createObjectURL(new Blob([svgStr], { type: "image/svg+xml" }));
+    try {
+      const svgImg = await loadImage(svgUrl);
+      ctx.drawImage(svgImg, pad, pad, inner, inner);
+    } finally {
+      URL.revokeObjectURL(svgUrl);
+    }
+
+    // Circular portrait overlay with the cream ring from the on-screen design.
+    const portraitSize = inner * 0.26;
+    const cx = exportSize / 2;
+    const cy = exportSize / 2;
+    const ringThickness = inner * 0.024;
+    const ringRadius = portraitSize / 2 + ringThickness;
+
+    ctx.fillStyle = "#fdfcf9";
+    ctx.beginPath();
+    ctx.arc(cx, cy, ringRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    const portraitImg = await loadImage(portrait.currentSrc || portrait.src);
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(cx, cy, portraitSize / 2, 0, Math.PI * 2);
+    ctx.clip();
+    ctx.drawImage(portraitImg, cx - portraitSize / 2, cy - portraitSize / 2, portraitSize, portraitSize);
+    ctx.restore();
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Canvas toBlob returned null"))), "image/png");
+    });
+  }
+
+  function toast(message: string, type: "success" | "error" | "info" = "info") {
+    (window as any).__showSnackbar?.(message, type);
+  }
+
+  async function copyImageToClipboard(blob: Blob, feedback: Feedback) {
+    if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+      toast(feedback.unsupported, "error");
+      return;
+    }
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      toast(feedback.copied, "success");
+    } catch {
+      toast(feedback.copyFailed, "error");
+    }
+  }
+
+  async function handleTrigger(face: HTMLElement) {
+    const feedback = JSON.parse(face.dataset.qrFeedback || "{}") as Feedback;
+    const shareTitle = face.dataset.qrShareTitle || "";
+    const shareText = face.dataset.qrShareText || "";
+
+    let blob: Blob;
+    try {
+      blob = await buildQrImage(face);
+    } catch {
+      toast(feedback.copyFailed, "error");
+      return;
+    }
+
+    const file = new File([blob], "kalandra-tech-qr.png", { type: "image/png" });
+    // Touch-primary devices get the native share sheet (it already includes
+    // Copy as one of the options). Everyone else goes straight to the
+    // clipboard, which on desktop pastes inline into Slack/email/etc.
+    const prefersShare =
+      matchMedia("(pointer: coarse)").matches && typeof navigator.canShare === "function" && navigator.canShare({ files: [file] });
+
+    if (prefersShare) {
+      try {
+        await navigator.share({ files: [file], title: shareTitle, text: shareText });
+        return;
+      } catch (err) {
+        if ((err as DOMException)?.name === "AbortError") return;
+        // Fall through to clipboard so the user still gets something useful.
+      }
+    }
+
+    await copyImageToClipboard(blob, feedback);
+  }
+
+  document.querySelectorAll<HTMLElement>("[data-qr-trigger]").forEach((face) => {
+    face.addEventListener("click", () => {
+      void handleTrigger(face);
+    });
+  });
+</script>

--- a/frontend/src/i18n/cs/home.json
+++ b/frontend/src/i18n/cs/home.json
@@ -29,8 +29,8 @@
     "paragraph2suffix": ". Sledujte novinky."
   },
   "qrCode": {
-    "label": "Naskenuj a sdílej",
-    "buttonAriaLabel": "Sdílet nebo zkopírovat obrázek QR kódu",
+    "label": "Klikni a sdílej",
+    "buttonAriaLabel": "Sdílet",
     "shareTitle": "kalandra.tech",
     "shareText": "Pavel Kalandra — kalandra.tech",
     "copied": "QR kód byl zkopírován do schránky",

--- a/frontend/src/i18n/cs/home.json
+++ b/frontend/src/i18n/cs/home.json
@@ -30,6 +30,12 @@
   },
   "qrCode": {
     "label": "Naskenuj a sdílej",
-    "ariaLabel": "QR kód s odkazem na www.kalandra.tech"
+    "buttonAriaLabel": "Sdílet nebo zkopírovat obrázek QR kódu",
+    "shareTitle": "kalandra.tech",
+    "shareText": "Pavel Kalandra — kalandra.tech",
+    "copied": "QR kód byl zkopírován do schránky",
+    "copyFailed": "QR kód se nepodařilo zkopírovat. Zkuste to prosím znovu.",
+    "shareFailed": "Sdílení nebylo dostupné. QR kód byl místo toho zkopírován do schránky.",
+    "unsupported": "Váš prohlížeč nepodporuje kopírování obrázků. Vyzkoušejte jiný prohlížeč nebo QR kód uložte pravým tlačítkem."
   }
 }

--- a/frontend/src/i18n/en/home.json
+++ b/frontend/src/i18n/en/home.json
@@ -29,8 +29,8 @@
     "paragraph2suffix": ". Stay tuned."
   },
   "qrCode": {
-    "label": "Scan to share",
-    "buttonAriaLabel": "Share or copy QR code image",
+    "label": "Click to share",
+    "buttonAriaLabel": "Share",
     "shareTitle": "kalandra.tech",
     "shareText": "Pavel Kalandra — kalandra.tech",
     "copied": "QR code copied to clipboard",

--- a/frontend/src/i18n/en/home.json
+++ b/frontend/src/i18n/en/home.json
@@ -30,6 +30,12 @@
   },
   "qrCode": {
     "label": "Scan to share",
-    "ariaLabel": "QR code linking to www.kalandra.tech"
+    "buttonAriaLabel": "Share or copy QR code image",
+    "shareTitle": "kalandra.tech",
+    "shareText": "Pavel Kalandra — kalandra.tech",
+    "copied": "QR code copied to clipboard",
+    "copyFailed": "Could not copy the QR code. Please try again.",
+    "shareFailed": "Sharing was not available. The QR code was copied to your clipboard instead.",
+    "unsupported": "Your browser doesn't support copying images. Try a different browser or right-click the QR code to save it."
   }
 }

--- a/frontend/src/pages/[...lang]/index.astro
+++ b/frontend/src/pages/[...lang]/index.astro
@@ -50,7 +50,19 @@ const t = translations[lang];
           >{t.whatsHere.paragraph2suffix}
         </p>
       </div>
-      <QrCodeCard url="https://www.kalandra.tech" label={t.qrCode.label} ariaLabel={t.qrCode.ariaLabel} />
+      <QrCodeCard
+        url="https://www.kalandra.tech"
+        label={t.qrCode.label}
+        buttonAriaLabel={t.qrCode.buttonAriaLabel}
+        shareTitle={t.qrCode.shareTitle}
+        shareText={t.qrCode.shareText}
+        t={{
+          copied: t.qrCode.copied,
+          copyFailed: t.qrCode.copyFailed,
+          shareFailed: t.qrCode.shareFailed,
+          unsupported: t.qrCode.unsupported,
+        }}
+      />
     </div>
 
     <!-- Cards -->


### PR DESCRIPTION
## Summary

- The home-page QR card is now an interactive **Share** button: clicking it (anywhere on the card, including the caption) hands the rendered PNG to the OS share sheet on touch devices, or writes it to the clipboard on desktop.
- Pasting raw PNG bytes into Slack/Discord/email/Figma produces an inline image — a copied URL pastes as a link (or a link-preview at best) and silently fails in apps that don't unfurl.
- Zero added bundle weight: the on-screen SVG + portrait are rasterized on click via a canvas roundtrip, so the exported PNG always matches what's rendered.

## Behaviour details

- **Touch devices** (`pointer: coarse` && `navigator.canShare({ files })`) → `navigator.share({ files: [png] })`. The OS sheet already exposes Copy alongside app targets, so it's a strict superset of the desktop path.
- **Everyone else** → `navigator.clipboard.write([new ClipboardItem({ \"image/png\": blob })])`.
- Share-cancel (`AbortError`) is silent; any other share failure falls through to the clipboard path; clipboard failure / missing `ClipboardItem` surfaces a localized snackbar (EN + CS) that hints at the right-click-save fallback.
- The whole card is a single \`<button class=\"qr-card\">\` wrapping the QR face and the caption — clicking the label works too. \`:focus-visible\` outline lives on the card.
- Caption relabeled \"Scan to share\" → **\"Click to share\"** (CS: \"Naskenuj a sdílej\" → \"Klikni a sdílej\"). Aria-label simplified to **\"Share\"** / \"Sdílet\".

## Test plan

- [x] \`npm run build:frontend\` — clean.
- [x] Frontend Playwright suite (\`cd frontend && npm test\`) — passing.
- [x] Verified in dev preview: clicking the caption (outside the QR face) triggers the handler; aria tree exposes a single \`button: \"Share\"\`.
- [ ] Backend + E2E layers weren't touched; run \`npm test\` locally before merging.
- [ ] Smoke in a real browser: Chrome desktop (clipboard → paste into Slack), Safari iOS / Chrome Android (share sheet), Firefox desktop (clipboard path — \`ClipboardItem\` supported from FF 127).
- [ ] Both locales render the QR card and the snackbar copy reads correctly.

https://claude.ai/code/session_01Nbf6urLLvtF79UniUD42ro