### PR TITLE
Build out Projects section, add About-me section, share ProjectCard

### DIFF
--- a/frontend/src/components/Breadcrumb.astro
+++ b/frontend/src/components/Breadcrumb.astro
@@ -1,0 +1,37 @@
+---
+import { Icon } from "astro-icon/components";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface Props {
+  items: BreadcrumbItem[];
+  ariaLabel: string;
+  class?: string;
+}
+
+const { items, ariaLabel, class: className } = Astro.props;
+---
+
+<nav aria-label={ariaLabel} class:list={["font-label text-xs uppercase tracking-widest", className]}>
+  <ol class="flex items-center gap-2 flex-wrap">
+    {
+      items.map((item, i) => (
+        <li class="flex items-center gap-2">
+          {i > 0 && <Icon name="material-symbols:chevron-right" class="size-3.5 text-on-surface-variant/40 shrink-0" aria-hidden="true" />}
+          {item.href ? (
+            <a href={item.href} class="text-on-surface-variant hover:text-primary transition-colors">
+              {item.label}
+            </a>
+          ) : (
+            <span class="text-on-surface" aria-current="page">
+              {item.label}
+            </span>
+          )}
+        </li>
+      ))
+    }
+  </ol>
+</nav>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -7,6 +7,7 @@ type ActivePage =
   | "home"
   | "about"
   | "project"
+  | "strong-types"
   | "hire-me"
   | "job-offers"
   | "admin/job-offers"
