### PR TITLE
Confirm incomplete job-offer submissions

### DIFF
--- a/frontend/src/i18n/cs/hire-me.json
+++ b/frontend/src/i18n/cs/hire-me.json
@@ -38,6 +38,18 @@
     "submitting": "Odesílám...",
     "successTitle": "Nabídka odeslána!",
     "successMessage": "Děkuji za váš zájem. Vaši nabídku posoudím a ozvu se vám e-mailem. Její stav můžete sledovat na stránce Pracovní nabídky.",
+    "confirmIncomplete": {
+      "title": "Odeslat s chybějícími údaji?",
+      "description": "Nevyplnili jste následující volitelné údaje. Přesto chcete nabídku odeslat?",
+      "fields": {
+        "salaryRange": "Mzdové rozmezí",
+        "location": "Lokalita",
+        "additionalNotes": "Další poznámky",
+        "attachments": "Přílohy"
+      },
+      "confirmButton": "Přesto odeslat",
+      "cancelButton": "Vrátit se"
+    },
     "captchaError": "Prosím dokončete ověření CAPTCHA.",
     "captchaRequiredError": "V poslední době jste odeslali několik nabídek. Potvrďte prosím, že jste člověk, a zkuste to znovu.",
     "errorMessage": "Něco se pokazilo. Zkuste to prosím znovu.",

--- a/frontend/src/i18n/en/hire-me.json
+++ b/frontend/src/i18n/en/hire-me.json
@@ -38,6 +38,18 @@
     "submitting": "Submitting...",
     "successTitle": "Offer Submitted!",
     "successMessage": "Thank you for your interest. I'll review your offer and get back to you via email. You can track its status on the Job Offers page.",
+    "confirmIncomplete": {
+      "title": "Submit with missing details?",
+      "description": "You didn't fill in the following optional information. Do you still want to submit?",
+      "fields": {
+        "salaryRange": "Salary range",
+        "location": "Location",
+        "additionalNotes": "Additional notes",
+        "attachments": "Attachments"
+      },
+      "confirmButton": "Submit anyway",
+      "cancelButton": "Go back"
+    },
     "captchaError": "Please complete the CAPTCHA verification.",
     "captchaRequiredError": "You've submitted several offers recently. Please verify you're human and try again.",
     "errorMessage": "Something went wrong. Please try again.",

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -503,9 +503,15 @@ const t = translations[lang];
           if (dialog.open) dialog.close();
           resolve(result);
         }
-        function onConfirm() { cleanup(true); }
-        function onCancel() { cleanup(false); }
-        function onClose() { cleanup(false); }
+        function onConfirm() {
+          cleanup(true);
+        }
+        function onCancel() {
+          cleanup(false);
+        }
+        function onClose() {
+          cleanup(false);
+        }
 
         confirmBtn.addEventListener("click", onConfirm);
         cancelBtn.addEventListener("click", onCancel);

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -214,6 +214,38 @@ const t = translations[lang];
   >
   <template id="icon-close"><Icon name="material-symbols:close" class="size-[18px]" aria-hidden="true" /></template>
 
