### PR TITLE
Replay snackbar entrance animation when already visible

### DIFF
--- a/frontend/src/components/Snackbar.astro
+++ b/frontend/src/components/Snackbar.astro
@@ -89,6 +89,15 @@ import { Icon } from "astro-icon/components";
       closeBtn.classList.remove("hidden");
     }
 
+    // If already visible, snap to hidden without transition so the entrance animation replays
+    if (snackbar.classList.contains("opacity-100")) {
+      snackbar.style.transition = "none";
+      snackbar.classList.remove("opacity-100", "translate-y-0", "pointer-events-auto");
+      snackbar.classList.add("opacity-0", "-translate-y-4", "pointer-events-none");
+      void snackbar.offsetWidth;
+      snackbar.style.transition = "";
+    }
+
     // Show
     snackbar.classList.remove("opacity-0", "-translate-y-4", "pointer-events-none");
     snackbar.classList.add("opacity-100", "translate-y-0", "pointer-events-auto");


### PR DESCRIPTION
## Summary
Re-invoking \`__showSnackbar\` while one was already on screen only swapped text/colors — the opacity/translate classes were already applied, so no transition fired and the user got no signal that a new message arrived (e.g. tapping the QR card repeatedly). Fix: snap to the hidden state without transition, force a reflow, then apply the show classes so the entrance animation plays again.

## Test plan
- [ ] Trigger a snackbar, then trigger another one while the first is still visible — the entrance animation should replay.
- [ ] A single snackbar with no predecessor still animates in normally.
- [ ] Auto-hide still fires after the duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)