@@ -22,7 +23,9 @@ interface Props {
     nav: {
       home: string;
       about: string;
-      project: string;
+      projects: string;
+      projectThisSite: string;
+      projectStrongTypes: string;
       hireMe: string;
       mySubmissions: string;
       admin: string;
@@ -34,6 +37,7 @@ interface Props {
       skipToContent: string;
       toggleDarkMode: string;
       changeLanguage: string;
+      openProjectsMenu: string;
     };
     theme: { switchToDark: string };
   };
@@ -41,11 +45,17 @@ interface Props {
 
 const { activePage, lang, t } = Astro.props;
 
+const projectsActive = activePage === "project" || activePage === "strong-types";
+
+const projectItems = [
+  { label: t.nav.projectThisSite, page: "project" as const },
+  { label: t.nav.projectStrongTypes, page: "strong-types" as const },
+];
+
 const navItems = [
-  { label: t.nav.home, page: "home" as const },
-  { label: t.nav.about, page: "about" as const },
-  { label: t.nav.project, page: "project" as const },
-  { label: t.nav.hireMe, page: "hire-me" as const },
+  { label: t.nav.home, page: "home" as const, active: activePage === "home" },
+  { label: t.nav.about, page: "about" as const, active: activePage === "about" },
+  { label: t.nav.hireMe, page: "hire-me" as const, active: activePage === "hire-me" },
 ];
 ---
 
@@ -136,21 +146,87 @@ const navItems = [
     </div>
 
     <div class="hidden md:flex pt-1 items-center gap-8 font-headline tracking-tighter font-bold text-nowrap">
-      {
-        navItems.map(({ label, page }) => (
-          <a
-            href={localePath(lang, page)}
-            class:list={[
-              activePage === page
-                ? "text-primary border-b-2 border-primary pb-1"
-                : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-            ]}
-            aria-current={activePage === page ? "page" : undefined}
-          >
-            {label}
-          </a>
-        ))
-      }
+      <a
+        href={localePath(lang, "home")}
+        class:list={[
+          activePage === "home"
+            ? "text-primary border-b-2 border-primary pb-1"
+            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+        ]}
+        aria-current={activePage === "home" ? "page" : undefined}
+      >
+        {t.nav.home}
+      </a>
+      <a
+        href={localePath(lang, "about")}
+        class:list={[
+          activePage === "about"
+            ? "text-primary border-b-2 border-primary pb-1"
+            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+        ]}
+        aria-current={activePage === "about" ? "page" : undefined}
+      >
+        {t.nav.about}
+      </a>
+
+      <!-- Projects dropdown (desktop) -->
+      <div class="relative group">
+        <button
+          type="button"
+          class:list={[
+            "flex items-center gap-1 pb-1 cursor-pointer border-b-2 transition-colors",
+            projectsActive ? "text-primary border-primary" : "text-on-surface-variant hover:text-on-surface border-transparent",
+          ]}
+          aria-haspopup="true"
+          aria-expanded={projectsActive ? "true" : "false"}
+          aria-label={t.a11y.openProjectsMenu}
+          aria-current={projectsActive ? "page" : undefined}
+        >
+          {t.nav.projects}
+          <Icon name="material-symbols:expand-more" class="size-4 transition-transform group-hover:rotate-180" aria-hidden="true" />
+        </button>
+        <div
+          class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute left-1/2 -translate-x-1/2 top-full pt-2 z-50"
+          role="menu"
+        >
+          <div class="bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[200px]">
+            {
+              projectItems.map(({ label, page }) => (
+                <a
+                  href={localePath(lang, page)}
+                  class:list={[
+                    "flex items-center gap-3 px-4 py-2.5 text-sm font-label transition-colors",
+                    activePage === page
+                      ? "text-primary font-semibold bg-primary/5"
+                      : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
+                  ]}
+                  role="menuitem"
+                  aria-current={activePage === page ? "page" : undefined}
+                >
+                  <Icon
+                    name={page === "project" ? "material-symbols:rocket-launch" : "material-symbols:package-2"}
+                    class="size-[18px] shrink-0"
+                    aria-hidden="true"
+                  />
+                  {label}
+                </a>
+              ))
+            }
+          </div>
+        </div>
+      </div>
+
+      <a
+        href={localePath(lang, "hire-me")}
+        class:list={[
+          activePage === "hire-me"
+            ? "text-primary border-b-2 border-primary pb-1"
+            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+        ]}
+        aria-current={activePage === "hire-me" ? "page" : undefined}
+      >
+        {t.nav.hireMe}
+      </a>
     </div>
 
     <!-- Theme toggle + Language picker + Auth (desktop) -->
@@ -292,22 +368,84 @@ const navItems = [
 
   <!-- Mobile nav -->
   <div class="md:hidden flex items-center">
-    <div class="flex items-center gap-6 px-4 font-headline tracking-tighter font-bold text-sm text-nowrap">
+    <div class="flex items-center gap-5 px-4 font-headline tracking-tighter font-bold text-sm text-nowrap">
       {
-        navItems.map(({ label, page }) => (
+        navItems.map(({ label, page, active }) => (
           <a
             href={localePath(lang, page)}
             class:list={[
-              activePage === page
-                ? "text-primary border-b-2 border-primary pb-1"
-                : "text-on-surface-variant border-b-2 border-transparent pb-1",
+              active ? "text-primary border-b-2 border-primary pb-1" : "text-on-surface-variant border-b-2 border-transparent pb-1",
             ]}
-            aria-current={activePage === page ? "page" : undefined}
+            aria-current={active ? "page" : undefined}
           >
             {label}
           </a>
         ))
       }
+      <!-- Projects dropdown (mobile) -->
+      <details class="relative">
+        <summary
+          class:list={[
+            "flex items-center gap-0.5 cursor-pointer list-none border-b-2 pb-1 select-none",
+            projectsActive ? "text-primary border-primary" : "text-on-surface-variant border-transparent",
+          ]}
+          aria-haspopup="true"
+          aria-current={projectsActive ? "page" : undefined}
+        >
+          {t.nav.projects}
+          <Icon name="material-symbols:expand-more" class="size-4 transition-transform" aria-hidden="true" />
+        </summary>
+        <div
+          class="absolute left-1/2 -translate-x-1/2 top-full mt-1 bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[180px] z-50"
+          role="menu"
+        >
+          {
+            projectItems.map(({ label, page }) => (
+              <a
+                href={localePath(lang, page)}
+                class:list={[
+                  "flex items-center gap-2 px-4 py-2 text-xs font-label transition-colors",
+                  activePage === page
+                    ? "text-primary font-semibold bg-primary/5"
+                    : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
+                ]}
+                role="menuitem"
+                aria-current={activePage === page ? "page" : undefined}
+              >
+                <Icon
+                  name={page === "project" ? "material-symbols:rocket-launch" : "material-symbols:package-2"}
+                  class="size-4 shrink-0"
+                  aria-hidden="true"
+                />
+                {label}
+              </a>
+            ))
+          }
+        </div>
+      </details>
     </div>
   </div>
 </nav>
+
+<style>
+  /* Hide the default disclosure triangle on the mobile Projects dropdown summary. */
+  summary::-webkit-details-marker {
+    display: none;
+  }
+  details[open] > summary > svg,
+  details[open] > summary > [data-icon] {
+    transform: rotate(180deg);
+  }
+</style>
+
+<script>
+  // Close the mobile Projects <details> dropdown when tapping outside.
+  const projectDetails = document.querySelectorAll<HTMLDetailsElement>("nav details");
+  document.addEventListener("click", (event) => {
+    projectDetails.forEach((d) => {
+      if (d.open && !d.contains(event.target as Node)) {
+        d.open = false;
+      }
+    });
+  });
+</script>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -6,6 +6,7 @@ import { localePath, alternateLangUrl } from "../i18n/utils";
 type ActivePage =
   | "home"
   | "about"
+  | "projects"
   | "project"
   | "strong-types"
   | "hire-me"
@@ -45,17 +46,29 @@ interface Props {
 
 const { activePage, lang, t } = Astro.props;
 
-const projectsActive = activePage === "project" || activePage === "strong-types";
+// "Projects" in the nav is a real link to /projects (a category landing page)
+// AND has a hover-only quick-access dropdown on desktop. That gives us:
+// - click does navigate (to a meaningful index page)
+// - hover gives a one-tap shortcut to a specific project
+// - active state on /projects, /project, and /strong-types is "Projects",
+//   with the page-level breadcrumb telling the reader which specific one
+const projectsActive = activePage === "projects" || activePage === "project" || activePage === "strong-types";
 
-const projectItems = [
-  { label: t.nav.projectThisSite, page: "project" as const },
-  { label: t.nav.projectStrongTypes, page: "strong-types" as const },
-];
-
-const navItems = [
+// Sibling links shown directly on the bar. The Projects entry is rendered
+// separately (it has a dropdown), so it's not in this array.
+const flatItems = [
   { label: t.nav.home, page: "home" as const, active: activePage === "home" },
   { label: t.nav.about, page: "about" as const, active: activePage === "about" },
-  { label: t.nav.hireMe, page: "hire-me" as const, active: activePage === "hire-me" },
+];
+
+const afterItems = [{ label: t.nav.hireMe, page: "hire-me" as const, active: activePage === "hire-me" }];
+
+// Items that appear in the desktop hover dropdown for power users who
+// want to skip the /projects index. Mobile users get just the single
+// /projects link — they pick from the cards on that page.
+const projectMenuItems = [
+  { label: t.nav.projectThisSite, page: "project" as const, icon: "rocket-launch", active: activePage === "project" },
+  { label: t.nav.projectStrongTypes, page: "strong-types" as const, icon: "package-2", active: activePage === "strong-types" },
 ];
 ---
 
@@ -146,68 +159,59 @@ const navItems = [
     </div>
 
     <div class="hidden md:flex pt-1 items-center gap-8 font-headline tracking-tighter font-bold text-nowrap">
-      <a
-        href={localePath(lang, "home")}
-        class:list={[
-          activePage === "home"
-            ? "text-primary border-b-2 border-primary pb-1"
-            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-        ]}
-        aria-current={activePage === "home" ? "page" : undefined}
-      >
-        {t.nav.home}
-      </a>
-      <a
-        href={localePath(lang, "about")}
-        class:list={[
-          activePage === "about"
-            ? "text-primary border-b-2 border-primary pb-1"
-            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-        ]}
-        aria-current={activePage === "about" ? "page" : undefined}
-      >
-        {t.nav.about}
-      </a>
+      {
+        flatItems.map(({ label, page, active }) => (
+          <a
+            href={localePath(lang, page)}
+            class:list={[
+              active
+                ? "text-primary border-b-2 border-primary pb-1"
+                : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+            ]}
+            aria-current={active ? "page" : undefined}
+          >
+            {label}
+          </a>
+        ))
+      }
 
-      <!-- Projects dropdown (desktop) -->
+      <!-- Projects: a real link (clicking goes to /projects) with a hover-only
+           dropdown shortcut on desktop. The chevron is hint-only. -->
       <div class="relative group">
-        <button
-          type="button"
+        <a
+          href={localePath(lang, "projects")}
           class:list={[
-            "flex items-center gap-1 pb-1 cursor-pointer border-b-2 transition-colors",
-            projectsActive ? "text-primary border-primary" : "text-on-surface-variant hover:text-on-surface border-transparent",
+            "inline-flex items-center gap-1 pb-1 border-b-2 transition-colors",
+            projectsActive
+              ? "text-primary border-primary"
+              : "text-on-surface-variant hover:text-on-surface border-transparent hover:border-transparent",
           ]}
           aria-haspopup="true"
-          aria-expanded={projectsActive ? "true" : "false"}
-          aria-label={t.a11y.openProjectsMenu}
           aria-current={projectsActive ? "page" : undefined}
         >
           {t.nav.projects}
           <Icon name="material-symbols:expand-more" class="size-4 transition-transform group-hover:rotate-180" aria-hidden="true" />
-        </button>
+        </a>
         <div
           class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute left-1/2 -translate-x-1/2 top-full pt-2 z-50"
           role="menu"
+          aria-label={t.a11y.openProjectsMenu}
         >
           <div class="bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[200px]">
             {
-              projectItems.map(({ label, page }) => (
+              projectMenuItems.map(({ label, page, icon, active }) => (
                 <a
                   href={localePath(lang, page)}
                   class:list={[
                     "flex items-center gap-3 px-4 py-2.5 text-sm font-label transition-colors",
-                    activePage === page
+                    active
                       ? "text-primary font-semibold bg-primary/5"
                       : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
                   ]}
                   role="menuitem"
-                  aria-current={activePage === page ? "page" : undefined}
+                  aria-current={active ? "page" : undefined}
                 >
-                  <Icon
-                    name={page === "project" ? "material-symbols:rocket-launch" : "material-symbols:package-2"}
-                    class="size-[18px] shrink-0"
-                    aria-hidden="true"
-                  />
+                  <Icon name={`material-symbols:${icon}`} class="size-[18px] shrink-0" aria-hidden="true" />
                   {label}
                 </a>
               ))
@@ -216,17 +220,21 @@ const navItems = [
         </div>
       </div>
 
-      <a
-        href={localePath(lang, "hire-me")}
-        class:list={[
-          activePage === "hire-me"
-            ? "text-primary border-b-2 border-primary pb-1"
-            : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-        ]}
-        aria-current={activePage === "hire-me" ? "page" : undefined}
-      >
-        {t.nav.hireMe}
-      </a>
+      {
+        afterItems.map(({ label, page, active }) => (
+          <a
+            href={localePath(lang, page)}
+            class:list={[
+              active
+                ? "text-primary border-b-2 border-primary pb-1"
+                : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+            ]}
+            aria-current={active ? "page" : undefined}
+          >
+            {label}
+          </a>
+        ))
+      }
     </div>
 
     <!-- Theme toggle + Language picker + Auth (desktop) -->
@@ -366,11 +374,12 @@ const navItems = [
     </div>
   </div>
 
-  <!-- Mobile nav -->
+  <!-- Mobile nav. No hover dropdown — touch devices don't have hover. The single
+       "Projects" link goes to /projects, where the user picks a project from the cards. -->
   <div class="md:hidden flex items-center">
-    <div class="flex items-center gap-5 px-4 font-headline tracking-tighter font-bold text-sm text-nowrap">
+    <div class="flex items-center gap-4 px-4 overflow-x-auto font-headline tracking-tighter font-bold text-sm text-nowrap">
       {
-        navItems.map(({ label, page, active }) => (
+        flatItems.map(({ label, page, active }) => (
           <a
             href={localePath(lang, page)}
             class:list={[
@@ -382,70 +391,30 @@ const navItems = [
           </a>
         ))
       }
-      <!-- Projects dropdown (mobile) -->
-      <details class="relative">
-        <summary
-          class:list={[
-            "flex items-center gap-0.5 cursor-pointer list-none border-b-2 pb-1 select-none",
-            projectsActive ? "text-primary border-primary" : "text-on-surface-variant border-transparent",
-          ]}
-          aria-haspopup="true"
-          aria-current={projectsActive ? "page" : undefined}
-        >
-          {t.nav.projects}
-          <Icon name="material-symbols:expand-more" class="size-4 transition-transform" aria-hidden="true" />
-        </summary>
-        <div
-          class="absolute left-1/2 -translate-x-1/2 top-full mt-1 bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[180px] z-50"
-          role="menu"
-        >
-          {
-            projectItems.map(({ label, page }) => (
-              <a
-                href={localePath(lang, page)}
-                class:list={[
-                  "flex items-center gap-2 px-4 py-2 text-xs font-label transition-colors",
-                  activePage === page
-                    ? "text-primary font-semibold bg-primary/5"
-                    : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
-                ]}
-                role="menuitem"
-                aria-current={activePage === page ? "page" : undefined}
-              >
-                <Icon
-                  name={page === "project" ? "material-symbols:rocket-launch" : "material-symbols:package-2"}
-                  class="size-4 shrink-0"
-                  aria-hidden="true"
-                />
-                {label}
-              </a>
-            ))
-          }
-        </div>
-      </details>
+
+      <a
+        href={localePath(lang, "projects")}
+        class:list={[
+          projectsActive ? "text-primary border-b-2 border-primary pb-1" : "text-on-surface-variant border-b-2 border-transparent pb-1",
+        ]}
+        aria-current={projectsActive ? "page" : undefined}
+      >
+        {t.nav.projects}
+      </a>
+
+      {
+        afterItems.map(({ label, page, active }) => (
+          <a
+            href={localePath(lang, page)}
+            class:list={[
+              active ? "text-primary border-b-2 border-primary pb-1" : "text-on-surface-variant border-b-2 border-transparent pb-1",
+            ]}
+            aria-current={active ? "page" : undefined}
+          >
+            {label}
+          </a>
+        ))
+      }
     </div>
   </div>
 </nav>
-
-<style>
-  /* Hide the default disclosure triangle on the mobile Projects dropdown summary. */
-  summary::-webkit-details-marker {
-    display: none;
-  }
-  details[open] > summary > svg,
-  details[open] > summary > [data-icon] {
-    transform: rotate(180deg);
-  }
-</style>
-
-<script>
-  // Close the mobile Projects <details> dropdown when tapping outside.
-  const projectDetails = document.querySelectorAll<HTMLDetailsElement>("nav details");
-  document.addEventListener("click", (event) => {
-    projectDetails.forEach((d) => {
-      if (d.open && !d.contains(event.target as Node)) {
-        d.open = false;
-      }
-    });
-  });
-</script>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -46,29 +46,39 @@ interface Props {
 
 const { activePage, lang, t } = Astro.props;
 
-// "Projects" in the nav is a real link to /projects (a category landing page)
-// AND has a hover-only quick-access dropdown on desktop. That gives us:
-// - click does navigate (to a meaningful index page)
-// - hover gives a one-tap shortcut to a specific project
-// - active state on /projects, /project, and /strong-types is "Projects",
-//   with the page-level breadcrumb telling the reader which specific one
+// One ordered list of nav items, in the order they appear on the bar.
+// Items with `children` are rendered as a hover dropdown on desktop (the parent
+// is still a real link to its own `page`), and as a plain link on mobile —
+// touch devices have no hover, so mobile users go to the index page and pick
+// from the cards there.
+//
+// The parent of a dropdown is "active" when its own page is active OR any
+// child's page is. That keeps the nav highlight on "Projects" while the user
+// is on /projects, /project, or /strong-types — the page-level breadcrumb
+// then tells them which specific project.
+type NavLeaf = {
+  label: string;
+  page: ActivePage;
+  active: boolean;
+};
+type NavMenuChild = NavLeaf & { icon: string };
+type NavItem = NavLeaf & { children?: NavMenuChild[] };
+
 const projectsActive = activePage === "projects" || activePage === "project" || activePage === "strong-types";
 
-// Sibling links shown directly on the bar. The Projects entry is rendered
-// separately (it has a dropdown), so it's not in this array.
-const flatItems = [
-  { label: t.nav.home, page: "home" as const, active: activePage === "home" },
-  { label: t.nav.about, page: "about" as const, active: activePage === "about" },
-];
-
-const afterItems = [{ label: t.nav.hireMe, page: "hire-me" as const, active: activePage === "hire-me" }];
-
-// Items that appear in the desktop hover dropdown for power users who
-// want to skip the /projects index. Mobile users get just the single
-// /projects link — they pick from the cards on that page.
-const projectMenuItems = [
-  { label: t.nav.projectThisSite, page: "project" as const, icon: "rocket-launch", active: activePage === "project" },
-  { label: t.nav.projectStrongTypes, page: "strong-types" as const, icon: "package-2", active: activePage === "strong-types" },
+const navItems: NavItem[] = [
+  { label: t.nav.home, page: "home", active: activePage === "home" },
+  { label: t.nav.about, page: "about", active: activePage === "about" },
+  {
+    label: t.nav.projects,
+    page: "projects",
+    active: projectsActive,
+    children: [
+      { label: t.nav.projectThisSite, page: "project", icon: "rocket-launch", active: activePage === "project" },
+      { label: t.nav.projectStrongTypes, page: "strong-types", icon: "package-2", active: activePage === "strong-types" },
+    ],
+  },
+  { label: t.nav.hireMe, page: "hire-me", active: activePage === "hire-me" },
 ];
 ---
 
@@ -160,80 +170,64 @@ const projectMenuItems = [
 
     <div class="hidden md:flex pt-1 items-center gap-8 font-headline tracking-tighter font-bold text-nowrap">
       {
-        flatItems.map(({ label, page, active }) => (
-          <a
-            href={localePath(lang, page)}
-            class:list={[
-              active
-                ? "text-primary border-b-2 border-primary pb-1"
-                : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-            ]}
-            aria-current={active ? "page" : undefined}
-          >
-            {label}
-          </a>
-        ))
-      }
-
-      <!-- Projects: a real link (clicking goes to /projects) with a hover-only
-           dropdown shortcut on desktop. The chevron is hint-only. -->
-      <div class="relative group">
-        <a
-          href={localePath(lang, "projects")}
-          class:list={[
-            "inline-flex items-center gap-1 pb-1 border-b-2 transition-colors",
-            projectsActive
-              ? "text-primary border-primary"
-              : "text-on-surface-variant hover:text-on-surface border-transparent hover:border-transparent",
-          ]}
-          aria-haspopup="true"
-          aria-current={projectsActive ? "page" : undefined}
-        >
-          {t.nav.projects}
-          <Icon name="material-symbols:expand-more" class="size-4 transition-transform group-hover:rotate-180" aria-hidden="true" />
-        </a>
-        <div
-          class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute left-1/2 -translate-x-1/2 top-full pt-2 z-50"
-          role="menu"
-          aria-label={t.a11y.openProjectsMenu}
-        >
-          <div class="bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[200px]">
-            {
-              projectMenuItems.map(({ label, page, icon, active }) => (
-                <a
-                  href={localePath(lang, page)}
-                  class:list={[
-                    "flex items-center gap-3 px-4 py-2.5 text-sm font-label transition-colors",
-                    active
-                      ? "text-primary font-semibold bg-primary/5"
-                      : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
-                  ]}
-                  role="menuitem"
-                  aria-current={active ? "page" : undefined}
-                >
-                  <Icon name={`material-symbols:${icon}`} class="size-[18px] shrink-0" aria-hidden="true" />
-                  {label}
-                </a>
-              ))
-            }
-          </div>
-        </div>
-      </div>
-
-      {
-        afterItems.map(({ label, page, active }) => (
-          <a
-            href={localePath(lang, page)}
-            class:list={[
-              active
-                ? "text-primary border-b-2 border-primary pb-1"
-                : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
-            ]}
-            aria-current={active ? "page" : undefined}
-          >
-            {label}
-          </a>
-        ))
+        navItems.map((item) =>
+          item.children ? (
+            // Dropdown parent: a real link to its own page with a hover-only
+            // menu of children. The chevron is a hint, not a control.
+            <div class="relative group">
+              <a
+                href={localePath(lang, item.page)}
+                class:list={[
+                  "inline-flex items-center gap-1 pb-1 border-b-2 transition-colors",
+                  item.active
+                    ? "text-primary border-primary"
+                    : "text-on-surface-variant hover:text-on-surface border-transparent hover:border-transparent",
+                ]}
+                aria-haspopup="true"
+                aria-current={item.active ? "page" : undefined}
+              >
+                {item.label}
+                <Icon name="material-symbols:expand-more" class="size-4 transition-transform group-hover:rotate-180" aria-hidden="true" />
+              </a>
+              <div
+                class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute left-1/2 -translate-x-1/2 top-full pt-2 z-50"
+                role="menu"
+                aria-label={t.a11y.openProjectsMenu}
+              >
+                <div class="bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-lg py-1 min-w-[200px]">
+                  {item.children.map((child) => (
+                    <a
+                      href={localePath(lang, child.page)}
+                      class:list={[
+                        "flex items-center gap-3 px-4 py-2.5 text-sm font-label transition-colors",
+                        child.active
+                          ? "text-primary font-semibold bg-primary/5"
+                          : "text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high",
+                      ]}
+                      role="menuitem"
+                      aria-current={child.active ? "page" : undefined}
+                    >
+                      <Icon name={`material-symbols:${child.icon}`} class="size-[18px] shrink-0" aria-hidden="true" />
+                      {child.label}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <a
+              href={localePath(lang, item.page)}
+              class:list={[
+                item.active
+                  ? "text-primary border-b-2 border-primary pb-1"
+                  : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
+              ]}
+              aria-current={item.active ? "page" : undefined}
+            >
+              {item.label}
+            </a>
+          ),
+        )
       }
     </div>
 
@@ -374,36 +368,13 @@ const projectMenuItems = [
     </div>
   </div>
 
-  <!-- Mobile nav. No hover dropdown — touch devices don't have hover. The single
-       "Projects" link goes to /projects, where the user picks a project from the cards. -->
+  <!-- Mobile nav. No hover dropdown — touch devices don't have hover, so dropdown
+       parents collapse to a plain link to their own index page (e.g. /projects),
+       and the user picks from the cards there. Children are ignored at this width. -->
   <div class="md:hidden flex items-center">
     <div class="flex items-center gap-4 px-4 overflow-x-auto font-headline tracking-tighter font-bold text-sm text-nowrap">
       {
-        flatItems.map(({ label, page, active }) => (
-          <a
-            href={localePath(lang, page)}
-            class:list={[
-              active ? "text-primary border-b-2 border-primary pb-1" : "text-on-surface-variant border-b-2 border-transparent pb-1",
-            ]}
-            aria-current={active ? "page" : undefined}
-          >
-            {label}
-          </a>
-        ))
-      }
-
-      <a
-        href={localePath(lang, "projects")}
-        class:list={[
-          projectsActive ? "text-primary border-b-2 border-primary pb-1" : "text-on-surface-variant border-b-2 border-transparent pb-1",
-        ]}
-        aria-current={projectsActive ? "page" : undefined}
-      >
-        {t.nav.projects}
-      </a>
-
-      {
-        afterItems.map(({ label, page, active }) => (
+        navItems.map(({ label, page, active }) => (
           <a
             href={localePath(lang, page)}
             class:list={[

--- a/frontend/src/components/OnThisPage.astro
+++ b/frontend/src/components/OnThisPage.astro
@@ -7,16 +7,17 @@ interface TocItem {
 interface Props {
   title: string;
   items: TocItem[];
-  desktop?: boolean;
 }
 
-const { title, items, desktop = true } = Astro.props;
+const { title, items } = Astro.props;
 ---
 
-<!-- Mobile TOC — Sticky Bottom Tab Bar -->
+<!-- Sticky bottom-bar TOC, shown at all viewport widths.
+     One UX, one mental model — desktop gets the same scrollable pill row as mobile,
+     freeing the page's horizontal space for content. -->
 <nav
   id="toc-bar"
-  class="xl:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
+  class="fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
   aria-label={title}
 >
   <div class="flex overflow-x-auto gap-1 px-3 py-2 scrollbar-hide items-center">
@@ -36,33 +37,7 @@ const { title, items, desktop = true } = Astro.props;
   </div>
 </nav>
 
-{
-  desktop && (
-    <aside class="hidden xl:block">
-      <nav class="sticky top-24 space-y-3" aria-label={title}>
-        <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-4">{title}</h4>
-        {items.map((item) => (
-          <a
-            href={`#${item.id}`}
-            class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-            data-toc-target={item.id}
-          >
-            {item.label}
-          </a>
-        ))}
-      </nav>
-    </aside>
-  )
-}
-
 <style>
-  .toc-link-active {
-    color: var(--color-primary);
-    font-weight: 600;
-    border-left: 2px solid var(--color-primary);
-    padding-left: 0.5rem;
-    margin-left: -0.625rem;
-  }
   .toc-pill-active {
     background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
     color: var(--color-primary);
@@ -76,17 +51,17 @@ const { title, items, desktop = true } = Astro.props;
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
-  /* Bottom padding so content isn't hidden behind the sticky bar */
-  @media (max-width: 1279px) {
-    body {
-      padding-bottom: 3.5rem;
-    }
+  /* Bottom padding so content isn't hidden behind the sticky bar — applied at all widths
+     since the bar is now always visible. Tuned to roughly match the bar's own height
+     (py-2 outer + py-1.5 pill + ~16px text line + 1px border ≈ 45px) so the footer sits
+     flush against the bar without a visible gap. */
+  body {
+    padding-bottom: 3rem;
   }
 </style>
 
 <script>
   const sections = document.querySelectorAll("section[id]");
-  const tocLinks = document.querySelectorAll(".toc-link");
   const tocPills = document.querySelectorAll(".toc-pill");
 
   const observer = new IntersectionObserver(
@@ -95,12 +70,6 @@ const { title, items, desktop = true } = Astro.props;
         if (entry.isIntersecting) {
           const id = entry.target.id;
 
-          // Desktop rail
-          tocLinks.forEach((link) => link.classList.remove("toc-link-active"));
-          const activeDesktop = document.querySelector(`.toc-link[data-toc-target="${id}"]`);
-          if (activeDesktop) activeDesktop.classList.add("toc-link-active");
-
-          // Mobile pill bar
           tocPills.forEach((l) => l.classList.remove("toc-pill-active"));
           const activePill = document.querySelector(`.toc-pill[data-toc-target="${id}"]`);
           if (activePill) {

--- a/frontend/src/components/ProjectCard.astro
+++ b/frontend/src/components/ProjectCard.astro
@@ -1,0 +1,54 @@
+---
+import { Icon } from "astro-icon/components";
+
+// Shared card used on the home page (compact, single-paragraph blurb) and on
+// the /projects index (richer, multi-paragraph blurb). Description accepts both
+// shapes; a single string is normalized to a one-element array so the markup
+// stays identical in both call sites.
+//
+// Accent picks the per-project color (e.g. tertiary for "This Site", primary
+// for "StrongTypes") which threads through icon color, hover border, hover
+// title color, and CTA label color.
+interface Props {
+  href: string;
+  // material-symbols name without the prefix (e.g. "rocket-launch")
+  icon: string;
+  accent: "primary" | "tertiary";
+  title: string;
+  description: string | string[];
+  cta: string;
+  // Extra classes for layout overrides (e.g. responsive grid spans on the home
+  // page where the StrongTypes card needs `md:col-span-2 lg:col-span-1`).
+  class?: string;
+}
+
+const { href, icon, accent, title, description, cta, class: extraClass } = Astro.props;
+const paragraphs = Array.isArray(description) ? description : [description];
+
+const accentText = accent === "tertiary" ? "text-tertiary" : "text-primary";
+const accentBorder = accent === "tertiary" ? "hover:border-tertiary/30" : "hover:border-primary/30";
+const accentTitleHover = accent === "tertiary" ? "group-hover:text-tertiary" : "group-hover:text-primary";
+---
+
+<a
+  href={href}
+  class:list={[
+    "group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col",
+    accentBorder,
+    extraClass,
+  ]}
+>
+  <div class="flex items-center gap-3 mb-4">
+    <Icon name={`material-symbols:${icon}`} class:list={["size-6", accentText]} aria-hidden="true" />
+    <h2 class:list={["font-headline text-2xl font-bold transition-colors", accentTitleHover]}>
+      {title}
+    </h2>
+  </div>
+  <div class="text-on-surface-variant leading-relaxed mb-6 flex-1 space-y-3">
+    {paragraphs.map((paragraph) => <p>{paragraph}</p>)}
+  </div>
+  <span class:list={["font-label text-sm uppercase tracking-widest flex items-center gap-1", accentText]}>
+    {cta}
+    <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+  </span>
+</a>

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -30,7 +30,7 @@
         "icon": "mic-external-on",
         "color": "primary",
         "title": "Zpívám",
-        "description": "Když je k tomu příležitost, rád si zazpívám."
+        "description": "Karaoke? Jdu do toho!"
       },
       {
         "icon": "casino",
@@ -42,7 +42,7 @@
         "icon": "sports-soccer",
         "color": "primary",
         "title": "Bývalý fotbalista",
-        "description": "Za mlada jsem fotbal hrával závodně."
+        "description": "Dřív jsem hodně sportoval. Teď to musím dávkovat kvůli zraněním kotníků."
       },
       {
         "icon": "stadia-controller",
@@ -54,7 +54,7 @@
         "icon": "two-wheeler",
         "color": "primary",
         "title": "Motorky",
-        "description": "Pár let jsem závodil na malých 190ccm motorkách."
+        "description": "Nějaký čas jsem se věnoval amatérským motocyklovým závodům. (190 ccm)"
       },
       {
         "icon": "family-restroom",

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -19,7 +19,50 @@
     "overview": "Přehled",
     "manifesto": "Manifest",
     "skills": "Dovednosti",
+    "personal": "O mně",
     "career": "Kariéra"
+  },
+  "personal": {
+    "title": "O mně",
+    "subtitle": "Pár věcí, kterým se věnuju, když nejsem u klávesnice.",
+    "items": [
+      {
+        "icon": "mic-external-on",
+        "color": "primary",
+        "title": "Zpívám",
+        "description": "Když je k tomu příležitost, rád si zazpívám."
+      },
+      {
+        "icon": "casino",
+        "color": "tertiary",
+        "title": "Hry všeho druhu",
+        "description": "Deskové, počítačové, sportovní — když je to hra, jsem v ní."
+      },
+      {
+        "icon": "sports-soccer",
+        "color": "primary",
+        "title": "Bývalý fotbalista",
+        "description": "Za mlada jsem fotbal hrával závodně."
+      },
+      {
+        "icon": "stadia-controller",
+        "color": "tertiary",
+        "title": "Esportová minulost",
+        "description": "Hrál jsem League of Legends a Rocket League na vysoké úrovni."
+      },
+      {
+        "icon": "two-wheeler",
+        "color": "primary",
+        "title": "Motorky",
+        "description": "Pár let jsem závodil na malých 190ccm motorkách."
+      },
+      {
+        "icon": "family-restroom",
+        "color": "tertiary",
+        "title": "Otec dvou dětí",
+        "description": "Sem směřuje většina mého času mimo práci."
+      }
+    ]
   },
   "manifesto": {
     "title": "Můj manifest",

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -2,7 +2,9 @@
   "nav": {
     "home": "Domů",
     "about": "O mně",
-    "project": "Projekt",
+    "projects": "Projekty",
+    "projectThisSite": "Tato stránka",
+    "projectStrongTypes": "StrongTypes",
     "hireMe": "Najměte mě",
     "mySubmissions": "Mé nabídky",
     "admin": "Administrace",
@@ -39,7 +41,8 @@
     "skipToContent": "Přeskočit na obsah",
     "mainNavigation": "Hlavní navigace",
     "toggleDarkMode": "Přepnout tmavý režim",
-    "changeLanguage": "Změnit jazyk"
+    "changeLanguage": "Změnit jazyk",
+    "openProjectsMenu": "Otevřít nabídku projektů"
   },
   "notFound": {
     "title": "Stránka nenalezena",

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -42,7 +42,8 @@
     "mainNavigation": "Hlavní navigace",
     "toggleDarkMode": "Přepnout tmavý režim",
     "changeLanguage": "Změnit jazyk",
-    "openProjectsMenu": "Otevřít nabídku projektů"
+    "openProjectsMenu": "Rychlé odkazy na konkrétní projekty",
+    "breadcrumb": "Drobečková navigace"
   },
   "notFound": {
     "title": "Stránka nenalezena",

--- a/frontend/src/i18n/cs/home.json
+++ b/frontend/src/i18n/cs/home.json
@@ -14,19 +14,21 @@
       "description": "Co mě jako inženýra pohání.",
       "cta": "Číst dále"
     },
-    "project": {
-      "title": "Projekt",
-      "description": "Od jednoduché stránky až po pokročilé funkce. Sledujte plán do budoucna.",
+    "thisSite": {
+      "title": "Tato stránka",
+      "description": "Stavěná veřejně — každá verze, rozhodnutí i nasazení jsou zdokumentovány.",
       "cta": "Zobrazit plán"
+    },
+    "strongTypes": {
+      "title": "StrongTypes",
+      "description": "C# knihovna pro bezpečnější a výstižnější kód — neprázdné řetězce, validované numerické typy, Maybe a Result.",
+      "cta": "Prozkoumat knihovnu"
     }
   },
   "whatsHere": {
     "title": "Co je tato stránka?",
     "siteName": "kalandra.tech",
-    "paragraph1": " je moje osobní webová stránka, a zároveň i experiment. Stavím ji transparentě — každá verze, každé architektonické rozhodnutí, každý deployment je veřejný.",
-    "paragraph2prefix": "Další projekty přibudou časem. Zatím je tu jediný projekt — ",
-    "paragraph2link": "meta-projekt stavby tohoto webu",
-    "paragraph2suffix": ". Sledujte novinky."
+    "paragraph1": " je moje osobní webová stránka, a zároveň i experiment. Stavím ji transparentě — každá verze, každé architektonické rozhodnutí, každý deployment je veřejný."
   },
   "qrCode": {
     "label": "Klikni a sdílej",

--- a/frontend/src/i18n/cs/home.json
+++ b/frontend/src/i18n/cs/home.json
@@ -11,7 +11,10 @@
   "cards": {
     "about": {
       "title": "O mně",
-      "description": "Co mě jako inženýra pohání.",
+      "description": [
+        "Co mě jako inženýra žene vpřed — a pár věcí o mně mimo klávesnici.",
+        "Technologie, se kterými pracuji, kariérní cesta, která mě sem dovedla, a pohled na život mimo IDE."
+      ],
       "cta": "Číst dále"
     }
   },

--- a/frontend/src/i18n/cs/home.json
+++ b/frontend/src/i18n/cs/home.json
@@ -13,16 +13,6 @@
       "title": "O mně",
       "description": "Co mě jako inženýra pohání.",
       "cta": "Číst dále"
-    },
-    "thisSite": {
-      "title": "Tato stránka",
-      "description": "Stavěná veřejně — každá verze, rozhodnutí i nasazení jsou zdokumentovány.",
-      "cta": "Zobrazit plán"
-    },
-    "strongTypes": {
-      "title": "StrongTypes",
-      "description": "C# knihovna pro bezpečnější a výstižnější kód — neprázdné řetězce, validované numerické typy, Maybe a Result.",
-      "cta": "Prozkoumat knihovnu"
     }
   },
   "whatsHere": {

--- a/frontend/src/i18n/cs/projects.json
+++ b/frontend/src/i18n/cs/projects.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "title": "Projekty | kalandra.tech",
+    "description": "Softwarové projekty Pavla Kalandry — samotná kalandra.tech, stavěná veřejně, a StrongTypes, C# NuGet balíček pro bezpečnější typy."
+  },
+  "hero": {
+    "title": "Projekty",
+    "subtitle": "Co stavím — veřejně. Vyberte si jeden a ponořte se."
+  },
+  "items": {
+    "thisSite": {
+      "title": "Tato stránka",
+      "description": [
+        "Samotná kalandra.tech — stavěná veřejně, s každým architektonickým rozhodnutím, nasazením a získanou lekcí zapsanou v okamžiku, kdy se to děje. Stránka sama je artefakt."
+      ],
+      "cta": "Zobrazit plán"
+    },
+    "strongTypes": {
+      "title": "StrongTypes",
+      "description": [
+        "C# NuGet balíček, který přesouvá invarianty do typového systému: NonEmptyString, NonEmptyEnumerable, validované numerické typy, Maybe a Result.",
+        "Umožňuje bezkódové validace vynucené překladačem."
+      ],
+      "cta": "Prozkoumat knihovnu"
+    }
+  }
+}

--- a/frontend/src/i18n/cs/projects.json
+++ b/frontend/src/i18n/cs/projects.json
@@ -9,9 +9,10 @@
   },
   "items": {
     "thisSite": {
-      "title": "Tato stránka",
+      "title": "Jak jsem stavěl tuto stránku",
       "description": [
-        "Samotná kalandra.tech — stavěná veřejně, s každým architektonickým rozhodnutím, nasazením a získanou lekcí zapsanou v okamžiku, kdy se to děje. Stránka sama je artefakt."
+        "Samotná kalandra.tech — stavěná veřejně, s každým architektonickým rozhodnutím, nasazením a získanou lekcí zapsanou v okamžiku, kdy se to děje. Stránka sama je artefakt.",
+        "Pokrývá webovou stránku a její hosting, API a jeho hosting, databázi s event sourcingem, CI/CD pipeline s E2E testy. A další."
       ],
       "cta": "Zobrazit plán"
     },

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -22,13 +22,47 @@
     "items": [
       { "label": "Licence", "value": "MIT" },
       { "label": "Cíl", "value": ".NET 10" },
-      { "label": "Verze", "value": "1.0.1" },
       { "label": "Závislosti", "value": "Žádné" }
+    ]
+  },
+  "badges": {
+    "ariaLabel": "Stavové odznaky projektu",
+    "items": [
+      {
+        "src": "https://img.shields.io/github/v/release/KaliCZ/StrongTypes?label=verze&color=4858ab",
+        "alt": "Nejnovější verze na GitHubu",
+        "href": "https://github.com/KaliCZ/StrongTypes/releases"
+      },
+      {
+        "src": "https://img.shields.io/nuget/v/Kalicz.StrongTypes?label=nuget",
+        "alt": "Nejnovější NuGet verze balíčku Kalicz.StrongTypes",
+        "href": "https://www.nuget.org/packages/Kalicz.StrongTypes"
+      },
+      {
+        "src": "https://img.shields.io/nuget/dt/Kalicz.StrongTypes?label=stahovani",
+        "alt": "Celkový počet stažení balíčku Kalicz.StrongTypes",
+        "href": "https://www.nuget.org/packages/Kalicz.StrongTypes"
+      },
+      {
+        "src": "https://img.shields.io/github/actions/workflow/status/KaliCZ/StrongTypes/build.yml?branch=main&label=build",
+        "alt": "Stav buildu na GitHub Actions",
+        "href": "https://github.com/KaliCZ/StrongTypes/actions/workflows/build.yml"
+      },
+      {
+        "src": "https://img.shields.io/github/license/KaliCZ/StrongTypes",
+        "alt": "Licence projektu",
+        "href": "https://github.com/KaliCZ/StrongTypes/blob/main/license.txt"
+      }
     ]
   },
   "why": {
     "title": "Proč se obtěžovat se silnými typy?",
     "subtitle": "Většina C# kódu se brání neplatnému vstupu tím, že ho znovu validuje všude. StrongTypes to obrací: validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
+    "diagram": {
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
+      "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek",
+      "caption": "Validace se přesouvá na hranici. Vnitřní kód přestane stále dokola kontrolovat tytéž invarianty."
+    },
     "points": [
       {
         "icon": "shield-lock",
@@ -49,6 +83,24 @@
         "icon": "package-2",
         "title": "Malé a zaměřené",
         "description": "Žádný těžký framework, žádné runtime kouzlení s reflexí. Přidá se vedle existujícího kódu — typy se kombinují s tím, co už máte."
+      }
+    ]
+  },
+  "anatomy": {
+    "title": "Anatomie",
+    "subtitle": "Jak do sebe balíčky zapadají a jaký kousek variance dělá NonEmptyEnumerable kompozičním.",
+    "items": [
+      {
+        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+        "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck",
+        "title": "Rozložení balíčků",
+        "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete."
+      },
+      {
+        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/covariance.svg",
+        "alt": "Diagram zobrazující kovariantní upcast z INonEmptyEnumerable<Cat> na INonEmptyEnumerable<Animal>",
+        "title": "Kovariance",
+        "description": "INonEmptyEnumerable<out T> je kovariantní, takže neprázdná sekvence Cats je zároveň neprázdná sekvence Animals — bez kopie, bez LINQ."
       }
     ]
   },
@@ -105,7 +157,11 @@
       {
         "title": "Vytvoření NonEmptyString",
         "description": "Tři varianty: vyhodit výjimku, zkusit, nebo plynulé rozšíření. Vyberte si tu, která se hodí pro dané volání.",
-        "code": "// Vyhodí výjimku, pokud je vstup neplatný\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Vrátí null, pokud je vstup neplatný\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Forma rozšíření\nNonEmptyString? fluent = userInput.AsNonEmpty();"
+        "code": "// Vyhodí výjimku, pokud je vstup neplatný\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Vrátí null, pokud je vstup neplatný\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Forma rozšíření\nNonEmptyString? fluent = userInput.AsNonEmpty();",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
+          "alt": "Diagram porovnávající TryCreate (vrátí null při neplatném vstupu) a Create (vyhodí výjimku při neplatném vstupu)"
+        }
       },
       {
         "title": "Validace na hranici API",
@@ -115,17 +171,29 @@
       {
         "title": "Skládání s Maybe<T>",
         "description": "Řetězení volitelných operací bez vnořených null kontrol.",
-        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());"
+        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "alt": "Diagram pipeline ukazující, jak Some a None hodnoty procházejí operacemi Map a FlatMap nad Maybe<T>"
+        }
       },
       {
         "title": "Explicitní chyby s Result<T, TError>",
         "description": "Pattern matching na Success nebo Error — žádné výjimky, žádné out parametry.",
-        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");"
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
+          "alt": "Diagram pipeline ukazující, jak hodnota Result<T, TError> prochází fázemi Map, MapError a FlatMap"
+        }
       },
       {
         "title": "Tři stavy v PATCH s Maybe<T>",
         "description": "Rozlišení \"neměnit\", \"nastavit na null\" a \"nastavit na hodnotu\" — letitý problém v REST API.",
-        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → pole neměnit\n// Some(null)   → vyprázdnit\n// Some(\"abc\")  → nastavit\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;"
+        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → pole neměnit\n// Some(null)   → vyprázdnit\n// Some(\"abc\")  → nastavit\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
+          "alt": "Diagram tří stavů v PATCH: null (neměnit), Some(null) (vyprázdnit), Some(value) (nastavit)"
+        }
       }
     ]
   },

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -1,14 +1,13 @@
 {
   "meta": {
-    "title": "StrongTypes | kalandra.tech — Bezpečnější C# typy",
-    "description": "StrongTypes je malá C# knihovna pro bezpečnější a výstižnější kód: NonEmptyString, validované numerické typy, NonEmptyEnumerable, Maybe<T> a Result<T, TError>."
+    "title": "Kalicz.StrongTypes | kalandra.tech — Bezpečnější C# typy",
+    "description": "Kalicz.StrongTypes je C# NuGet balíček pro bezpečnější a výstižnější kód: NonEmptyString, validované numerické typy, NonEmptyEnumerable, Maybe<T> a Result<T, TError>."
   },
   "hero": {
-    "tagline": "C# knihovna · NuGet",
     "titlePrefix": "Pár malých typů, které dělají C# ",
     "titleHighlight": "bezpečnějším",
     "titleSuffix": ".",
-    "description": "StrongTypes přidává úzce zaměřené, validované typy, které přesouvají invarianty do typového systému — \"řetězec, který nikdy není prázdný\" nebo \"číslo, které je vždy kladné\". Validace se odehrává na hranici, takže neplatná data se k vašim handlerům vůbec nedostanou.",
+    "description": "Kalicz.StrongTypes je C# NuGet balíček, který přidává bezkódové validace vynucené překladačem. Typy jako NonEmptyString nebo Positive<int> přesouvají invarianty do typového systému a validace se odehrává na hranici — takže neplatná data se k vašim handlerům vůbec nedostanou.",
     "primaryCta": "Zobrazit na GitHubu",
     "secondaryCta": "Zobrazit na NuGetu",
     "install": "dotnet add package Kalicz.StrongTypes",
@@ -134,30 +133,21 @@
       {
         "title": "Validace na hranici API",
         "description": "JSON konvertor odmítne neplatný vstup při deserializaci. Váš endpoint nikdy neuvidí špatnou hodnotu.",
-        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// V ASP.NET Core: prázdné Name nebo nulové/záporné Age\n// selže při model bindingu ještě před handlerem.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n[HttpPost]\npublic async Task<IResult> Create(CreateUserRequest req)\n{\n    // Žádná další validace tu není potřeba:\n    // ASP pipeline odmítne neplatný vstup s 400.\n    _users.Add(req.Name, req.Age);\n    await _users.SaveChangesAsync();\n    return Results.NoContent();\n}"
       },
       {
         "title": "Explicitní vytváření hodnot",
         "description": "Každý typ má Create (vyhodí výjimku při neplatném vstupu) a TryCreate (vrátí null). Stringové typy mají i plynulou formu rozšíření.",
-        "code": "// Stringy — tři varianty volání\nNonEmptyString name = NonEmptyString.Create(input);    // throws\nNonEmptyString? maybe = NonEmptyString.TryCreate(input); // null on fail\nNonEmptyString? fluent = input.AsNonEmpty();             // extension\n\n// Čísla — obaly nad libovolným INumber<T> vynucující znaménko\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = NonNegative<decimal>.TryCreate(amount);\n\n// Sekvence — alespoň jeden prvek, Head a Tail jsou vždy bezpečné\nNonEmptyEnumerable<string> tags =\n    NonEmptyEnumerable.Create(\"primary\", \"secondary\", \"tertiary\");\nstring first = tags.Head;",
+        "code": "// Stringy — tři varianty volání\n// throws při neplatném vstupu\nNonEmptyString name = NonEmptyString.Create(input);\n// null při neplatném\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent rozšíření\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Čísla — vynucené znaménko nad INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sekvence — alespoň jeden prvek, Head bezpečné\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
           "alt": "Diagram porovnávající TryCreate (vrátí null při neplatném vstupu) a Create (vyhodí výjimku při neplatném vstupu)"
         }
       },
       {
-        "title": "Skládání s Maybe<T>",
-        "description": "Řetězení volitelných operací bez vnořených null kontrol.",
-        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());",
-        "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
-          "alt": "Diagram pipeline ukazující, jak Some a None hodnoty procházejí operacemi Map a FlatMap nad Maybe<T>"
-        }
-      },
-      {
         "title": "Explicitní chyby s Result<T, TError>",
         "description": "Pattern matching na Success nebo Error — žádné výjimky, žádné out parametry.",
-        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");",
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
           "alt": "Diagram pipeline ukazující, jak hodnota Result<T, TError> prochází fázemi Map, MapError a FlatMap"
@@ -171,8 +161,29 @@
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
           "alt": "Diagram tří stavů v PATCH: null (neměnit), Some(null) (vyprázdnit), Some(value) (nastavit)"
         }
+      },
+      {
+        "title": "Skládání s Maybe<T>",
+        "description": "Řetězení volitelných operací bez vnořených null kontrol. Implicitní operátory zařídí zabalení — vrátíte T nebo Maybe.None a funguje to.",
+        "code": "// Producent: implicitní převod z T nebo Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, automaticky zabalí v Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, bez dvojitého zabalení\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "alt": "Diagram pipeline ukazující, jak Some a None hodnoty procházejí operacemi Map a FlatMap nad Maybe<T>"
+        }
       }
     ]
+  },
+  "lightbox": {
+    "dialogLabel": "Zvětšený diagram",
+    "closeLabel": "Zavřít"
+  },
+  "toc": {
+    "title": "Na této stránce",
+    "overview": "Přehled",
+    "why": "Proč",
+    "features": "Co je uvnitř",
+    "examples": "Jak to vypadá",
+    "getStarted": "Začínáme"
   },
   "links": {
     "title": "Začínáme",

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -17,22 +17,9 @@
     "copied": "Zkopírováno do schránky",
     "copyFailed": "Kopírování selhalo. Zkopírujte prosím ručně."
   },
-  "facts": {
-    "title": "V kostce",
-    "items": [
-      { "label": "Licence", "value": "MIT" },
-      { "label": "Cíl", "value": ".NET 10" },
-      { "label": "Závislosti", "value": "Žádné" }
-    ]
-  },
   "badges": {
     "ariaLabel": "Stavové odznaky projektu",
     "items": [
-      {
-        "src": "https://img.shields.io/github/v/release/KaliCZ/StrongTypes?label=verze&color=4858ab",
-        "alt": "Nejnovější verze na GitHubu",
-        "href": "https://github.com/KaliCZ/StrongTypes/releases"
-      },
       {
         "src": "https://img.shields.io/nuget/v/Kalicz.StrongTypes?label=nuget",
         "alt": "Nejnovější NuGet verze balíčku Kalicz.StrongTypes",
@@ -86,23 +73,13 @@
       }
     ]
   },
-  "anatomy": {
-    "title": "Anatomie",
-    "subtitle": "Jak do sebe balíčky zapadají a jaký kousek variance dělá NonEmptyEnumerable kompozičním.",
-    "items": [
-      {
-        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
-        "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck",
-        "title": "Rozložení balíčků",
-        "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete."
-      },
-      {
-        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/covariance.svg",
-        "alt": "Diagram zobrazující kovariantní upcast z INonEmptyEnumerable<Cat> na INonEmptyEnumerable<Animal>",
-        "title": "Kovariance",
-        "description": "INonEmptyEnumerable<out T> je kovariantní, takže neprázdná sekvence Cats je zároveň neprázdná sekvence Animals — bez kopie, bez LINQ."
-      }
-    ]
+  "packageLayout": {
+    "title": "Rozložení balíčků",
+    "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete.",
+    "diagram": {
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+      "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck"
+    }
   },
   "features": {
     "title": "Co je uvnitř",
@@ -155,18 +132,18 @@
     "subtitle": "Pár ukázek pro představu. Plnou dokumentaci a další příklady najdete na GitHubu.",
     "items": [
       {
-        "title": "Vytvoření NonEmptyString",
-        "description": "Tři varianty: vyhodit výjimku, zkusit, nebo plynulé rozšíření. Vyberte si tu, která se hodí pro dané volání.",
-        "code": "// Vyhodí výjimku, pokud je vstup neplatný\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Vrátí null, pokud je vstup neplatný\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Forma rozšíření\nNonEmptyString? fluent = userInput.AsNonEmpty();",
+        "title": "Validace na hranici API",
+        "description": "JSON konvertor odmítne neplatný vstup při deserializaci. Váš endpoint nikdy neuvidí špatnou hodnotu.",
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// V ASP.NET Core: prázdné Name nebo nulové/záporné Age\n// selže při model bindingu ještě před handlerem.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+      },
+      {
+        "title": "Explicitní vytváření hodnot",
+        "description": "Každý typ má Create (vyhodí výjimku při neplatném vstupu) a TryCreate (vrátí null). Stringové typy mají i plynulou formu rozšíření.",
+        "code": "// Stringy — tři varianty volání\nNonEmptyString name = NonEmptyString.Create(input);    // throws\nNonEmptyString? maybe = NonEmptyString.TryCreate(input); // null on fail\nNonEmptyString? fluent = input.AsNonEmpty();             // extension\n\n// Čísla — obaly nad libovolným INumber<T> vynucující znaménko\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = NonNegative<decimal>.TryCreate(amount);\n\n// Sekvence — alespoň jeden prvek, Head a Tail jsou vždy bezpečné\nNonEmptyEnumerable<string> tags =\n    NonEmptyEnumerable.Create(\"primary\", \"secondary\", \"tertiary\");\nstring first = tags.Head;",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
           "alt": "Diagram porovnávající TryCreate (vrátí null při neplatném vstupu) a Create (vyhodí výjimku při neplatném vstupu)"
         }
-      },
-      {
-        "title": "Validace na hranici API",
-        "description": "JSON konvertor odmítne neplatný vstup při deserializaci. Váš endpoint nikdy neuvidí špatnou hodnotu.",
-        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// V ASP.NET Core: prázdné Name nebo nulové/záporné Age\n// selže při model bindingu ještě před handlerem.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
       },
       {
         "title": "Skládání s Maybe<T>",

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -1,0 +1,166 @@
+{
+  "meta": {
+    "title": "StrongTypes | kalandra.tech — Bezpečnější C# typy",
+    "description": "StrongTypes je malá C# knihovna pro bezpečnější a výstižnější kód: NonEmptyString, validované numerické typy, NonEmptyEnumerable, Maybe<T> a Result<T, TError>."
+  },
+  "hero": {
+    "tagline": "C# knihovna · NuGet",
+    "titlePrefix": "Pár malých typů, které dělají C# ",
+    "titleHighlight": "bezpečnějším",
+    "titleSuffix": ".",
+    "description": "StrongTypes přidává úzce zaměřené, validované typy, které přesouvají invarianty do typového systému — \"řetězec, který nikdy není prázdný\" nebo \"číslo, které je vždy kladné\". Validace se odehrává na hranici, takže neplatná data se k vašim handlerům vůbec nedostanou.",
+    "primaryCta": "Zobrazit na GitHubu",
+    "secondaryCta": "Zobrazit na NuGetu",
+    "install": "dotnet add package Kalicz.StrongTypes",
+    "installLabel": "Instalace",
+    "copyAriaLabel": "Zkopírovat instalační příkaz",
+    "copied": "Zkopírováno do schránky",
+    "copyFailed": "Kopírování selhalo. Zkopírujte prosím ručně."
+  },
+  "facts": {
+    "title": "V kostce",
+    "items": [
+      { "label": "Licence", "value": "MIT" },
+      { "label": "Cíl", "value": ".NET 10" },
+      { "label": "Verze", "value": "1.0.1" },
+      { "label": "Závislosti", "value": "Žádné" }
+    ]
+  },
+  "why": {
+    "title": "Proč se obtěžovat se silnými typy?",
+    "subtitle": "Většina C# kódu se brání neplatnému vstupu tím, že ho znovu validuje všude. StrongTypes to obrací: validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
+    "points": [
+      {
+        "icon": "shield-lock",
+        "title": "Invarianty v typu",
+        "description": "Pokud metoda přijímá NonEmptyString, prázdný řetězec se k ní nedostane. Práci odvede překladač — ne strážní podmínka v runtime."
+      },
+      {
+        "icon": "bolt",
+        "title": "Validace na hranici",
+        "description": "Vestavěné konvertory pro System.Text.Json odmítnou neplatná data při deserializaci, ještě než se zavolá handler endpointu."
+      },
+      {
+        "icon": "code-blocks",
+        "title": "Výstižný záměr",
+        "description": "Signatura jako Result<Order, OrderError> Place(Positive<int> qty) čtenáři přesně říká, co je dovoleno a co může selhat."
+      },
+      {
+        "icon": "package-2",
+        "title": "Malé a zaměřené",
+        "description": "Žádný těžký framework, žádné runtime kouzlení s reflexí. Přidá se vedle existujícího kódu — typy se kombinují s tím, co už máte."
+      }
+    ]
+  },
+  "features": {
+    "title": "Co je uvnitř",
+    "groups": [
+      {
+        "color": "primary",
+        "icon": "label",
+        "heading": "Validované obaly",
+        "items": [
+          { "name": "NonEmptyString", "description": "Zaručeně nenulový, neprázdný řetězec, který není ani jen samé bílé znaky." },
+          {
+            "name": "Positive<T>, NonNegative<T>, Negative<T>, NonPositive<T>",
+            "description": "Obaly vynucující znaménko nad libovolným INumber<T>."
+          },
+          {
+            "name": "NonEmptyEnumerable<T>",
+            "description": "Read-only sekvence s alespoň jedním prvkem — Head a Tail jsou vždy bezpečně přístupné."
+          }
+        ]
+      },
+      {
+        "color": "tertiary",
+        "icon": "alt-route",
+        "heading": "Algebraické typy",
+        "items": [
+          {
+            "name": "Maybe<T>",
+            "description": "Volitelné hodnoty s Map a FlatMap. Hodí se pro HTTP PATCH (neměnit / vyprázdnit / nastavit)."
+          },
+          { "name": "Result<T, TError>", "description": "Explicitní zacházení s chybami bez výjimek. Včetně podpory async." }
+        ]
+      },
+      {
+        "color": "primary",
+        "icon": "settings",
+        "heading": "Vestavěné integrace",
+        "items": [
+          { "name": "System.Text.Json", "description": "Automatické konvertory — bez nutnosti registrace." },
+          { "name": "EF Core value convertery", "description": "Skrze doplňkový balíček Kalicz.StrongTypes.EfCore." },
+          {
+            "name": "Generátory pro FsCheck",
+            "description": "Skrze doplňkový balíček Kalicz.StrongTypes.FsCheck pro property-based testing."
+          }
+        ]
+      }
+    ]
+  },
+  "examples": {
+    "title": "Jak to vypadá",
+    "subtitle": "Pár ukázek pro představu. Plnou dokumentaci a další příklady najdete na GitHubu.",
+    "items": [
+      {
+        "title": "Vytvoření NonEmptyString",
+        "description": "Tři varianty: vyhodit výjimku, zkusit, nebo plynulé rozšíření. Vyberte si tu, která se hodí pro dané volání.",
+        "code": "// Vyhodí výjimku, pokud je vstup neplatný\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Vrátí null, pokud je vstup neplatný\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Forma rozšíření\nNonEmptyString? fluent = userInput.AsNonEmpty();"
+      },
+      {
+        "title": "Validace na hranici API",
+        "description": "JSON konvertor odmítne neplatný vstup při deserializaci. Váš endpoint nikdy neuvidí špatnou hodnotu.",
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// V ASP.NET Core: prázdné Name nebo nulové/záporné Age\n// selže při model bindingu ještě před handlerem.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+      },
+      {
+        "title": "Skládání s Maybe<T>",
+        "description": "Řetězení volitelných operací bez vnořených null kontrol.",
+        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());"
+      },
+      {
+        "title": "Explicitní chyby s Result<T, TError>",
+        "description": "Pattern matching na Success nebo Error — žádné výjimky, žádné out parametry.",
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");"
+      },
+      {
+        "title": "Tři stavy v PATCH s Maybe<T>",
+        "description": "Rozlišení \"neměnit\", \"nastavit na null\" a \"nastavit na hodnotu\" — letitý problém v REST API.",
+        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → pole neměnit\n// Some(null)   → vyprázdnit\n// Some(\"abc\")  → nastavit\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;"
+      }
+    ]
+  },
+  "links": {
+    "title": "Začínáme",
+    "subtitle": "Zdrojový kód, balíčky a dokumentace.",
+    "items": [
+      {
+        "icon": "github",
+        "title": "GitHub repozitář",
+        "description": "Zdrojový kód, README, releases a issue tracker.",
+        "url": "https://github.com/KaliCZ/StrongTypes",
+        "cta": "KaliCZ/StrongTypes"
+      },
+      {
+        "icon": "package",
+        "title": "NuGet — Core",
+        "description": "Hlavní balíček. Obsahuje všechny validované a algebraické typy.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes",
+        "cta": "Kalicz.StrongTypes"
+      },
+      {
+        "icon": "database",
+        "title": "NuGet — EF Core",
+        "description": "Value convertery pro ukládání StrongTypes přes Entity Framework Core.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore",
+        "cta": "Kalicz.StrongTypes.EfCore"
+      },
+      {
+        "icon": "science",
+        "title": "NuGet — FsCheck",
+        "description": "Generátory pro property-based testing hodnot StrongTypes.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes.FsCheck",
+        "cta": "Kalicz.StrongTypes.FsCheck"
+      }
+    ]
+  }
+}

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -19,7 +19,50 @@
     "overview": "Overview",
     "manifesto": "Manifesto",
     "skills": "Skills",
+    "personal": "About me",
     "career": "Career"
+  },
+  "personal": {
+    "title": "About me",
+    "subtitle": "A few things I get up to when I'm away from the keyboard.",
+    "items": [
+      {
+        "icon": "mic-external-on",
+        "color": "primary",
+        "title": "I sing",
+        "description": "If there's a chance to sing along, I'll take it."
+      },
+      {
+        "icon": "casino",
+        "color": "tertiary",
+        "title": "Games of every kind",
+        "description": "Board games, video games, sport — if it's a game, I want in."
+      },
+      {
+        "icon": "sports-soccer",
+        "color": "primary",
+        "title": "Former footballer",
+        "description": "Played football competitively as a younger man."
+      },
+      {
+        "icon": "stadia-controller",
+        "color": "tertiary",
+        "title": "Esports past",
+        "description": "Competed at a high level in League of Legends and Rocket League."
+      },
+      {
+        "icon": "two-wheeler",
+        "color": "primary",
+        "title": "Two wheels",
+        "description": "Spent a few years racing 190cc motorcycles."
+      },
+      {
+        "icon": "family-restroom",
+        "color": "tertiary",
+        "title": "Father of two",
+        "description": "Most of my non-work time goes here."
+      }
+    ]
   },
   "manifesto": {
     "title": "My Manifesto",

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -30,7 +30,7 @@
         "icon": "mic-external-on",
         "color": "primary",
         "title": "I sing",
-        "description": "If there's a chance to sing along, I'll take it."
+        "description": "Karaoke? I'm in!"
       },
       {
         "icon": "casino",
@@ -42,7 +42,7 @@
         "icon": "sports-soccer",
         "color": "primary",
         "title": "Former footballer",
-        "description": "Played football competitively as a younger man."
+        "description": "I used to spend a lot of time doing sports. Now I need to pace myself due to ankle injuries."
       },
       {
         "icon": "stadia-controller",
@@ -54,7 +54,7 @@
         "icon": "two-wheeler",
         "color": "primary",
         "title": "Two wheels",
-        "description": "Spent a few years racing 190cc motorcycles."
+        "description": "I spent some time in motorcycle amateur races. (190cc)"
       },
       {
         "icon": "family-restroom",

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -42,7 +42,8 @@
     "mainNavigation": "Main navigation",
     "toggleDarkMode": "Toggle dark mode",
     "changeLanguage": "Change language",
-    "openProjectsMenu": "Open projects menu"
+    "openProjectsMenu": "Quick links to specific projects",
+    "breadcrumb": "Breadcrumb"
   },
   "notFound": {
     "title": "Page Not Found",

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -2,7 +2,9 @@
   "nav": {
     "home": "Home",
     "about": "About Me",
-    "project": "Project",
+    "projects": "Projects",
+    "projectThisSite": "This Site",
+    "projectStrongTypes": "StrongTypes",
     "hireMe": "Hire Me",
     "mySubmissions": "My Submissions",
     "admin": "Admin",
@@ -39,7 +41,8 @@
     "skipToContent": "Skip to content",
     "mainNavigation": "Main navigation",
     "toggleDarkMode": "Toggle dark mode",
-    "changeLanguage": "Change language"
+    "changeLanguage": "Change language",
+    "openProjectsMenu": "Open projects menu"
   },
   "notFound": {
     "title": "Page Not Found",

--- a/frontend/src/i18n/en/home.json
+++ b/frontend/src/i18n/en/home.json
@@ -11,7 +11,10 @@
   "cards": {
     "about": {
       "title": "About Me",
-      "description": "What drives me as an engineer.",
+      "description": [
+        "What drives me as an engineer — and a few things about me beyond the keyboard.",
+        "The tech stack I work with, the career path that got me here, and a glimpse of life outside the IDE."
+      ],
       "cta": "Read more"
     }
   },

--- a/frontend/src/i18n/en/home.json
+++ b/frontend/src/i18n/en/home.json
@@ -14,19 +14,21 @@
       "description": "What drives me as an engineer.",
       "cta": "Read more"
     },
-    "project": {
-      "title": "Project",
-      "description": "From a simple page to advanced features. Follow the roadmap.",
+    "thisSite": {
+      "title": "This Site",
+      "description": "Built in public — every version, decision, and deployment documented.",
       "cta": "View roadmap"
+    },
+    "strongTypes": {
+      "title": "StrongTypes",
+      "description": "A C# library for safer, more expressive code — non-empty strings, validated numerics, Maybe and Result.",
+      "cta": "Explore the library"
     }
   },
   "whatsHere": {
     "title": "What is this page?",
     "siteName": "kalandra.tech",
-    "paragraph1": " is my personal website, but it's also an experiment. I'm building it transparently — every version, every architectural decision, every deployment is public.",
-    "paragraph2prefix": "More projects are coming in the future. For now, the only project here is ",
-    "paragraph2link": "the meta-project of building this very site",
-    "paragraph2suffix": ". Stay tuned."
+    "paragraph1": " is my personal website, but it's also an experiment. I'm building it transparently — every version, every architectural decision, every deployment is public."
   },
   "qrCode": {
     "label": "Click to share",

--- a/frontend/src/i18n/en/home.json
+++ b/frontend/src/i18n/en/home.json
@@ -13,16 +13,6 @@
       "title": "About Me",
       "description": "What drives me as an engineer.",
       "cta": "Read more"
-    },
-    "thisSite": {
-      "title": "This Site",
-      "description": "Built in public — every version, decision, and deployment documented.",
-      "cta": "View roadmap"
-    },
-    "strongTypes": {
-      "title": "StrongTypes",
-      "description": "A C# library for safer, more expressive code — non-empty strings, validated numerics, Maybe and Result.",
-      "cta": "Explore the library"
     }
   },
   "whatsHere": {

--- a/frontend/src/i18n/en/projects.json
+++ b/frontend/src/i18n/en/projects.json
@@ -9,9 +9,10 @@
   },
   "items": {
     "thisSite": {
-      "title": "This Site",
+      "title": "How I built this site",
       "description": [
-        "kalandra.tech itself — built in public, with every architecture decision, deployment, and lesson learned written down as it happens. The site is the artifact."
+        "kalandra.tech itself — built in public, with every architecture decision, deployment, and lesson learned written down as it happens. The site is the artifact.",
+        "Covers the webpage and its hosting, the API and its hosting, the database with event sourcing, the CI/CD pipeline with E2E tests. And more."
       ],
       "cta": "View roadmap"
     },

--- a/frontend/src/i18n/en/projects.json
+++ b/frontend/src/i18n/en/projects.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "title": "Projects | kalandra.tech",
+    "description": "Pavel Kalandra's software projects — kalandra.tech itself, built in public, and StrongTypes, a C# NuGet package for safer types."
+  },
+  "hero": {
+    "title": "Projects",
+    "subtitle": "What I'm building, in public. Pick one to dive in."
+  },
+  "items": {
+    "thisSite": {
+      "title": "This Site",
+      "description": [
+        "kalandra.tech itself — built in public, with every architecture decision, deployment, and lesson learned written down as it happens. The site is the artifact."
+      ],
+      "cta": "View roadmap"
+    },
+    "strongTypes": {
+      "title": "StrongTypes",
+      "description": [
+        "A C# NuGet package that pushes invariants into the type system: NonEmptyString, NonEmptyEnumerable, validated numerics, Maybe and Result.",
+        "Enable no-code validations enforced by the compiler."
+      ],
+      "cta": "Explore the library"
+    }
+  }
+}

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -22,13 +22,47 @@
     "items": [
       { "label": "License", "value": "MIT" },
       { "label": "Target", "value": ".NET 10" },
-      { "label": "Latest", "value": "1.0.1" },
       { "label": "Dependencies", "value": "None" }
+    ]
+  },
+  "badges": {
+    "ariaLabel": "Project status badges",
+    "items": [
+      {
+        "src": "https://img.shields.io/github/v/release/KaliCZ/StrongTypes?label=latest&color=4858ab",
+        "alt": "Latest release on GitHub",
+        "href": "https://github.com/KaliCZ/StrongTypes/releases"
+      },
+      {
+        "src": "https://img.shields.io/nuget/v/Kalicz.StrongTypes?label=nuget",
+        "alt": "Latest NuGet version of Kalicz.StrongTypes",
+        "href": "https://www.nuget.org/packages/Kalicz.StrongTypes"
+      },
+      {
+        "src": "https://img.shields.io/nuget/dt/Kalicz.StrongTypes?label=downloads",
+        "alt": "Total NuGet downloads of Kalicz.StrongTypes",
+        "href": "https://www.nuget.org/packages/Kalicz.StrongTypes"
+      },
+      {
+        "src": "https://img.shields.io/github/actions/workflow/status/KaliCZ/StrongTypes/build.yml?branch=main&label=build",
+        "alt": "GitHub Actions build status",
+        "href": "https://github.com/KaliCZ/StrongTypes/actions/workflows/build.yml"
+      },
+      {
+        "src": "https://img.shields.io/github/license/KaliCZ/StrongTypes",
+        "alt": "Project license",
+        "href": "https://github.com/KaliCZ/StrongTypes/blob/main/license.txt"
+      }
     ]
   },
   "why": {
     "title": "Why bother with strong types?",
     "subtitle": "Most C# code defends against invalid input by re-validating it everywhere. StrongTypes flips that around: validate once, at the boundary, and let the compiler enforce the rest.",
+    "diagram": {
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
+      "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses",
+      "caption": "Validation moves to the boundary. Internal code stops re-checking the same invariants over and over."
+    },
     "points": [
       {
         "icon": "shield-lock",
@@ -49,6 +83,24 @@
         "icon": "package-2",
         "title": "Small and focused",
         "description": "No heavy framework, no runtime reflection magic. Drop it in alongside your existing code — types compose with what you already have."
+      }
+    ]
+  },
+  "anatomy": {
+    "title": "Anatomy",
+    "subtitle": "How the packages fit together, and the small piece of variance that makes NonEmptyEnumerable composable.",
+    "items": [
+      {
+        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+        "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages",
+        "title": "Package layout",
+        "description": "One core package, two opt-in companions. Pull in only what you need."
+      },
+      {
+        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/covariance.svg",
+        "alt": "Diagram showing covariant upcast from INonEmptyEnumerable<Cat> to INonEmptyEnumerable<Animal>",
+        "title": "Covariance",
+        "description": "INonEmptyEnumerable<out T> is covariant, so a non-empty sequence of Cats is a non-empty sequence of Animals — no copy, no LINQ."
       }
     ]
   },
@@ -102,7 +154,11 @@
       {
         "title": "Create a NonEmptyString",
         "description": "Three flavours: throw, try, or fluent extension. Pick whichever suits the call site.",
-        "code": "// Throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Returns null if invalid\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Extension form\nNonEmptyString? fluent = userInput.AsNonEmpty();"
+        "code": "// Throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Returns null if invalid\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Extension form\nNonEmptyString? fluent = userInput.AsNonEmpty();",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
+          "alt": "Flow diagram contrasting TryCreate (returns null on invalid input) and Create (throws on invalid input)"
+        }
       },
       {
         "title": "Validate at the API boundary",
@@ -112,17 +168,29 @@
       {
         "title": "Compose with Maybe<T>",
         "description": "Chain optional operations without nested null checks.",
-        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());"
+        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "alt": "Pipeline diagram showing Some and None values flowing through Map and FlatMap operations on Maybe<T>"
+        }
       },
       {
         "title": "Explicit failures with Result<T, TError>",
         "description": "Pattern-match on Success or Error — no exceptions, no out parameters.",
-        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");"
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
+          "alt": "Pipeline diagram showing how a Result<T, TError> value flows through Map, MapError, and FlatMap stages"
+        }
       },
       {
         "title": "Three-state PATCH with Maybe<T>",
         "description": "Distinguish \"don't touch\", \"clear to null\", and \"set to value\" — a long-standing pain point in REST APIs.",
-        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → don't touch the field\n// Some(null)   → clear it\n// Some(\"abc\")  → set it\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;"
+        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → don't touch the field\n// Some(null)   → clear it\n// Some(\"abc\")  → set it\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
+          "alt": "Diagram of the three-state PATCH model: null (don't touch), Some(null) (clear), Some(value) (set)"
+        }
       }
     ]
   },

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -17,22 +17,9 @@
     "copied": "Copied to clipboard",
     "copyFailed": "Could not copy. Please copy manually."
   },
-  "facts": {
-    "title": "At a glance",
-    "items": [
-      { "label": "License", "value": "MIT" },
-      { "label": "Target", "value": ".NET 10" },
-      { "label": "Dependencies", "value": "None" }
-    ]
-  },
   "badges": {
     "ariaLabel": "Project status badges",
     "items": [
-      {
-        "src": "https://img.shields.io/github/v/release/KaliCZ/StrongTypes?label=latest&color=4858ab",
-        "alt": "Latest release on GitHub",
-        "href": "https://github.com/KaliCZ/StrongTypes/releases"
-      },
       {
         "src": "https://img.shields.io/nuget/v/Kalicz.StrongTypes?label=nuget",
         "alt": "Latest NuGet version of Kalicz.StrongTypes",
@@ -86,23 +73,13 @@
       }
     ]
   },
-  "anatomy": {
-    "title": "Anatomy",
-    "subtitle": "How the packages fit together, and the small piece of variance that makes NonEmptyEnumerable composable.",
-    "items": [
-      {
-        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
-        "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages",
-        "title": "Package layout",
-        "description": "One core package, two opt-in companions. Pull in only what you need."
-      },
-      {
-        "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/covariance.svg",
-        "alt": "Diagram showing covariant upcast from INonEmptyEnumerable<Cat> to INonEmptyEnumerable<Animal>",
-        "title": "Covariance",
-        "description": "INonEmptyEnumerable<out T> is covariant, so a non-empty sequence of Cats is a non-empty sequence of Animals — no copy, no LINQ."
-      }
-    ]
+  "packageLayout": {
+    "title": "Package layout",
+    "description": "One core package, two opt-in companions. Pull in only what you need.",
+    "diagram": {
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+      "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages"
+    }
   },
   "features": {
     "title": "What's in the box",
@@ -152,18 +129,18 @@
     "subtitle": "A few snippets to give you the feel of it. Full docs and more examples are on GitHub.",
     "items": [
       {
-        "title": "Create a NonEmptyString",
-        "description": "Three flavours: throw, try, or fluent extension. Pick whichever suits the call site.",
-        "code": "// Throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Returns null if invalid\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Extension form\nNonEmptyString? fluent = userInput.AsNonEmpty();",
+        "title": "Validate at the API boundary",
+        "description": "The JSON converter rejects invalid input during deserialization. Your endpoint never sees a bad value.",
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// In ASP.NET Core: an empty Name or zero/negative Age\n// fails model binding before the handler runs.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+      },
+      {
+        "title": "Construct values explicitly",
+        "description": "Each type has Create (throws on invalid) and TryCreate (returns null). String types also have a fluent extension form.",
+        "code": "// Strings — three call styles\nNonEmptyString name = NonEmptyString.Create(input);    // throws\nNonEmptyString? maybe = NonEmptyString.TryCreate(input); // null on fail\nNonEmptyString? fluent = input.AsNonEmpty();             // extension\n\n// Numbers — sign-enforced wrappers over any INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = NonNegative<decimal>.TryCreate(amount);\n\n// Sequences — at least one element, Head and Tail always safe\nNonEmptyEnumerable<string> tags =\n    NonEmptyEnumerable.Create(\"primary\", \"secondary\", \"tertiary\");\nstring first = tags.Head;",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
           "alt": "Flow diagram contrasting TryCreate (returns null on invalid input) and Create (throws on invalid input)"
         }
-      },
-      {
-        "title": "Validate at the API boundary",
-        "description": "The JSON converter rejects invalid input during deserialization. Your endpoint never sees a bad value.",
-        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// In ASP.NET Core: an empty Name or zero/negative Age\n// fails model binding before the handler runs.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
       },
       {
         "title": "Compose with Maybe<T>",

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -1,0 +1,163 @@
+{
+  "meta": {
+    "title": "StrongTypes | kalandra.tech — Safer C# Types",
+    "description": "StrongTypes is a small C# library for safer, more expressive code: NonEmptyString, validated numerics, NonEmptyEnumerable, Maybe<T>, and Result<T, TError>."
+  },
+  "hero": {
+    "tagline": "C# Library · NuGet",
+    "titlePrefix": "A few small types that make C# ",
+    "titleHighlight": "safer",
+    "titleSuffix": ".",
+    "description": "StrongTypes adds focused, validated wrapper types that move invariants into the type system — \"a string that is never empty\" or \"an integer that is always positive\". Validation happens at the boundary, so invalid data never reaches your handlers.",
+    "primaryCta": "View on GitHub",
+    "secondaryCta": "View on NuGet",
+    "install": "dotnet add package Kalicz.StrongTypes",
+    "installLabel": "Install",
+    "copyAriaLabel": "Copy install command",
+    "copied": "Copied to clipboard",
+    "copyFailed": "Could not copy. Please copy manually."
+  },
+  "facts": {
+    "title": "At a glance",
+    "items": [
+      { "label": "License", "value": "MIT" },
+      { "label": "Target", "value": ".NET 10" },
+      { "label": "Latest", "value": "1.0.1" },
+      { "label": "Dependencies", "value": "None" }
+    ]
+  },
+  "why": {
+    "title": "Why bother with strong types?",
+    "subtitle": "Most C# code defends against invalid input by re-validating it everywhere. StrongTypes flips that around: validate once, at the boundary, and let the compiler enforce the rest.",
+    "points": [
+      {
+        "icon": "shield-lock",
+        "title": "Invariants in the type",
+        "description": "If a method takes NonEmptyString, it cannot receive an empty one. The compiler — not a runtime guard clause — does the work."
+      },
+      {
+        "icon": "bolt",
+        "title": "Validation at the edge",
+        "description": "Built-in System.Text.Json converters reject invalid payloads during deserialization, before your endpoint method is even called."
+      },
+      {
+        "icon": "code-blocks",
+        "title": "Expressive intent",
+        "description": "A signature like Result<Order, OrderError> Place(Positive<int> qty) tells the reader exactly what's allowed and what can fail."
+      },
+      {
+        "icon": "package-2",
+        "title": "Small and focused",
+        "description": "No heavy framework, no runtime reflection magic. Drop it in alongside your existing code — types compose with what you already have."
+      }
+    ]
+  },
+  "features": {
+    "title": "What's in the box",
+    "groups": [
+      {
+        "color": "primary",
+        "icon": "label",
+        "heading": "Validated wrappers",
+        "items": [
+          { "name": "NonEmptyString", "description": "Guaranteed non-null, non-empty, non-whitespace string." },
+          {
+            "name": "Positive<T>, NonNegative<T>, Negative<T>, NonPositive<T>",
+            "description": "Sign-enforcing wrappers over any INumber<T>."
+          },
+          {
+            "name": "NonEmptyEnumerable<T>",
+            "description": "Read-only sequence with at least one element — Head and Tail are always safe to access."
+          }
+        ]
+      },
+      {
+        "color": "tertiary",
+        "icon": "alt-route",
+        "heading": "Algebraic types",
+        "items": [
+          { "name": "Maybe<T>", "description": "Optional values with Map and FlatMap. Useful for HTTP PATCH (don't touch / clear / set)." },
+          { "name": "Result<T, TError>", "description": "Explicit failure handling without exceptions. Includes async support." }
+        ]
+      },
+      {
+        "color": "primary",
+        "icon": "settings",
+        "heading": "Built-in integrations",
+        "items": [
+          { "name": "System.Text.Json", "description": "Automatic converters — no registration required." },
+          { "name": "EF Core value converters", "description": "Via the Kalicz.StrongTypes.EfCore companion package." },
+          {
+            "name": "FsCheck generators",
+            "description": "Via the Kalicz.StrongTypes.FsCheck companion package for property-based testing."
+          }
+        ]
+      }
+    ]
+  },
+  "examples": {
+    "title": "How it looks",
+    "subtitle": "A few snippets to give you the feel of it. Full docs and more examples are on GitHub.",
+    "items": [
+      {
+        "title": "Create a NonEmptyString",
+        "description": "Three flavours: throw, try, or fluent extension. Pick whichever suits the call site.",
+        "code": "// Throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n\n// Returns null if invalid\nNonEmptyString? maybeName = NonEmptyString.TryCreate(input);\n\n// Extension form\nNonEmptyString? fluent = userInput.AsNonEmpty();"
+      },
+      {
+        "title": "Validate at the API boundary",
+        "description": "The JSON converter rejects invalid input during deserialization. Your endpoint never sees a bad value.",
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// In ASP.NET Core: an empty Name or zero/negative Age\n// fails model binding before the handler runs.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+      },
+      {
+        "title": "Compose with Maybe<T>",
+        "description": "Chain optional operations without nested null checks.",
+        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());"
+      },
+      {
+        "title": "Explicit failures with Result<T, TError>",
+        "description": "Pattern-match on Success or Error — no exceptions, no out parameters.",
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");"
+      },
+      {
+        "title": "Three-state PATCH with Maybe<T>",
+        "description": "Distinguish \"don't touch\", \"clear to null\", and \"set to value\" — a long-standing pain point in REST APIs.",
+        "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → don't touch the field\n// Some(null)   → clear it\n// Some(\"abc\")  → set it\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;"
+      }
+    ]
+  },
+  "links": {
+    "title": "Get started",
+    "subtitle": "Source, packages, and docs.",
+    "items": [
+      {
+        "icon": "github",
+        "title": "GitHub repository",
+        "description": "Source, README, releases, and issue tracker.",
+        "url": "https://github.com/KaliCZ/StrongTypes",
+        "cta": "KaliCZ/StrongTypes"
+      },
+      {
+        "icon": "package",
+        "title": "NuGet — Core",
+        "description": "The main package. Contains all validated and algebraic types.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes",
+        "cta": "Kalicz.StrongTypes"
+      },
+      {
+        "icon": "database",
+        "title": "NuGet — EF Core",
+        "description": "Value converters for persisting StrongTypes with Entity Framework Core.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore",
+        "cta": "Kalicz.StrongTypes.EfCore"
+      },
+      {
+        "icon": "science",
+        "title": "NuGet — FsCheck",
+        "description": "Generators for property-based testing of StrongTypes values.",
+        "url": "https://www.nuget.org/packages/Kalicz.StrongTypes.FsCheck",
+        "cta": "Kalicz.StrongTypes.FsCheck"
+      }
+    ]
+  }
+}

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -1,14 +1,13 @@
 {
   "meta": {
-    "title": "StrongTypes | kalandra.tech — Safer C# Types",
-    "description": "StrongTypes is a small C# library for safer, more expressive code: NonEmptyString, validated numerics, NonEmptyEnumerable, Maybe<T>, and Result<T, TError>."
+    "title": "Kalicz.StrongTypes | kalandra.tech — Safer C# Types",
+    "description": "Kalicz.StrongTypes is a C# NuGet package for safer, more expressive code: NonEmptyString, validated numerics, NonEmptyEnumerable, Maybe<T>, and Result<T, TError>."
   },
   "hero": {
-    "tagline": "C# Library · NuGet",
     "titlePrefix": "A few small types that make C# ",
     "titleHighlight": "safer",
     "titleSuffix": ".",
-    "description": "StrongTypes adds focused, validated wrapper types that move invariants into the type system — \"a string that is never empty\" or \"an integer that is always positive\". Validation happens at the boundary, so invalid data never reaches your handlers.",
+    "description": "Kalicz.StrongTypes is a C# NuGet package that adds no-code validations enforced by the compiler. Wrapper types like NonEmptyString or Positive<int> move invariants into the type system, and validation happens at the boundary — so invalid data never reaches your handlers.",
     "primaryCta": "View on GitHub",
     "secondaryCta": "View on NuGet",
     "install": "dotnet add package Kalicz.StrongTypes",
@@ -131,30 +130,21 @@
       {
         "title": "Validate at the API boundary",
         "description": "The JSON converter rejects invalid input during deserialization. Your endpoint never sees a bad value.",
-        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n// In ASP.NET Core: an empty Name or zero/negative Age\n// fails model binding before the handler runs.\n[HttpPost]\npublic IResult Create(CreateUserRequest req) =>\n    Results.Ok(_users.Add(req.Name, req.Age));"
+        "code": "public record CreateUserRequest(\n    NonEmptyString Name,\n    Positive<int> Age);\n\n[HttpPost]\npublic async Task<IResult> Create(CreateUserRequest req)\n{\n    // No extra validation needed here:\n    // ASP pipeline rejects invalid payloads with 400.\n    _users.Add(req.Name, req.Age);\n    await _users.SaveChangesAsync();\n    return Results.NoContent();\n}"
       },
       {
         "title": "Construct values explicitly",
         "description": "Each type has Create (throws on invalid) and TryCreate (returns null). String types also have a fluent extension form.",
-        "code": "// Strings — three call styles\nNonEmptyString name = NonEmptyString.Create(input);    // throws\nNonEmptyString? maybe = NonEmptyString.TryCreate(input); // null on fail\nNonEmptyString? fluent = input.AsNonEmpty();             // extension\n\n// Numbers — sign-enforced wrappers over any INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = NonNegative<decimal>.TryCreate(amount);\n\n// Sequences — at least one element, Head and Tail always safe\nNonEmptyEnumerable<string> tags =\n    NonEmptyEnumerable.Create(\"primary\", \"secondary\", \"tertiary\");\nstring first = tags.Head;",
+        "code": "// Strings — three call styles\n// throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n// null if invalid\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent extension\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Numbers — sign-enforced over INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sequences — at least one element, Head safe\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
           "alt": "Flow diagram contrasting TryCreate (returns null on invalid input) and Create (throws on invalid input)"
         }
       },
       {
-        "title": "Compose with Maybe<T>",
-        "description": "Chain optional operations without nested null checks.",
-        "code": "Maybe<int> doubled = Maybe.Some(3).Map(x => x * 2);\n// Some(6)\n\nMaybe<int> parsed = Maybe.Some(\"42\")\n    .FlatMap(s => int.TryParse(s, out var n)\n        ? Maybe.Some(n)\n        : Maybe.None<int>());",
-        "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
-          "alt": "Pipeline diagram showing Some and None values flowing through Map and FlatMap operations on Maybe<T>"
-        }
-      },
-      {
         "title": "Explicit failures with Result<T, TError>",
         "description": "Pattern-match on Success or Error — no exceptions, no out parameters.",
-        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value) Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg) Console.WriteLine($\"failed: {msg}\");",
+        "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
           "alt": "Pipeline diagram showing how a Result<T, TError> value flows through Map, MapError, and FlatMap stages"
@@ -168,8 +158,29 @@
           "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
           "alt": "Diagram of the three-state PATCH model: null (don't touch), Some(null) (clear), Some(value) (set)"
         }
+      },
+      {
+        "title": "Compose with Maybe<T>",
+        "description": "Chain optional operations without nested null checks. Implicit operators handle the wrapping — you return a T or Maybe.None and it just works.",
+        "code": "// Producer: implicit conversion from T or Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, auto-wraps in Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, no double-wrap\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
+        "diagram": {
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "alt": "Pipeline diagram showing Some and None values flowing through Map and FlatMap operations on Maybe<T>"
+        }
       }
     ]
+  },
+  "lightbox": {
+    "dialogLabel": "Enlarged diagram",
+    "closeLabel": "Close"
+  },
+  "toc": {
+    "title": "On this page",
+    "overview": "Overview",
+    "why": "Why",
+    "features": "What's in the box",
+    "examples": "How it looks",
+    "getStarted": "Get started"
   },
   "links": {
     "title": "Get started",

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ interface Props {
   activePage:
     | "home"
     | "about"
+    | "projects"
     | "project"
     | "strong-types"
     | "hire-me"

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -17,6 +17,7 @@ interface Props {
     | "home"
     | "about"
     | "project"
+    | "strong-types"
     | "hire-me"
     | "job-offers"
     | "admin/job-offers"

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -170,7 +170,7 @@ const tocItems = [
   <!-- Skills Section -->
   <section
     id="skills"
-    class="bg-surface-container dark:bg-surface-container-lowest py-12 lg:py-16 mb-16 lg:mb-24 relative overflow-hidden border-b border-outline-variant/60 dark:border-on-surface/5"
+    class="bg-surface-container dark:bg-surface-container-lowest py-12 lg:py-16 relative overflow-hidden border-b border-outline-variant/60 dark:border-on-surface/5"
   >
     <div class="max-w-7xl mx-auto px-4 md:px-8">
       <div class="text-center mb-10">
@@ -207,36 +207,42 @@ const tocItems = [
     </div>
   </section>
 
-  <!-- Personal Section. A lighter, transparent band between the heavier Skills
-       band above and the no-bg Career timeline below — gives the page some
-       breath and signals "human" before the career timeline kicks in. Cards
+  <!-- Personal Section. Third band in the sequence Manifesto → Skills → Personal,
+       using the lighter shade so it alternates with Skills (which uses the
+       middle shade). The band's bottom border acts as the divider that closes
+       off the colored-bands zone before the transparent Career timeline. Cards
        use a horizontal icon-then-text layout so each item reads as a quick
        human attribute rather than a feature. -->
-  <section id="personal" class="max-w-7xl mx-auto px-4 md:px-8 mb-16 lg:mb-24">
-    <div class="text-center mb-10">
-      <h2 class="font-headline text-4xl md:text-5xl font-bold tracking-tighter mb-4">
-        {t.personal.title}
-      </h2>
-      <p class="font-body text-on-surface-variant max-w-2xl mx-auto">
-        {t.personal.subtitle}
-      </p>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
-      {
-        t.personal.items.map((item) => (
-          <div class="bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/20 flex items-start gap-4">
-            <Icon
-              name={`material-symbols:${item.icon.replace(/_/g, "-")}`}
-              class:list={["size-8 shrink-0", `text-${item.color}`]}
-              aria-hidden="true"
-            />
-            <div>
-              <h3 class="font-headline font-bold text-lg mb-1">{item.title}</h3>
-              <p class="font-body text-on-surface-variant text-sm leading-relaxed">{item.description}</p>
+  <section
+    id="personal"
+    class="bg-surface-container-highest dark:bg-surface-container-low py-12 lg:py-16 mb-16 lg:mb-24 relative overflow-hidden border-b border-outline-variant/60 dark:border-on-surface/5"
+  >
+    <div class="max-w-7xl mx-auto px-4 md:px-8">
+      <div class="text-center mb-10">
+        <h2 class="font-headline text-4xl md:text-5xl font-bold tracking-tighter mb-4">
+          {t.personal.title}
+        </h2>
+        <p class="font-body text-on-surface-variant max-w-2xl mx-auto">
+          {t.personal.subtitle}
+        </p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {
+          t.personal.items.map((item) => (
+            <div class="bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/20 flex items-start gap-4">
+              <Icon
+                name={`material-symbols:${item.icon.replace(/_/g, "-")}`}
+                class:list={["size-8 shrink-0", `text-${item.color}`]}
+                aria-hidden="true"
+              />
+              <div>
+                <h3 class="font-headline font-bold text-lg mb-1">{item.title}</h3>
+                <p class="font-body text-on-surface-variant text-sm leading-relaxed">{item.description}</p>
+              </div>
             </div>
-          </div>
-        ))
-      }
+          ))
+        }
+      </div>
     </div>
   </section>
 

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -24,6 +24,7 @@ const tocItems = [
   { id: "hero", label: t.toc.overview },
   { id: "manifesto", label: t.toc.manifesto },
   { id: "skills", label: t.toc.skills },
+  { id: "personal", label: t.toc.personal },
   { id: "career", label: t.toc.career },
 ];
 ---
@@ -206,6 +207,39 @@ const tocItems = [
     </div>
   </section>
 
+  <!-- Personal Section. A lighter, transparent band between the heavier Skills
+       band above and the no-bg Career timeline below — gives the page some
+       breath and signals "human" before the career timeline kicks in. Cards
+       use a horizontal icon-then-text layout so each item reads as a quick
+       human attribute rather than a feature. -->
+  <section id="personal" class="max-w-7xl mx-auto px-4 md:px-8 mb-16 lg:mb-24">
+    <div class="text-center mb-10">
+      <h2 class="font-headline text-4xl md:text-5xl font-bold tracking-tighter mb-4">
+        {t.personal.title}
+      </h2>
+      <p class="font-body text-on-surface-variant max-w-2xl mx-auto">
+        {t.personal.subtitle}
+      </p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+      {
+        t.personal.items.map((item) => (
+          <div class="bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/20 flex items-start gap-4">
+            <Icon
+              name={`material-symbols:${item.icon.replace(/_/g, "-")}`}
+              class:list={["size-8 shrink-0", `text-${item.color}`]}
+              aria-hidden="true"
+            />
+            <div>
+              <h3 class="font-headline font-bold text-lg mb-1">{item.title}</h3>
+              <p class="font-body text-on-surface-variant text-sm leading-relaxed">{item.description}</p>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
   <!-- Career Journey Section -->
   <section id="career" class="max-w-7xl mx-auto px-4 md:px-8 mb-40">
     <div class="text-center mb-24">
@@ -310,5 +344,5 @@ const tocItems = [
     </div>
   </section>
 
-  <OnThisPage title={t.toc.title} items={tocItems} desktop={false} />
+  <OnThisPage title={t.toc.title} items={tocItems} />
 </Layout>

--- a/frontend/src/pages/[...lang]/index.astro
+++ b/frontend/src/pages/[...lang]/index.astro
@@ -41,13 +41,8 @@ const t = translations[lang];
         <h2 class="font-headline text-3xl font-extrabold mb-6 tracking-tight">
           {t.whatsHere.title}
         </h2>
-        <p class="text-on-surface-variant text-lg leading-relaxed mb-6">
-          <strong class="text-on-surface">{t.whatsHere.siteName}</strong>{t.whatsHere.paragraph1}
-        </p>
         <p class="text-on-surface-variant text-lg leading-relaxed">
-          {t.whatsHere.paragraph2prefix}<a href={localePath(lang, "project")} class="text-primary hover:underline"
-            >{t.whatsHere.paragraph2link}</a
-          >{t.whatsHere.paragraph2suffix}
+          <strong class="text-on-surface">{t.whatsHere.siteName}</strong>{t.whatsHere.paragraph1}
         </p>
       </div>
       <QrCodeCard
@@ -66,11 +61,11 @@ const t = translations[lang];
     </div>
 
     <!-- Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl">
       <!-- About Me card -->
       <a
         href={localePath(lang, "about")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md"
+        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
       >
         <div class="flex items-center gap-3 mb-4">
           <Icon name="material-symbols:person" class="size-6 text-primary" aria-hidden="true" />
@@ -78,7 +73,7 @@ const t = translations[lang];
             {t.cards.about.title}
           </h2>
         </div>
-        <p class="text-on-surface-variant leading-relaxed mb-6">
+        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
           {t.cards.about.description}
         </p>
         <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
@@ -87,22 +82,42 @@ const t = translations[lang];
         </span>
       </a>
 
-      <!-- Project card -->
+      <!-- This Site project card -->
       <a
         href={localePath(lang, "project")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-tertiary/30 transition-all duration-300 shadow-sm hover:shadow-md"
+        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-tertiary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
       >
         <div class="flex items-center gap-3 mb-4">
           <Icon name="material-symbols:rocket-launch" class="size-6 text-tertiary" aria-hidden="true" />
           <h2 class="font-headline text-2xl font-bold group-hover:text-tertiary transition-colors">
-            {t.cards.project.title}
+            {t.cards.thisSite.title}
           </h2>
         </div>
-        <p class="text-on-surface-variant leading-relaxed mb-6">
-          {t.cards.project.description}
+        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
+          {t.cards.thisSite.description}
         </p>
         <span class="font-label text-sm uppercase tracking-widest text-tertiary flex items-center gap-1">
-          {t.cards.project.cta}
+          {t.cards.thisSite.cta}
+          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+        </span>
+      </a>
+
+      <!-- StrongTypes project card -->
+      <a
+        href={localePath(lang, "strong-types")}
+        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col md:col-span-2 lg:col-span-1"
+      >
+        <div class="flex items-center gap-3 mb-4">
+          <Icon name="material-symbols:package-2" class="size-6 text-primary" aria-hidden="true" />
+          <h2 class="font-headline text-2xl font-bold group-hover:text-primary transition-colors">
+            {t.cards.strongTypes.title}
+          </h2>
+        </div>
+        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
+          {t.cards.strongTypes.description}
+        </p>
+        <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
+          {t.cards.strongTypes.cta}
           <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
         </span>
       </a>

--- a/frontend/src/pages/[...lang]/index.astro
+++ b/frontend/src/pages/[...lang]/index.astro
@@ -6,8 +6,14 @@ import ProjectCard from "../../components/ProjectCard.astro";
 import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/home.json";
 import csStrings from "../../i18n/cs/home.json";
+// Project cards on the home page render the same content as on the /projects
+// index — both surfaces read from the same JSON so a copy edit lands in both
+// places at once.
+import enProjects from "../../i18n/en/projects.json";
+import csProjects from "../../i18n/cs/projects.json";
 
 const translations = { en: enStrings, cs: csStrings };
+const projectTranslations = { en: enProjects, cs: csProjects };
 
 export function getStaticPaths() {
   return locales.map((lang) => ({
@@ -17,28 +23,30 @@ export function getStaticPaths() {
 
 const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
+const tProjects = projectTranslations[lang];
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="home" lang={lang}>
   <!-- Hero -->
   <section class="max-w-7xl mx-auto px-4 md:px-8 mb-24 lg:mb-40">
-    <div class="max-w-4xl">
-      <h1
-        class:list={[
-          "font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-[1.1] mb-8",
-          lang === "cs" && "whitespace-nowrap",
-        ]}
-      >
-        {t.hero.titlePrefix}<span class="gradient-text text-primary bg-linear-to-r from-primary to-tertiary">{t.hero.titleName}</span>
-      </h1>
-      <p class="font-body text-xl md:text-2xl text-on-surface-variant leading-relaxed mb-12">
-        {t.hero.subtitle}
-      </p>
-    </div>
+    <h1
+      class:list={[
+        "font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-[1.1] mb-8 max-w-4xl",
+        lang === "cs" && "whitespace-nowrap",
+      ]}
+    >
+      {t.hero.titlePrefix}<span class="gradient-text text-primary bg-linear-to-r from-primary to-tertiary">{t.hero.titleName}</span>
+    </h1>
 
-    <!-- What's here + QR card -->
+    <!-- Subtitle + "What is this page?" copy on the left, QR card on the right.
+         items-start anchors the QR card's top edge to the same y-axis as the
+         "Software engineer..." subtitle line — previously the card sat next to
+         the "What is this page?" heading instead, which gave it too much air. -->
     <div class="grid lg:grid-cols-[minmax(0,1fr)_auto] gap-10 lg:gap-16 items-start mb-16 max-w-5xl">
       <div>
+        <p class="font-body text-xl md:text-2xl text-on-surface-variant leading-relaxed mb-12">
+          {t.hero.subtitle}
+        </p>
         <h2 class="font-headline text-3xl font-extrabold mb-6 tracking-tight">
           {t.whatsHere.title}
         </h2>
@@ -83,23 +91,24 @@ const t = translations[lang];
         </span>
       </a>
 
-      <!-- Project cards. Shared component with the /projects index page; same visual
-           vocabulary, just shorter copy here since the index has room for a richer blurb. -->
+      <!-- Project cards. Shared component AND shared content with the /projects
+           index — both pages read from projects.json so a copy edit there
+           updates both surfaces. -->
       <ProjectCard
         href={localePath(lang, "project")}
         icon="rocket-launch"
         accent="tertiary"
-        title={t.cards.thisSite.title}
-        description={t.cards.thisSite.description}
-        cta={t.cards.thisSite.cta}
+        title={tProjects.items.thisSite.title}
+        description={tProjects.items.thisSite.description}
+        cta={tProjects.items.thisSite.cta}
       />
       <ProjectCard
         href={localePath(lang, "strong-types")}
         icon="package-2"
         accent="primary"
-        title={t.cards.strongTypes.title}
-        description={t.cards.strongTypes.description}
-        cta={t.cards.strongTypes.cta}
+        title={tProjects.items.strongTypes.title}
+        description={tProjects.items.strongTypes.description}
+        cta={tProjects.items.strongTypes.cta}
         class="md:col-span-2 lg:col-span-1"
       />
     </div>

--- a/frontend/src/pages/[...lang]/index.astro
+++ b/frontend/src/pages/[...lang]/index.astro
@@ -2,6 +2,7 @@
 import { Icon } from "astro-icon/components";
 import Layout from "../../layouts/Layout.astro";
 import QrCodeCard from "../../components/QrCodeCard.astro";
+import ProjectCard from "../../components/ProjectCard.astro";
 import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/home.json";
 import csStrings from "../../i18n/cs/home.json";
@@ -82,45 +83,25 @@ const t = translations[lang];
         </span>
       </a>
 
-      <!-- This Site project card -->
-      <a
+      <!-- Project cards. Shared component with the /projects index page; same visual
+           vocabulary, just shorter copy here since the index has room for a richer blurb. -->
+      <ProjectCard
         href={localePath(lang, "project")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-tertiary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Icon name="material-symbols:rocket-launch" class="size-6 text-tertiary" aria-hidden="true" />
-          <h2 class="font-headline text-2xl font-bold group-hover:text-tertiary transition-colors">
-            {t.cards.thisSite.title}
-          </h2>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
-          {t.cards.thisSite.description}
-        </p>
-        <span class="font-label text-sm uppercase tracking-widest text-tertiary flex items-center gap-1">
-          {t.cards.thisSite.cta}
-          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
-        </span>
-      </a>
-
-      <!-- StrongTypes project card -->
-      <a
+        icon="rocket-launch"
+        accent="tertiary"
+        title={t.cards.thisSite.title}
+        description={t.cards.thisSite.description}
+        cta={t.cards.thisSite.cta}
+      />
+      <ProjectCard
         href={localePath(lang, "strong-types")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col md:col-span-2 lg:col-span-1"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Icon name="material-symbols:package-2" class="size-6 text-primary" aria-hidden="true" />
-          <h2 class="font-headline text-2xl font-bold group-hover:text-primary transition-colors">
-            {t.cards.strongTypes.title}
-          </h2>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
-          {t.cards.strongTypes.description}
-        </p>
-        <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
-          {t.cards.strongTypes.cta}
-          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
-        </span>
-      </a>
+        icon="package-2"
+        accent="primary"
+        title={t.cards.strongTypes.title}
+        description={t.cards.strongTypes.description}
+        cta={t.cards.strongTypes.cta}
+        class="md:col-span-2 lg:col-span-1"
+      />
     </div>
   </section>
 </Layout>

--- a/frontend/src/pages/[...lang]/index.astro
+++ b/frontend/src/pages/[...lang]/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Icon } from "astro-icon/components";
 import Layout from "../../layouts/Layout.astro";
 import QrCodeCard from "../../components/QrCodeCard.astro";
 import ProjectCard from "../../components/ProjectCard.astro";
@@ -71,25 +70,17 @@ const tProjects = projectTranslations[lang];
 
     <!-- Cards -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl">
-      <!-- About Me card -->
-      <a
+      <!-- About Me card. Same <ProjectCard> component as the project cards below
+           — visually identical, no point keeping inline markup just because the
+           page it links to isn't a "project" per se. -->
+      <ProjectCard
         href={localePath(lang, "about")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Icon name="material-symbols:person" class="size-6 text-primary" aria-hidden="true" />
-          <h2 class="font-headline text-2xl font-bold group-hover:text-primary transition-colors">
-            {t.cards.about.title}
-          </h2>
-        </div>
-        <p class="text-on-surface-variant leading-relaxed mb-6 flex-1">
-          {t.cards.about.description}
-        </p>
-        <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
-          {t.cards.about.cta}
-          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
-        </span>
-      </a>
+        icon="person"
+        accent="primary"
+        title={t.cards.about.title}
+        description={t.cards.about.description}
+        cta={t.cards.about.cta}
+      />
 
       <!-- Project cards. Shared component AND shared content with the /projects
            index — both pages read from projects.json so a copy edit there

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -4,11 +4,15 @@ import Layout from "../../layouts/Layout.astro";
 import IconGitHub from "../../components/icons/IconGitHub.astro";
 import ArchitectureDiagram from "../../components/ArchitectureDiagram.astro";
 import OnThisPage from "../../components/OnThisPage.astro";
-import { locales, defaultLocale, type Locale } from "../../i18n/utils";
+import Breadcrumb from "../../components/Breadcrumb.astro";
+import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/project.json";
 import csStrings from "../../i18n/cs/project.json";
+import enCommon from "../../i18n/en/common.json";
+import csCommon from "../../i18n/cs/common.json";
 
 const translations = { en: enStrings, cs: csStrings };
+const commonTranslations = { en: enCommon, cs: csCommon };
 
 export function getStaticPaths() {
   return locales.map((lang) => ({
@@ -18,6 +22,7 @@ export function getStaticPaths() {
 
 const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
+const tCommon = commonTranslations[lang];
 
 const tocItems = [
   { id: "hero", label: t.toc.overview },
@@ -31,8 +36,13 @@ const tocItems = [
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="project" lang={lang}>
-  <div class="xl:grid xl:grid-cols-[1fr_220px] xl:gap-12 max-w-7xl mx-auto px-4 md:px-8 relative">
+  <div class="max-w-7xl mx-auto px-4 md:px-8 relative">
     <div>
+      <Breadcrumb
+        ariaLabel={tCommon.a11y.breadcrumb}
+        items={[{ label: tCommon.nav.projects, href: localePath(lang, "projects") }, { label: tCommon.nav.projectThisSite }]}
+        class="mb-8"
+      />
       <!-- Hero / Intro Section -->
       <section id="hero" class="mb-24">
         <div class="grid grid-cols-1 md:grid-cols-12 gap-12 items-start">

--- a/frontend/src/pages/[...lang]/projects.astro
+++ b/frontend/src/pages/[...lang]/projects.astro
@@ -1,6 +1,6 @@
 ---
-import { Icon } from "astro-icon/components";
 import Layout from "../../layouts/Layout.astro";
+import ProjectCard from "../../components/ProjectCard.astro";
 import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/projects.json";
 import csStrings from "../../i18n/cs/projects.json";
@@ -29,48 +29,27 @@ const t = translations[lang];
       </p>
     </div>
 
-    <!-- Project cards. Same shape as the home-page cards so the visual vocabulary is consistent;
-         this page exists as a category landing so the nav's "Projects" link has somewhere
-         meaningful to point, and so each project gets a richer description than the home page
-         can afford. -->
+    <!-- Project cards. Same component as the home page so the visual vocabulary stays
+         consistent; this page exists as a category landing so the nav's "Projects" link
+         has somewhere meaningful to point, and so each project gets a richer (multi-
+         paragraph) description than the home page can afford. -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mb-24">
-      <a
+      <ProjectCard
         href={localePath(lang, "project")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-tertiary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Icon name="material-symbols:rocket-launch" class="size-6 text-tertiary" aria-hidden="true" />
-          <h2 class="font-headline text-2xl font-bold group-hover:text-tertiary transition-colors">
-            {t.items.thisSite.title}
-          </h2>
-        </div>
-        <div class="text-on-surface-variant leading-relaxed mb-6 flex-1 space-y-3">
-          {t.items.thisSite.description.map((paragraph) => <p>{paragraph}</p>)}
-        </div>
-        <span class="font-label text-sm uppercase tracking-widest text-tertiary flex items-center gap-1">
-          {t.items.thisSite.cta}
-          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
-        </span>
-      </a>
-
-      <a
+        icon="rocket-launch"
+        accent="tertiary"
+        title={t.items.thisSite.title}
+        description={t.items.thisSite.description}
+        cta={t.items.thisSite.cta}
+      />
+      <ProjectCard
         href={localePath(lang, "strong-types")}
-        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
-      >
-        <div class="flex items-center gap-3 mb-4">
-          <Icon name="material-symbols:package-2" class="size-6 text-primary" aria-hidden="true" />
-          <h2 class="font-headline text-2xl font-bold group-hover:text-primary transition-colors">
-            {t.items.strongTypes.title}
-          </h2>
-        </div>
-        <div class="text-on-surface-variant leading-relaxed mb-6 flex-1 space-y-3">
-          {t.items.strongTypes.description.map((paragraph) => <p>{paragraph}</p>)}
-        </div>
-        <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
-          {t.items.strongTypes.cta}
-          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
-        </span>
-      </a>
+        icon="package-2"
+        accent="primary"
+        title={t.items.strongTypes.title}
+        description={t.items.strongTypes.description}
+        cta={t.items.strongTypes.cta}
+      />
     </div>
   </section>
 </Layout>

--- a/frontend/src/pages/[...lang]/projects.astro
+++ b/frontend/src/pages/[...lang]/projects.astro
@@ -1,0 +1,76 @@
+---
+import { Icon } from "astro-icon/components";
+import Layout from "../../layouts/Layout.astro";
+import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
+import enStrings from "../../i18n/en/projects.json";
+import csStrings from "../../i18n/cs/projects.json";
+
+const translations = { en: enStrings, cs: csStrings };
+
+export function getStaticPaths() {
+  return locales.map((lang) => ({
+    params: { lang: lang === defaultLocale ? undefined : lang },
+  }));
+}
+
+const lang = (Astro.params.lang ?? defaultLocale) as Locale;
+const t = translations[lang];
+---
+
+<Layout title={t.meta.title} description={t.meta.description} activePage="projects" lang={lang}>
+  <section class="max-w-7xl mx-auto px-4 md:px-8">
+    <!-- Hero -->
+    <div class="mb-12 md:mb-16 max-w-3xl">
+      <h1 class="font-headline text-4xl md:text-6xl font-extrabold tracking-tight mb-6 leading-[1.1] text-on-surface">
+        {t.hero.title}
+      </h1>
+      <p class="font-body text-lg md:text-xl text-on-surface-variant leading-relaxed">
+        {t.hero.subtitle}
+      </p>
+    </div>
+
+    <!-- Project cards. Same shape as the home-page cards so the visual vocabulary is consistent;
+         this page exists as a category landing so the nav's "Projects" link has somewhere
+         meaningful to point, and so each project gets a richer description than the home page
+         can afford. -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mb-24">
+      <a
+        href={localePath(lang, "project")}
+        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-tertiary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
+      >
+        <div class="flex items-center gap-3 mb-4">
+          <Icon name="material-symbols:rocket-launch" class="size-6 text-tertiary" aria-hidden="true" />
+          <h2 class="font-headline text-2xl font-bold group-hover:text-tertiary transition-colors">
+            {t.items.thisSite.title}
+          </h2>
+        </div>
+        <div class="text-on-surface-variant leading-relaxed mb-6 flex-1 space-y-3">
+          {t.items.thisSite.description.map((paragraph) => <p>{paragraph}</p>)}
+        </div>
+        <span class="font-label text-sm uppercase tracking-widest text-tertiary flex items-center gap-1">
+          {t.items.thisSite.cta}
+          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+        </span>
+      </a>
+
+      <a
+        href={localePath(lang, "strong-types")}
+        class="group bg-surface-container-lowest p-8 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex flex-col"
+      >
+        <div class="flex items-center gap-3 mb-4">
+          <Icon name="material-symbols:package-2" class="size-6 text-primary" aria-hidden="true" />
+          <h2 class="font-headline text-2xl font-bold group-hover:text-primary transition-colors">
+            {t.items.strongTypes.title}
+          </h2>
+        </div>
+        <div class="text-on-surface-variant leading-relaxed mb-6 flex-1 space-y-3">
+          {t.items.strongTypes.description.map((paragraph) => <p>{paragraph}</p>)}
+        </div>
+        <span class="font-label text-sm uppercase tracking-widest text-primary flex items-center gap-1">
+          {t.items.strongTypes.cta}
+          <Icon name="material-symbols:arrow-forward" class="size-4 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
+        </span>
+      </a>
+    </div>
+  </section>
+</Layout>

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -1,0 +1,266 @@
+---
+import { Icon } from "astro-icon/components";
+import Layout from "../../layouts/Layout.astro";
+import IconGitHub from "../../components/icons/IconGitHub.astro";
+import { locales, defaultLocale, type Locale } from "../../i18n/utils";
+import enStrings from "../../i18n/en/strong-types.json";
+import csStrings from "../../i18n/cs/strong-types.json";
+
+const translations = { en: enStrings, cs: csStrings };
+
+export function getStaticPaths() {
+  return locales.map((lang) => ({
+    params: { lang: lang === defaultLocale ? undefined : lang },
+  }));
+}
+
+const lang = (Astro.params.lang ?? defaultLocale) as Locale;
+const t = translations[lang];
+
+const githubUrl = "https://github.com/KaliCZ/StrongTypes";
+const nugetUrl = "https://www.nuget.org/packages/Kalicz.StrongTypes";
+
+const linkIconMap: Record<string, string> = {
+  github: "material-symbols:code",
+  package: "material-symbols:package-2",
+  database: "material-symbols:database",
+  science: "material-symbols:science",
+};
+---
+
+<Layout title={t.meta.title} description={t.meta.description} activePage="strong-types" lang={lang}>
+  <div class="max-w-7xl mx-auto px-4 md:px-8">
+    <!-- Hero -->
+    <section class="mb-24 md:mb-32">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-start">
+        <div class="lg:col-span-8">
+          <div class="flex items-center gap-2 mb-6 font-label text-xs uppercase tracking-widest text-primary">
+            <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
+            <span>{t.hero.tagline}</span>
+          </div>
+          <h1 class="font-headline text-4xl md:text-6xl font-extrabold tracking-tight mb-8 leading-[1.1] text-on-surface">
+            {t.hero.titlePrefix}<span class="gradient-text text-primary bg-linear-to-r from-primary to-tertiary"
+              >{t.hero.titleHighlight}</span
+            >{t.hero.titleSuffix}
+          </h1>
+          <p class="font-body text-lg md:text-xl text-on-surface-variant max-w-2xl leading-relaxed mb-10">
+            {t.hero.description}
+          </p>
+
+          <div class="flex flex-wrap items-center gap-3 mb-8">
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="bg-on-surface text-surface px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
+            >
+              <IconGitHub class="w-4 h-4" />
+              {t.hero.primaryCta}
+            </a>
+            <a
+              href={nugetUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="bg-primary text-on-primary px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
+            >
+              <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
+              {t.hero.secondaryCta}
+            </a>
+          </div>
+
+          <!-- Install command -->
+          <div class="bg-surface-container rounded-xl border border-outline-variant/40 p-1 max-w-xl">
+            <div class="flex items-center gap-2 px-3 pt-2 pb-1 font-label text-[10px] uppercase tracking-widest text-on-surface-variant">
+              <Icon name="material-symbols:terminal" class="size-3.5" aria-hidden="true" />
+              {t.hero.installLabel}
+            </div>
+            <div class="flex items-center justify-between gap-3 px-3 pb-3 pt-1">
+              <code class="font-mono text-sm md:text-[15px] text-on-surface truncate" data-install-command>
+                {t.hero.install}
+              </code>
+              <button
+                type="button"
+                data-copy-install
+                class="shrink-0 p-2 rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors cursor-pointer"
+                aria-label={t.hero.copyAriaLabel}
+                title={t.hero.copyAriaLabel}
+                data-copied-msg={t.hero.copied}
+                data-copy-failed-msg={t.hero.copyFailed}
+              >
+                <Icon name="material-symbols:content-copy" class="size-4 copy-idle" aria-hidden="true" />
+                <Icon name="material-symbols:check" class="size-4 hidden copy-done" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quick facts card -->
+        <aside class="lg:col-span-4 bg-surface-container p-8 rounded-xl border border-outline-variant/40 shadow-sm">
+          <h2 class="font-headline font-bold text-xl mb-6 flex items-center gap-2 text-on-surface">
+            <Icon name="material-symbols:bolt" class="size-6 text-tertiary" aria-hidden="true" />
+            {t.facts.title}
+          </h2>
+          <dl class="space-y-5">
+            {
+              t.facts.items.map((fact) => (
+                <div>
+                  <dt class="font-label text-xs text-on-surface-variant uppercase mb-1">{fact.label}</dt>
+                  <dd class="font-body font-semibold text-on-surface">{fact.value}</dd>
+                </div>
+              ))
+            }
+          </dl>
+        </aside>
+      </div>
+    </section>
+
+    <!-- Why -->
+    <section class="mb-24 md:mb-32">
+      <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
+        {t.why.title}
+      </h2>
+      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
+        {t.why.subtitle}
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {
+          t.why.points.map((point) => (
+            <div class="bg-surface-container p-8 rounded-xl border border-outline-variant/40">
+              <Icon name={`material-symbols:${point.icon.replace(/_/g, "-")}`} class="size-7 text-primary mb-4 block" aria-hidden="true" />
+              <h3 class="font-headline font-bold text-lg mb-2 text-on-surface">{point.title}</h3>
+              <p class="font-body text-on-surface-variant text-sm leading-relaxed">{point.description}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="mb-24 md:mb-32">
+      <h2 class="font-headline text-3xl font-bold mb-12 text-on-surface">
+        {t.features.title}
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {
+          t.features.groups.map((group) => {
+            const accent = group.color === "tertiary" ? "text-tertiary" : "text-primary";
+            const dot = group.color === "tertiary" ? "bg-tertiary" : "bg-primary";
+            return (
+              <div class="bg-surface-container p-8 rounded-xl border border-outline-variant/40">
+                <h3 class:list={["font-label text-sm uppercase tracking-widest mb-6 flex items-center gap-2", accent]}>
+                  <Icon name={`material-symbols:${group.icon.replace(/_/g, "-")}`} class="size-[18px]" aria-hidden="true" />
+                  {group.heading}
+                </h3>
+                <ul class="space-y-4">
+                  {group.items.map((item) => (
+                    <li class="font-body text-on-surface-variant">
+                      <div class="flex items-start gap-2">
+                        <span class:list={["w-1.5 h-1.5 rounded-full shrink-0 mt-2", dot]} aria-hidden="true" />
+                        <div>
+                          <code class="font-mono text-sm text-on-surface">{item.name}</code>
+                          <p class="text-sm text-on-surface-variant mt-1 leading-relaxed">{item.description}</p>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })
+        }
+      </div>
+    </section>
+
+    <!-- Examples -->
+    <section class="mb-24 md:mb-32">
+      <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
+        {t.examples.title}
+      </h2>
+      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
+        {t.examples.subtitle}
+      </p>
+      <div class="space-y-6">
+        {
+          t.examples.items.map((example) => (
+            <div class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
+              <div class="px-6 pt-5 pb-3 border-b border-outline-variant/30">
+                <h3 class="font-headline font-bold text-on-surface text-lg">{example.title}</h3>
+                <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{example.description}</p>
+              </div>
+              <pre class="px-6 py-5 overflow-x-auto bg-surface-container-low font-mono text-sm leading-relaxed text-on-surface">
+                <code>{example.code}</code>
+              </pre>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Links -->
+    <section class="mb-24">
+      <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
+        {t.links.title}
+      </h2>
+      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
+        {t.links.subtitle}
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {
+          t.links.items.map((item) => {
+            const iconName = linkIconMap[item.icon] ?? "material-symbols:link";
+            const isGitHub = item.icon === "github";
+            return (
+              <a
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="group bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/20 hover:border-primary/30 transition-all duration-300 shadow-sm hover:shadow-md flex items-start gap-4"
+              >
+                <div class="shrink-0 size-10 rounded-lg bg-primary/10 grid place-items-center text-primary group-hover:bg-primary/15 transition-colors">
+                  {isGitHub ? <IconGitHub class="w-5 h-5" /> : <Icon name={iconName} class="size-5" aria-hidden="true" />}
+                </div>
+                <div class="flex-1 min-w-0">
+                  <h3 class="font-headline font-bold text-on-surface group-hover:text-primary transition-colors">{item.title}</h3>
+                  <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{item.description}</p>
+                  <span class="font-mono text-xs text-on-surface-variant mt-3 inline-flex items-center gap-1">
+                    {item.cta}
+                    <Icon
+                      name="material-symbols:arrow-outward"
+                      class="size-3.5 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+                      aria-hidden="true"
+                    />
+                  </span>
+                </div>
+              </a>
+            );
+          })
+        }
+      </div>
+    </section>
+  </div>
+</Layout>
+
+<script>
+  const copyButton = document.querySelector<HTMLButtonElement>("[data-copy-install]");
+  const installCommand = document.querySelector<HTMLElement>("[data-install-command]");
+
+  copyButton?.addEventListener("click", async () => {
+    if (!installCommand) return;
+    const text = installCommand.textContent?.trim() ?? "";
+    const idle = copyButton.querySelector<HTMLElement>(".copy-idle");
+    const done = copyButton.querySelector<HTMLElement>(".copy-done");
+
+    try {
+      await navigator.clipboard.writeText(text);
+      idle?.classList.add("hidden");
+      done?.classList.remove("hidden");
+      (window as any).__showSnackbar?.(copyButton.dataset.copiedMsg ?? "Copied", "success");
+      setTimeout(() => {
+        idle?.classList.remove("hidden");
+        done?.classList.add("hidden");
+      }, 2000);
+    } catch {
+      (window as any).__showSnackbar?.(copyButton.dataset.copyFailedMsg ?? "Copy failed", "error");
+    }
+  });
+</script>

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -31,9 +31,9 @@ const linkIconMap: Record<string, string> = {
 <Layout title={t.meta.title} description={t.meta.description} activePage="strong-types" lang={lang}>
   <div class="max-w-7xl mx-auto px-4 md:px-8">
     <!-- Hero -->
-    <section class="mb-24 md:mb-32">
-      <div class="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-start">
-        <div class="lg:col-span-8">
+    <section class="mb-16 md:mb-20">
+      <div class="max-w-4xl">
+        <div>
           <div class="flex items-center gap-2 mb-6 font-label text-xs uppercase tracking-widest text-primary">
             <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
             <span>{t.hero.tagline}</span>
@@ -106,24 +106,6 @@ const linkIconMap: Record<string, string> = {
             </div>
           </div>
         </div>
-
-        <!-- Quick facts card -->
-        <aside class="lg:col-span-4 bg-surface-container p-8 rounded-xl border border-outline-variant/40 shadow-sm">
-          <h2 class="font-headline font-bold text-xl mb-6 flex items-center gap-2 text-on-surface">
-            <Icon name="material-symbols:bolt" class="size-6 text-tertiary" aria-hidden="true" />
-            {t.facts.title}
-          </h2>
-          <dl class="space-y-5">
-            {
-              t.facts.items.map((fact) => (
-                <div>
-                  <dt class="font-label text-xs text-on-surface-variant uppercase mb-1">{fact.label}</dt>
-                  <dd class="font-body font-semibold text-on-surface">{fact.value}</dd>
-                </div>
-              ))
-            }
-          </dl>
-        </aside>
       </div>
     </section>
 
@@ -159,37 +141,12 @@ const linkIconMap: Record<string, string> = {
       </div>
     </section>
 
-    <!-- Anatomy -->
-    <section class="mb-24 md:mb-32">
-      <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
-        {t.anatomy.title}
-      </h2>
-      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
-        {t.anatomy.subtitle}
-      </p>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {
-          t.anatomy.items.map((item) => (
-            <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden flex flex-col">
-              <div class="bg-white p-6 flex items-center justify-center">
-                <img src={item.src} alt={item.alt} loading="lazy" decoding="async" class="block max-w-full h-auto" />
-              </div>
-              <figcaption class="p-6 border-t border-outline-variant/30">
-                <h3 class="font-headline font-bold text-on-surface mb-1">{item.title}</h3>
-                <p class="font-body text-sm text-on-surface-variant leading-relaxed">{item.description}</p>
-              </figcaption>
-            </figure>
-          ))
-        }
-      </div>
-    </section>
-
     <!-- Features -->
     <section class="mb-24 md:mb-32">
       <h2 class="font-headline text-3xl font-bold mb-12 text-on-surface">
         {t.features.title}
       </h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
         {
           t.features.groups.map((group) => {
             const accent = group.color === "tertiary" ? "text-tertiary" : "text-primary";
@@ -200,14 +157,14 @@ const linkIconMap: Record<string, string> = {
                   <Icon name={`material-symbols:${group.icon.replace(/_/g, "-")}`} class="size-[18px]" aria-hidden="true" />
                   {group.heading}
                 </h3>
-                <ul class="space-y-4">
+                <ul class="space-y-5">
                   {group.items.map((item) => (
                     <li class="font-body text-on-surface-variant">
                       <div class="flex items-start gap-2">
-                        <span class:list={["w-1.5 h-1.5 rounded-full shrink-0 mt-2", dot]} aria-hidden="true" />
+                        <span class:list={["w-1.5 h-1.5 rounded-full shrink-0 mt-[10px]", dot]} aria-hidden="true" />
                         <div>
-                          <code class="font-mono text-sm text-on-surface">{item.name}</code>
-                          <p class="text-sm text-on-surface-variant mt-1 leading-relaxed">{item.description}</p>
+                          <code class="font-mono text-[15px] font-bold text-on-surface block leading-snug">{item.name}</code>
+                          <p class="font-body text-sm text-on-surface-variant mt-1.5 leading-relaxed">{item.description}</p>
                         </div>
                       </div>
                     </li>
@@ -218,6 +175,23 @@ const linkIconMap: Record<string, string> = {
           })
         }
       </div>
+
+      <!-- Package layout diagram. -->
+      <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
+        <div class="bg-white p-6 flex items-center justify-center">
+          <img
+            src={t.packageLayout.diagram.src}
+            alt={t.packageLayout.diagram.alt}
+            loading="lazy"
+            decoding="async"
+            class="block max-w-full h-auto"
+          />
+        </div>
+        <figcaption class="p-6 border-t border-outline-variant/30">
+          <h3 class="font-headline font-bold text-on-surface mb-1">{t.packageLayout.title}</h3>
+          <p class="font-body text-sm text-on-surface-variant leading-relaxed">{t.packageLayout.description}</p>
+        </figcaption>
+      </figure>
     </section>
 
     <!-- Examples -->
@@ -239,9 +213,10 @@ const linkIconMap: Record<string, string> = {
                   <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{example.description}</p>
                 </div>
                 <div class:list={["grid", hasDiagram ? "lg:grid-cols-2 lg:divide-x lg:divide-outline-variant/30" : "grid-cols-1"]}>
-                  <pre class="px-6 py-5 overflow-x-auto bg-surface-container-low font-mono text-sm leading-relaxed text-on-surface m-0">
-                    <code>{example.code}</code>
-                  </pre>
+                  <pre
+                    class="px-6 py-5 overflow-x-auto bg-surface-container-low font-mono text-sm leading-relaxed text-on-surface m-0"
+                    set:text={example.code}
+                  />
                   {hasDiagram && (
                     <div class="bg-white p-6 flex items-center justify-center">
                       <img

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -68,6 +68,19 @@ const linkIconMap: Record<string, string> = {
             </a>
           </div>
 
+          <!-- Live status badges -->
+          <ul class="flex flex-wrap items-center gap-2 mb-6" aria-label={t.badges.ariaLabel}>
+            {
+              t.badges.items.map((badge) => (
+                <li>
+                  <a href={badge.href} target="_blank" rel="noopener noreferrer" class="inline-block">
+                    <img src={badge.src} alt={badge.alt} loading="lazy" class="block h-5" />
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+
           <!-- Install command -->
           <div class="bg-surface-container rounded-xl border border-outline-variant/40 p-1 max-w-xl">
             <div class="flex items-center gap-2 px-3 pt-2 pb-1 font-label text-[10px] uppercase tracking-widest text-on-surface-variant">
@@ -119,9 +132,20 @@ const linkIconMap: Record<string, string> = {
       <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
         {t.why.title}
       </h2>
-      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
+      <p class="font-body text-on-surface-variant mb-10 max-w-3xl text-lg leading-relaxed">
         {t.why.subtitle}
       </p>
+
+      <!-- Featured diagram. Wrapped in a forced light surface because the SVG colors are hardcoded. -->
+      <figure class="mb-12 bg-white rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
+        <img src={t.why.diagram.src} alt={t.why.diagram.alt} loading="lazy" decoding="async" class="block w-full h-auto p-6" />
+        <figcaption
+          class="px-6 pb-5 pt-1 text-sm text-on-surface-variant border-t border-outline-variant/30 bg-surface-container-low font-body italic"
+        >
+          {t.why.diagram.caption}
+        </figcaption>
+      </figure>
+
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {
           t.why.points.map((point) => (
@@ -130,6 +154,31 @@ const linkIconMap: Record<string, string> = {
               <h3 class="font-headline font-bold text-lg mb-2 text-on-surface">{point.title}</h3>
               <p class="font-body text-on-surface-variant text-sm leading-relaxed">{point.description}</p>
             </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Anatomy -->
+    <section class="mb-24 md:mb-32">
+      <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
+        {t.anatomy.title}
+      </h2>
+      <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
+        {t.anatomy.subtitle}
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {
+          t.anatomy.items.map((item) => (
+            <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden flex flex-col">
+              <div class="bg-white p-6 flex items-center justify-center">
+                <img src={item.src} alt={item.alt} loading="lazy" decoding="async" class="block max-w-full h-auto" />
+              </div>
+              <figcaption class="p-6 border-t border-outline-variant/30">
+                <h3 class="font-headline font-bold text-on-surface mb-1">{item.title}</h3>
+                <p class="font-body text-sm text-on-surface-variant leading-relaxed">{item.description}</p>
+              </figcaption>
+            </figure>
           ))
         }
       </div>
@@ -179,19 +228,35 @@ const linkIconMap: Record<string, string> = {
       <p class="font-body text-on-surface-variant mb-12 max-w-3xl text-lg leading-relaxed">
         {t.examples.subtitle}
       </p>
-      <div class="space-y-6">
+      <div class="space-y-8">
         {
-          t.examples.items.map((example) => (
-            <div class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
-              <div class="px-6 pt-5 pb-3 border-b border-outline-variant/30">
-                <h3 class="font-headline font-bold text-on-surface text-lg">{example.title}</h3>
-                <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{example.description}</p>
+          t.examples.items.map((example) => {
+            const hasDiagram = "diagram" in example && example.diagram;
+            return (
+              <div class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
+                <div class="px-6 pt-5 pb-3 border-b border-outline-variant/30">
+                  <h3 class="font-headline font-bold text-on-surface text-lg">{example.title}</h3>
+                  <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{example.description}</p>
+                </div>
+                <div class:list={["grid", hasDiagram ? "lg:grid-cols-2 lg:divide-x lg:divide-outline-variant/30" : "grid-cols-1"]}>
+                  <pre class="px-6 py-5 overflow-x-auto bg-surface-container-low font-mono text-sm leading-relaxed text-on-surface m-0">
+                    <code>{example.code}</code>
+                  </pre>
+                  {hasDiagram && (
+                    <div class="bg-white p-6 flex items-center justify-center">
+                      <img
+                        src={example.diagram!.src}
+                        alt={example.diagram!.alt}
+                        loading="lazy"
+                        decoding="async"
+                        class="block max-w-full h-auto"
+                      />
+                    </div>
+                  )}
+                </div>
               </div>
-              <pre class="px-6 py-5 overflow-x-auto bg-surface-container-low font-mono text-sm leading-relaxed text-on-surface">
-                <code>{example.code}</code>
-              </pre>
-            </div>
-          ))
+            );
+          })
         }
       </div>
     </section>

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -1,12 +1,17 @@
 ---
 import { Icon } from "astro-icon/components";
 import Layout from "../../layouts/Layout.astro";
+import OnThisPage from "../../components/OnThisPage.astro";
+import Breadcrumb from "../../components/Breadcrumb.astro";
 import IconGitHub from "../../components/icons/IconGitHub.astro";
-import { locales, defaultLocale, type Locale } from "../../i18n/utils";
+import { locales, defaultLocale, localePath, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/strong-types.json";
 import csStrings from "../../i18n/cs/strong-types.json";
+import enCommon from "../../i18n/en/common.json";
+import csCommon from "../../i18n/cs/common.json";
 
 const translations = { en: enStrings, cs: csStrings };
+const commonTranslations = { en: enCommon, cs: csCommon };
 
 export function getStaticPaths() {
   return locales.map((lang) => ({
@@ -16,6 +21,7 @@ export function getStaticPaths() {
 
 const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
+const tCommon = commonTranslations[lang];
 
 const githubUrl = "https://github.com/KaliCZ/StrongTypes";
 const nugetUrl = "https://www.nuget.org/packages/Kalicz.StrongTypes";
@@ -26,63 +32,41 @@ const linkIconMap: Record<string, string> = {
   database: "material-symbols:database",
   science: "material-symbols:science",
 };
+
+const tocItems = [
+  { id: "overview", label: t.toc.overview },
+  { id: "why", label: t.toc.why },
+  { id: "features", label: t.toc.features },
+  { id: "examples", label: t.toc.examples },
+  { id: "get-started", label: t.toc.getStarted },
+];
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="strong-types" lang={lang}>
   <div class="max-w-7xl mx-auto px-4 md:px-8">
-    <!-- Hero -->
-    <section class="mb-16 md:mb-20">
-      <div class="max-w-4xl">
-        <div>
-          <div class="flex items-center gap-2 mb-6 font-label text-xs uppercase tracking-widest text-primary">
-            <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
-            <span>{t.hero.tagline}</span>
-          </div>
+    <Breadcrumb
+      ariaLabel={tCommon.a11y.breadcrumb}
+      items={[{ label: tCommon.nav.projects, href: localePath(lang, "projects") }, { label: tCommon.nav.projectStrongTypes }]}
+      class="mb-8"
+    />
+    <!-- Hero. Two columns at lg+: prose on the left, the call-to-action stack
+         (CTAs, badges, install command) on the right so neither half feels empty. -->
+    <section id="overview" class="mb-16 md:mb-20">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-center">
+        <div class="lg:col-span-7">
           <h1 class="font-headline text-4xl md:text-6xl font-extrabold tracking-tight mb-8 leading-[1.1] text-on-surface">
             {t.hero.titlePrefix}<span class="gradient-text text-primary bg-linear-to-r from-primary to-tertiary"
               >{t.hero.titleHighlight}</span
             >{t.hero.titleSuffix}
           </h1>
-          <p class="font-body text-lg md:text-xl text-on-surface-variant max-w-2xl leading-relaxed mb-10">
+          <p class="font-body text-lg md:text-xl text-on-surface-variant leading-relaxed">
             {t.hero.description}
           </p>
+        </div>
 
-          <div class="flex flex-wrap items-center gap-3 mb-8">
-            <a
-              href={githubUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="bg-on-surface text-surface px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
-            >
-              <IconGitHub class="w-4 h-4" />
-              {t.hero.primaryCta}
-            </a>
-            <a
-              href={nugetUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="bg-primary text-on-primary px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
-            >
-              <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
-              {t.hero.secondaryCta}
-            </a>
-          </div>
-
-          <!-- Live status badges -->
-          <ul class="flex flex-wrap items-center gap-2 mb-6" aria-label={t.badges.ariaLabel}>
-            {
-              t.badges.items.map((badge) => (
-                <li>
-                  <a href={badge.href} target="_blank" rel="noopener noreferrer" class="inline-block">
-                    <img src={badge.src} alt={badge.alt} loading="lazy" class="block h-5" />
-                  </a>
-                </li>
-              ))
-            }
-          </ul>
-
+        <div class="lg:col-span-5 flex flex-col gap-6">
           <!-- Install command -->
-          <div class="bg-surface-container rounded-xl border border-outline-variant/40 p-1 max-w-xl">
+          <div class="bg-surface-container rounded-xl border border-outline-variant/40 p-1">
             <div class="flex items-center gap-2 px-3 pt-2 pb-1 font-label text-[10px] uppercase tracking-widest text-on-surface-variant">
               <Icon name="material-symbols:terminal" class="size-3.5" aria-hidden="true" />
               {t.hero.installLabel}
@@ -105,12 +89,46 @@ const linkIconMap: Record<string, string> = {
               </button>
             </div>
           </div>
+
+          <!-- Live status badges -->
+          <ul class="flex flex-wrap items-center gap-2" aria-label={t.badges.ariaLabel}>
+            {
+              t.badges.items.map((badge) => (
+                <li>
+                  <a href={badge.href} target="_blank" rel="noopener noreferrer" class="inline-block">
+                    <img src={badge.src} alt={badge.alt} loading="lazy" class="block h-5" />
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+
+          <div class="flex flex-wrap items-center gap-3">
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="bg-on-surface text-surface px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
+            >
+              <IconGitHub class="w-4 h-4" />
+              {t.hero.primaryCta}
+            </a>
+            <a
+              href={nugetUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="bg-primary text-on-primary px-5 py-2.5 font-headline font-bold rounded-lg shadow-sm hover:opacity-90 transition-all hover:scale-[1.02] active:scale-95 flex items-center gap-2"
+            >
+              <Icon name="material-symbols:package-2" class="size-4" aria-hidden="true" />
+              {t.hero.secondaryCta}
+            </a>
+          </div>
         </div>
       </div>
     </section>
 
     <!-- Why -->
-    <section class="mb-24 md:mb-32">
+    <section id="why" class="mb-24 md:mb-32">
       <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
         {t.why.title}
       </h2>
@@ -120,7 +138,14 @@ const linkIconMap: Record<string, string> = {
 
       <!-- Featured diagram. Wrapped in a forced light surface because the SVG colors are hardcoded. -->
       <figure class="mb-12 bg-white rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
-        <img src={t.why.diagram.src} alt={t.why.diagram.alt} loading="lazy" decoding="async" class="block w-full h-auto p-6" />
+        <img
+          src={t.why.diagram.src}
+          alt={t.why.diagram.alt}
+          loading="lazy"
+          decoding="async"
+          data-zoomable
+          class="block w-full h-auto p-6 cursor-zoom-in transition-transform hover:scale-[1.01]"
+        />
         <figcaption
           class="px-6 pb-5 pt-1 text-sm text-on-surface-variant border-t border-outline-variant/30 bg-surface-container-low font-body italic"
         >
@@ -142,7 +167,7 @@ const linkIconMap: Record<string, string> = {
     </section>
 
     <!-- Features -->
-    <section class="mb-24 md:mb-32">
+    <section id="features" class="mb-24 md:mb-32">
       <h2 class="font-headline text-3xl font-bold mb-12 text-on-surface">
         {t.features.title}
       </h2>
@@ -184,7 +209,8 @@ const linkIconMap: Record<string, string> = {
             alt={t.packageLayout.diagram.alt}
             loading="lazy"
             decoding="async"
-            class="block max-w-full h-auto"
+            data-zoomable
+            class="block max-w-full h-auto cursor-zoom-in transition-transform hover:scale-[1.01]"
           />
         </div>
         <figcaption class="p-6 border-t border-outline-variant/30">
@@ -195,7 +221,7 @@ const linkIconMap: Record<string, string> = {
     </section>
 
     <!-- Examples -->
-    <section class="mb-24 md:mb-32">
+    <section id="examples" class="mb-24 md:mb-32">
       <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
         {t.examples.title}
       </h2>
@@ -224,7 +250,8 @@ const linkIconMap: Record<string, string> = {
                         alt={example.diagram!.alt}
                         loading="lazy"
                         decoding="async"
-                        class="block max-w-full h-auto"
+                        data-zoomable
+                        class="block max-w-full h-auto cursor-zoom-in transition-transform hover:scale-[1.01]"
                       />
                     </div>
                   )}
@@ -237,7 +264,7 @@ const linkIconMap: Record<string, string> = {
     </section>
 
     <!-- Links -->
-    <section class="mb-24">
+    <section id="get-started" class="mb-24">
       <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
         {t.links.title}
       </h2>
@@ -278,6 +305,31 @@ const linkIconMap: Record<string, string> = {
       </div>
     </section>
   </div>
+
+  <OnThisPage title={t.toc.title} items={tocItems} />
+
+  <!-- Diagram lightbox. Single shared <dialog> instance; we clone the clicked source <img>
+       into [data-lightbox-slot] each time so the lightbox renders the already-loaded image
+       at its natural size from the very first frame (no broken-image flash, no zero-size
+       collapse from an empty src=""). Native <dialog> gives us free Escape-to-close and
+       focus management for the modal. -->
+  <dialog
+    id="diagram-lightbox"
+    aria-label={t.lightbox.dialogLabel}
+    class="m-auto p-0 border-0 bg-transparent rounded-xl shadow-2xl backdrop:bg-black/70 backdrop:backdrop-blur-sm max-w-[95vw] max-h-[95vh]"
+  >
+    <div class="relative bg-white p-6 rounded-xl overflow-hidden min-w-[280px] min-h-[200px]">
+      <button
+        type="button"
+        data-lightbox-close
+        aria-label={t.lightbox.closeLabel}
+        class="absolute top-3 right-3 z-10 size-9 grid place-items-center rounded-full bg-black/60 text-white hover:bg-black/80 transition-colors cursor-pointer"
+      >
+        <Icon name="material-symbols:close" class="size-5" aria-hidden="true" />
+      </button>
+      <div data-lightbox-slot class="flex items-center justify-center"></div>
+    </div>
+  </dialog>
 </Layout>
 
 <script>
@@ -302,5 +354,60 @@ const linkIconMap: Record<string, string> = {
     } catch {
       (window as any).__showSnackbar?.(copyButton.dataset.copyFailedMsg ?? "Copy failed", "error");
     }
+  });
+
+  // Diagram lightbox: clicking any <img data-zoomable> clones it into the dialog slot
+  // and opens the shared <dialog>. tabindex=0 + keydown handlers make the imgs keyboard-
+  // activatable; cloning the already-loaded image avoids the broken-image flash that comes
+  // from setting .src on a placeholder element with an empty initial src.
+  const lightbox = document.getElementById("diagram-lightbox") as HTMLDialogElement | null;
+  const lightboxSlot = lightbox?.querySelector<HTMLElement>("[data-lightbox-slot]");
+  const lightboxClose = document.querySelector<HTMLButtonElement>("[data-lightbox-close]");
+
+  function openLightbox(source: HTMLImageElement) {
+    if (!lightbox || !lightboxSlot) return;
+    const clone = source.cloneNode(true) as HTMLImageElement;
+    clone.removeAttribute("data-zoomable");
+    clone.removeAttribute("tabindex");
+    clone.removeAttribute("role");
+    // Scale up to fit ~85% of viewport while preserving aspect ratio. The diagrams
+    // are SVGs so scaling up renders crisply, and the lightbox should be _bigger_
+    // than the inline rendering — not pinned to whatever pixel size the SVG's
+    // viewBox happens to declare. Setting explicit width/height as attributes
+    // also reserves layout space immediately, sidestepping the "freshly cloned
+    // <img> reports naturalWidth = 0 until the cached fetch resolves" problem.
+    const naturalW = source.naturalWidth || 800;
+    const naturalH = source.naturalHeight || 600;
+    const maxW = window.innerWidth * 0.85;
+    const maxH = window.innerHeight * 0.85;
+    const scale = Math.min(maxW / naturalW, maxH / naturalH);
+    clone.width = Math.round(naturalW * scale);
+    clone.height = Math.round(naturalH * scale);
+    // The page-level imgs use loading="lazy"; cloneNode carries that over,
+    // which delays even the cache hit. Force eager.
+    clone.loading = "eager";
+    clone.className = "block object-contain";
+    lightboxSlot.replaceChildren(clone);
+    lightbox.showModal();
+  }
+
+  document.querySelectorAll<HTMLImageElement>("img[data-zoomable]").forEach((img) => {
+    img.tabIndex = 0;
+    img.setAttribute("role", "button");
+    img.addEventListener("click", () => openLightbox(img));
+    img.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        openLightbox(img);
+      }
+    });
+  });
+
+  lightboxClose?.addEventListener("click", () => lightbox?.close());
+
+  // Backdrop click closes. The dialog's own click event fires on the backdrop pseudo-element
+  // by reporting `event.target === dialog` (since clicks on contents bubble from inner elements).
+  lightbox?.addEventListener("click", (event) => {
+    if (event.target === lightbox) lightbox.close();
   });
 </script>

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -43,6 +43,11 @@ test.describe("Page rendering", () => {
     await page.goto("/project");
     await expect(page).toHaveTitle(/Project/);
   });
+
+  test("strong-types page loads", async ({ page }) => {
+    await page.goto("/strong-types");
+    await expect(page).toHaveTitle(/StrongTypes/);
+  });
 });
 
 test.describe("Navigation", () => {

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -44,6 +44,11 @@ test.describe("Page rendering", () => {
     await expect(page).toHaveTitle(/Project/);
   });
 
+  test("projects index page loads", async ({ page }) => {
+    await page.goto("/projects");
+    await expect(page).toHaveTitle(/Projects/);
+  });
+
   test("strong-types page loads", async ({ page }) => {
     await page.goto("/strong-types");
     await expect(page).toHaveTitle(/StrongTypes/);


### PR DESCRIPTION
## Summary

A round of structural and copy work spanning the home page, the new `/projects` index, the `/about` page, and the StrongTypes subpage — plus a couple of internal cleanups (single-array Navbar, shared `<ProjectCard>`).

**Navigation**
- The nav's `Projects` entry now points to a real `/projects` index page (a category landing with one card per project — same visual vocabulary as the home-page cards).
- Desktop keeps a hover dropdown shortcut to jump directly to a specific project; mobile is a plain link to the index (touch has no hover).
- Active state on `/projects`, `/project`, and `/strong-types` all show "Projects" highlighted in the nav.
- Internal: nav items are now described by a single ordered `navItems` array with optional `children` for dropdown parents. Mobile is a single uniform map; order on the bar = order in the array. Replaced the previous three-array (`flatItems` / `projectMenuItems` / `afterItems`) split.

**Page-level wayfinding**
- New generic `<Breadcrumb>` component with proper `aria-current="page"` semantics.
- Project subpages (`/project`, `/strong-types`) now show `Projects → <project name>` above the hero so the reader knows exactly where they are inside the section.

**Home page**
- Hero restructured so the QR card's top edge aligns with the "Software engineer..." subtitle. The card previously sat next to the "What is this page?" heading, which gave it too much air.
- All three cards (About / How I built this site / StrongTypes) now render through the same `<ProjectCard>` component — no inline card markup on the home page.
- Project cards read directly from `projects.json` (same data as `/projects`), so a copy edit lands on both surfaces at once.
- About-Me card extended to two paragraphs (hook + teaser of what's on `/about`) so it doesn't look skimpy next to the project cards.

**Project cards**
- "This Site" → "How I built this site". Adds a second paragraph teasing what's on the page: webpage + hosting, API + hosting, database with event sourcing, CI/CD with E2E tests, "And more."

**StrongTypes page**
- Hero description rewritten to lead with the package name (`Kalicz.StrongTypes`) and the no-code-validations value prop, so visitors landing on the page learn what it is in the first sentence.
- Eyebrow tagline removed — package identity is now carried by the lead sentence + install command box.
- Meta description aligned to "C# NuGet package" wording.

**About page**
- New "About me" section between Skills and Career — a 3-column horizontal-icon card grid with six personal-attribute items (singing, sports, esports, motorcycles, family). Cards reworded for personality (karaoke punchline, ankle-injury sports caveat, amateur-races framing).
- The Personal section sits in a colored band that alternates with Skills above; the band's bottom border acts as the divider before the transparent Career timeline.

**Shared components**
- New `<ProjectCard>` component used by the home page and the `/projects` index — same visual treatment, same accent system. Description accepts both `string` (single-paragraph) and `string[]` (multi-paragraph).

**Other**
- `OnThisPage` simplified: the desktop floating aside is gone; the sticky bottom pill bar is used at all viewport widths. One mental model, frees up horizontal space for content.
- Translations (EN + CS) for all new strings.
- New Playwright test verifying `/projects` loads.
- Cleaned up a stale `desktop={false}` prop on the About page's `<OnThisPage>` left over from the floating-aside era.

## Test plan
- [x] `npm test` passes (backend + frontend Playwright + E2E)
- [x] Build clean (26 pages — both locales for projects, project, strong-types, about render)
- [x] Prettier ran on all touched files
- [x] Manual once-over in dev server — verified hero alignment, About-me band/divider, copy on home + /projects + /about
- [ ] Final once-over in deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)