+  <dialog
+    id="confirm-incomplete-dialog"
+    aria-labelledby="confirm-incomplete-title"
+    class="m-auto bg-surface-container-low rounded-2xl border border-outline-variant/10 p-8 max-w-sm w-full backdrop:bg-black/50"
+  >
+    <div class="space-y-5">
+      <h2 id="confirm-incomplete-title" class="font-headline text-xl font-bold text-on-surface">
+        {t.form.confirmIncomplete.title}
+      </h2>
+      <p class="text-sm text-on-surface-variant font-body">
+        {t.form.confirmIncomplete.description}
+      </p>
+      <ul id="confirm-incomplete-fields" class="list-disc pl-5 text-sm text-on-surface font-body space-y-1"></ul>
+      <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          id="confirm-incomplete-cancel"
+          class="px-4 py-2 rounded-xl text-sm font-label text-on-surface-variant hover:text-on-surface transition-colors cursor-pointer"
+        >
+          {t.form.confirmIncomplete.cancelButton}
+        </button>
+        <button
+          type="button"
+          id="confirm-incomplete-confirm"
+          class="px-4 py-2 rounded-xl text-sm font-semibold font-label bg-primary text-on-primary hover:bg-primary/90 transition-colors cursor-pointer"
+        >
+          {t.form.confirmIncomplete.confirmButton}
+        </button>
+      </div>
+    </div>
+  </dialog>
+
   <script
     define:vars={{
       apiUrl: import.meta.env.PUBLIC_API_URL || "",
@@ -226,6 +258,7 @@ const t = translations[lang];
       successText: t.form.successTitle,
       validationStrings: t.form.validation,
       apiErrorMap: t.form.errors,
+      incompleteFieldLabels: t.form.confirmIncomplete.fields,
       jobOffersPath: localePath(lang, "job-offers"),
     }}
   >
@@ -434,6 +467,53 @@ const t = translations[lang];
       });
     }
 
+    // Ask the user to confirm when optional fields or attachments are empty.
+    // Required fields are handled by validateAllFields above, so here we only
+    // look at the fields that are legitimately optional.
+    function getMissingOptionalFields(form) {
+      var missing = [];
+      if (!form.salaryRange.value.trim()) missing.push(incompleteFieldLabels.salaryRange);
+      if (!form.location.value.trim()) missing.push(incompleteFieldLabels.location);
+      if (!form.additionalNotes.value.trim()) missing.push(incompleteFieldLabels.additionalNotes);
+      if (selectedFiles.length === 0) missing.push(incompleteFieldLabels.attachments);
+      return missing;
+    }
+
+    function confirmIncompleteSubmission(missing) {
+      return new Promise(function (resolve) {
+        var dialog = document.getElementById("confirm-incomplete-dialog");
+        var list = document.getElementById("confirm-incomplete-fields");
+        var confirmBtn = document.getElementById("confirm-incomplete-confirm");
+        var cancelBtn = document.getElementById("confirm-incomplete-cancel");
+        if (!dialog || !list || !confirmBtn || !cancelBtn) {
+          resolve(true);
+          return;
+        }
+        list.innerHTML = "";
+        missing.forEach(function (label) {
+          var li = document.createElement("li");
+          li.textContent = label;
+          list.appendChild(li);
+        });
+
+        function cleanup(result) {
+          confirmBtn.removeEventListener("click", onConfirm);
+          cancelBtn.removeEventListener("click", onCancel);
+          dialog.removeEventListener("close", onClose);
+          if (dialog.open) dialog.close();
+          resolve(result);
+        }
+        function onConfirm() { cleanup(true); }
+        function onCancel() { cleanup(false); }
+        function onClose() { cleanup(false); }
+
+        confirmBtn.addEventListener("click", onConfirm);
+        cancelBtn.addEventListener("click", onCancel);
+        dialog.addEventListener("close", onClose);
+        dialog.showModal();
+      });
+    }
+
     // Form submission
     document.getElementById("job-offer-form")?.addEventListener("submit", async function (e) {
       e.preventDefault();
@@ -442,6 +522,12 @@ const t = translations[lang];
       var errorEl = document.getElementById("form-error");
 
       if (!validateAllFields(form)) return;
+
+      var missing = getMissingOptionalFields(form);
+      if (missing.length > 0) {
+        var confirmed = await confirmIncompleteSubmission(missing);
+        if (!confirmed) return;
+      }
 
       if (submitBtn) submitBtn.textContent = submittingText;
       if (submitBtn) submitBtn.disabled = true;

--- a/frontend/tests/e2e/avatar-flow.spec.ts
+++ b/frontend/tests/e2e/avatar-flow.spec.ts
@@ -110,6 +110,10 @@ test.describe("Avatar Flow", () => {
       input.value = "test-token";
     });
     await page.click("#submit-btn");
+    // The incomplete-submission confirmation appears because optional fields
+    // are left blank; confirm to proceed.
+    await expect(page.locator("#confirm-incomplete-dialog")).toBeVisible();
+    await page.click("#confirm-incomplete-confirm");
     await expect(page).toHaveURL(/\/job-offers#/, { timeout: 15000 });
 
     // Wait for the offer detail to load

--- a/frontend/tests/e2e/edit-activity-log.spec.ts
+++ b/frontend/tests/e2e/edit-activity-log.spec.ts
@@ -79,6 +79,10 @@ test.describe("Edit Activity Log", () => {
     });
 
     await page.click("#submit-btn");
+    // The incomplete-submission confirmation appears because optional fields
+    // are left blank; confirm to proceed.
+    await expect(page.locator("#confirm-incomplete-dialog")).toBeVisible();
+    await page.click("#confirm-incomplete-confirm");
     await expect(page).toHaveURL(/\/job-offers/, { timeout: 15000 });
 
     // --- Step 2: Verify the detail view is open ---

--- a/frontend/tests/e2e/hire-me-flow.spec.ts
+++ b/frontend/tests/e2e/hire-me-flow.spec.ts
@@ -106,6 +106,11 @@ test.describe("Hire Me Flow", () => {
     // 6. Submit the form — redirects to /job-offers#<offerId> on success
     await page.click("#submit-btn");
 
+    // The incomplete-submission confirmation appears because no attachment
+    // was provided; confirm to proceed.
+    await expect(page.locator("#confirm-incomplete-dialog")).toBeVisible();
+    await page.click("#confirm-incomplete-confirm");
+
     // 6. Verify redirect to job-offers page (allow extra time for API call)
     await expect(page).toHaveURL(/\/job-offers/, { timeout: 15000 });
 
@@ -169,8 +174,12 @@ test.describe("Hire Me Flow", () => {
         input.value = "test-token";
       });
 
-      // Submit — redirects to /job-offers#<offerId> on success
+      // Submit — redirects to /job-offers#<offerId> on success. The
+      // incomplete-submission confirmation appears because optional fields
+      // (salary, location, notes) were left blank; confirm to proceed.
       await page.click("#submit-btn");
+      await expect(page.locator("#confirm-incomplete-dialog")).toBeVisible();
+      await page.click("#confirm-incomplete-confirm");
       await expect(page).toHaveURL(/\/job-offers/, { timeout: 15000 });
 
       // 5. Get the access token to fetch the offer detail via API


### PR DESCRIPTION
## Summary
- The hire-me form accepted submissions with empty optional fields or no attachments without warning. Now, after required-field validation, a modal lists the missing items (salary range, location, additional notes, attachments) and asks the user to confirm or go back.
- Added a native `<dialog>` (styled to match `AuthDialog`) and a `confirmIncompleteSubmission()` helper that returns a Promise the submit handler awaits before proceeding. Esc/backdrop close is treated as cancel.
- Added `form.confirmIncomplete` translation block (title, description, per-field labels, buttons) to both `en` and `cs` `hire-me.json`.

## Test plan
- [ ] Submit a fully-filled offer — dialog does not appear and submission proceeds as before.
- [ ] Submit with one or more optional fields empty / no attachments — dialog opens, lists exactly the missing items, and "Submit anyway" continues while "Go back" / Esc / backdrop cancel aborts without changing button state or consuming the Turnstile token.
- [ ] Repeat in Czech locale (`/cs/hire-me`) to verify translations render.
- [ ] Verify both light and dark mode styling on the dialog.
- [ ] Run `npm test` locally (sandbox here lacks `dotnet` and Playwright browsers; `npm run build` passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKQUVR9XPcKsbrhj4apidY)_