### PR TITLE
About page: Skills section, shared TOC, and contrast refresh

### DIFF
--- a/frontend/src/components/Footer.astro
+++ b/frontend/src/components/Footer.astro
@@ -24,7 +24,10 @@ interface Props {
 const { lang, t } = Astro.props;
 ---
 
-<footer class="bg-surface-container-low w-full py-12 border-t border-on-surface/5" role="contentinfo">
+<footer
+  class="bg-surface-container-highest dark:bg-surface-container-low w-full py-12 border-t border-outline-variant dark:border-on-surface/5"
+  role="contentinfo"
+>
   <div class="flex flex-col md:flex-row justify-between items-center px-8 max-w-7xl mx-auto gap-6">
     <div class="text-lg font-bold text-on-surface font-headline">kalandra.tech</div>
     <div class="flex items-center gap-6">

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -59,7 +59,7 @@ const navItems = [
 
 <!-- Navigation -->
 <nav
-  class="bg-surface/70 backdrop-blur-xl fixed top-0 w-full z-50 shadow-[0_8px_32px_rgba(0,0,0,0.04)] border-b border-on-surface/5"
+  class="bg-surface-container-high/90 dark:bg-surface/70 backdrop-blur-xl fixed top-0 w-full z-50 shadow-[0_4px_16px_rgba(0,0,0,0.08)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.04)] border-b border-outline-variant dark:border-on-surface/5"
   aria-label={t.a11y.mainNavigation}
 >
   <div class="flex justify-between items-center px-8 py-4 max-w-7xl mx-auto">

--- a/frontend/src/components/OnThisPage.astro
+++ b/frontend/src/components/OnThisPage.astro
@@ -1,0 +1,121 @@
+---
+interface TocItem {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  title: string;
+  items: TocItem[];
+  desktop?: boolean;
+}
+
+const { title, items, desktop = true } = Astro.props;
+---
+
+<!-- Mobile TOC — Sticky Bottom Tab Bar -->
+<nav
+  id="toc-bar"
+  class="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
+  aria-label={title}
+>
+  <div class="flex overflow-x-auto gap-1 px-3 py-2 scrollbar-hide items-center">
+    <span class="shrink-0 font-label text-[10px] uppercase tracking-widest text-on-surface-variant pr-1">{title}</span>
+    <span class="shrink-0 w-px h-4 bg-outline-variant/40" aria-hidden="true"></span>
+    {
+      items.map((item) => (
+        <a
+          href={`#${item.id}`}
+          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
+          data-toc-target={item.id}
+        >
+          {item.label}
+        </a>
+      ))
+    }
+  </div>
+</nav>
+
+{
+  desktop && (
+    <aside class="hidden lg:block">
+      <nav class="sticky top-24 space-y-3" aria-label={title}>
+        <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-4">{title}</h4>
+        {items.map((item) => (
+          <a
+            href={`#${item.id}`}
+            class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
+            data-toc-target={item.id}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+    </aside>
+  )
+}
+
+<style>
+  .toc-link-active {
+    color: var(--color-primary);
+    font-weight: 600;
+    border-left: 2px solid var(--color-primary);
+    padding-left: 0.5rem;
+    margin-left: -0.625rem;
+  }
+  .toc-pill-active {
+    background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+  /* Hide scrollbar for the pill bar */
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+  /* Bottom padding so content isn't hidden behind the sticky bar */
+  @media (max-width: 1023px) {
+    body {
+      padding-bottom: 3.5rem;
+    }
+  }
+</style>
+
+<script>
+  const sections = document.querySelectorAll("section[id]");
+  const tocLinks = document.querySelectorAll(".toc-link");
+  const tocPills = document.querySelectorAll(".toc-pill");
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const id = entry.target.id;
+
+          // Desktop rail
+          tocLinks.forEach((link) => link.classList.remove("toc-link-active"));
+          const activeDesktop = document.querySelector(`.toc-link[data-toc-target="${id}"]`);
+          if (activeDesktop) activeDesktop.classList.add("toc-link-active");
+
+          // Mobile pill bar
+          tocPills.forEach((l) => l.classList.remove("toc-pill-active"));
+          const activePill = document.querySelector(`.toc-pill[data-toc-target="${id}"]`);
+          if (activePill) {
+            activePill.classList.add("toc-pill-active");
+            activePill.scrollIntoView({
+              behavior: "smooth",
+              block: "nearest",
+              inline: "center",
+            });
+          }
+        }
+      });
+    },
+    { rootMargin: "-20% 0px -70% 0px" },
+  );
+
+  sections.forEach((section) => observer.observe(section));
+</script>

--- a/frontend/src/components/OnThisPage.astro
+++ b/frontend/src/components/OnThisPage.astro
@@ -16,7 +16,7 @@ const { title, items, desktop = true } = Astro.props;
 <!-- Mobile TOC — Sticky Bottom Tab Bar -->
 <nav
   id="toc-bar"
-  class="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
+  class="xl:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
   aria-label={title}
 >
   <div class="flex overflow-x-auto gap-1 px-3 py-2 scrollbar-hide items-center">
@@ -38,7 +38,7 @@ const { title, items, desktop = true } = Astro.props;
 
 {
   desktop && (
-    <aside class="hidden lg:block">
+    <aside class="hidden xl:block">
       <nav class="sticky top-24 space-y-3" aria-label={title}>
         <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-4">{title}</h4>
         {items.map((item) => (
@@ -77,7 +77,7 @@ const { title, items, desktop = true } = Astro.props;
     display: none;
   }
   /* Bottom padding so content isn't hidden behind the sticky bar */
-  @media (max-width: 1023px) {
+  @media (max-width: 1279px) {
     body {
       padding-bottom: 3.5rem;
     }

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -84,14 +84,10 @@
         "label": "Cloud a infrastruktura",
         "description": "Komfortně vlastním celý produkční stack — od registrace domény přes nasazení až po živé dashboardy.",
         "items": [
-          "Microsoft Azure",
-          "Cloudflare",
-          "Supabase",
-          "Docker",
-          "GitHub Actions",
-          "Sentry",
-          "BetterStack",
-          "Vlastní DNS, SPF/DKIM/DMARC"
+          "Cloud platformy (Microsoft Azure, Cloudflare, Supabase)",
+          "CI/CD a kontejnery (GitHub Actions, Docker)",
+          "Observability (Sentry, BetterStack)",
+          "Nastavení DNS a e-maily (Brevo, SendGrid)"
         ]
       },
       {

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "O mně | Pavel Kalandra — kalandra.tech",
-    "description": "O Pavlu Kalandrovi — kariérní cesta od C# vývojáře po CTO."
+    "description": "O Pavlu Kalandrovi — kariérní cesta od C# vývojáře po lead engineera."
   },
   "hero": {
     "name": "Pavel Kalandra",
@@ -13,6 +13,13 @@
     "emailAriaLabel": "Poslat e-mail Pavlovi",
     "linkedinLabel": "LinkedIn",
     "linkedinAriaLabel": "LinkedIn profil"
+  },
+  "toc": {
+    "title": "Na této stránce",
+    "overview": "Přehled",
+    "manifesto": "Manifest",
+    "skills": "Dovednosti",
+    "career": "Kariéra"
   },
   "manifesto": {
     "title": "Můj manifest",
@@ -49,6 +56,52 @@
       }
     ]
   },
+  "skills": {
+    "label": "Nástroje",
+    "title": "Dovednosti",
+    "subtitle": "Deset let praktického inženýrství napříč celým stackem a vedení, které dokáže škálovat týmy i systémy zároveň.",
+    "categories": [
+      {
+        "icon": "code",
+        "color": "primary",
+        "label": "Jazyky a frameworky",
+        "items": ["C# / .NET / ASP.NET Core / WPF", "JavaScript / TypeScript / Vue.js / Astro", "Go"]
+      },
+      {
+        "icon": "database",
+        "color": "tertiary",
+        "label": "Data a úložiště",
+        "items": [
+          "SQL (MSSQL, PostgreSQL)",
+          "NoSQL (Azure Table Storage, Cosmos DB)",
+          "File Storage (Azure Blob, Supabase Storage)",
+          "Změny schématu při deployi bez výpadku"
+        ]
+      },
+      {
+        "icon": "cloud",
+        "color": "secondary",
+        "label": "Cloud a infrastruktura",
+        "description": "Komfortně vlastním celý produkční stack — od registrace domény přes nasazení až po živé dashboardy.",
+        "items": [
+          "Microsoft Azure",
+          "Cloudflare",
+          "Supabase",
+          "Docker",
+          "GitHub Actions",
+          "Sentry",
+          "BetterStack",
+          "Vlastní DNS, SPF/DKIM/DMARC"
+        ]
+      },
+      {
+        "icon": "hub",
+        "color": "primary",
+        "label": "Architektura a inženýrství",
+        "items": ["Architektura systémů", "Dekompozice modulárního monolitu", "Optimalizace výkonu", "REST / GraphQL / gRPC"]
+      }
+    ]
+  },
   "career": {
     "label": "Cesta",
     "title": "Kariérní cesta",
@@ -56,23 +109,23 @@
       {
         "side": "right",
         "date": "Čer 2025 — Současnost",
-        "role": "CTO",
+        "role": "Lead Engineer (CTO)",
         "company": "tickadoo",
-        "description": "Zodpovědný za celkovou architekturu systému, návrh featur a způsoby práce."
+        "description": "Hands-on role vedoucí single-pizza tým, který staví aplikaci pro prodej vstupenek od externích poskytovatelů.\n\nZodpovídám za celkovou architekturu systému, návrh featur, prioritizaci backlogu a způsoby práce — a zároveň každý týden píšu produkční kód."
       },
       {
         "side": "left",
         "date": "Úno 2025 — Srp 2025",
         "role": "Staff Software Engineer",
         "company": "Outreach",
-        "description": "Moc jsem se neohřál, odešel jsem za skvělou příležitostí jako CTO v tickadoo."
+        "description": "Moc jsem se neohřál, odešel jsem za skvělou příležitostí jako Lead Engineer v tickadoo."
       },
       {
         "side": "right",
         "date": "Dub 2024 — Led 2025",
         "role": "Tribe Lead",
         "company": "Rossum",
-        "description": "Vedl jsem třetinu engineeringu, restrukturalizoval týmy na produktově zaměřené a koučoval nové lídry."
+        "description": "Moje jediná hands-off role — middle management. Vedl jsem zhruba třetinu engineeringu — tým 15 lidí.\n\nVedl jsem iniciativu, která sladila strukturu týmů se strukturou produktu, aby inženýři mohli mít end-to-end vlastnictví své domény. Také jsem zavedl principy a procesy, které zajistily, že technická kvalita nepadla za oběť napjatým termínům."
       },
       {
         "side": "left",
@@ -103,7 +156,7 @@
         "date": "Dub 2016 — Úno 2018",
         "role": "Software Developer",
         "company": "ZENTITY a.s.",
-        "description": "Správa ASP.NET webové aplikace; později migrace z SQL reportingu na vlastní d3.js/Vue.js reporting."
+        "description": "Vlastnil jsem ASP.NET webovou aplikaci end-to-end, včetně Azure infrastruktury, na které běžela — Azure SQL, Azure Table Storage a Azure Active Directory. Nahradil jsem zastaralé SSRS reporty interaktivním Vue.js frontendem, který tahal data z dedikovaného API a vykresloval responzivní d3.js grafy, doplněné bočním filtrem, díky kterému si uživatelé mohli data sami krájet podle potřeby."
       },
       {
         "side": "left",

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -84,14 +84,10 @@
         "label": "Cloud & Infrastructure",
         "description": "Comfortable owning the full production stack — from registering a domain to shipping deploys and watching live dashboards.",
         "items": [
-          "Microsoft Azure",
-          "Cloudflare",
-          "Supabase",
-          "Docker",
-          "GitHub Actions",
-          "Sentry",
-          "BetterStack",
-          "Custom DNS, SPF/DKIM/DMARC"
+          "Cloud platforms (Microsoft Azure, Cloudflare, Supabase)",
+          "CI/CD & Containers (GitHub Actions, Docker)",
+          "Observability (Sentry, BetterStack)",
+          "DNS setup & Emails (Brevo, SendGrid)"
         ]
       },
       {

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "About Me | Pavel Kalandra — kalandra.tech",
-    "description": "About Pavel Kalandra — career journey from C# developer to CTO."
+    "description": "About Pavel Kalandra — career journey from C# developer to lead engineer."
   },
   "hero": {
     "name": "Pavel Kalandra",
@@ -13,6 +13,13 @@
     "emailAriaLabel": "Send email to Pavel",
     "linkedinLabel": "LinkedIn",
     "linkedinAriaLabel": "LinkedIn profile"
+  },
+  "toc": {
+    "title": "On this page",
+    "overview": "Overview",
+    "manifesto": "Manifesto",
+    "skills": "Skills",
+    "career": "Career"
   },
   "manifesto": {
     "title": "My Manifesto",
@@ -49,6 +56,52 @@
       }
     ]
   },
+  "skills": {
+    "label": "Toolbox",
+    "title": "Skills",
+    "subtitle": "A decade of hands-on engineering across the stack, plus the leadership instincts to scale teams and systems together.",
+    "categories": [
+      {
+        "icon": "code",
+        "color": "primary",
+        "label": "Languages & Frameworks",
+        "items": ["C# / .NET / ASP.NET Core / WPF", "JavaScript / TypeScript / Vue.js / Astro", "Go"]
+      },
+      {
+        "icon": "database",
+        "color": "tertiary",
+        "label": "Data & Storage",
+        "items": [
+          "SQL (MSSQL, PostgreSQL)",
+          "NoSQL (Azure Table Storage, Cosmos DB)",
+          "File Storage (Azure Blob, Supabase Storage)",
+          "Zero-downtime schema changes during deploy"
+        ]
+      },
+      {
+        "icon": "cloud",
+        "color": "secondary",
+        "label": "Cloud & Infrastructure",
+        "description": "Comfortable owning the full production stack — from registering a domain to shipping deploys and watching live dashboards.",
+        "items": [
+          "Microsoft Azure",
+          "Cloudflare",
+          "Supabase",
+          "Docker",
+          "GitHub Actions",
+          "Sentry",
+          "BetterStack",
+          "Custom DNS, SPF/DKIM/DMARC"
+        ]
+      },
+      {
+        "icon": "hub",
+        "color": "primary",
+        "label": "Architecture & Engineering",
+        "items": ["System Architecture", "Modular monolith decomposition", "Performance optimization", "REST / GraphQL / gRPC"]
+      }
+    ]
+  },
   "career": {
     "label": "The Path",
     "title": "Career Journey",
@@ -56,23 +109,23 @@
       {
         "side": "right",
         "date": "Jun 2025 — Present",
-        "role": "CTO",
+        "role": "Lead Engineer (CTO)",
         "company": "tickadoo",
-        "description": "Responsible for overall system architecture, feature design and ways of working."
+        "description": "A hands-on role leading a single-pizza team building an app for selling tickets from third-party providers.\n\nOwning the overall system architecture, feature design, backlog prioritization and engineering ways of working — while still shipping production code every week."
       },
       {
         "side": "left",
         "date": "Feb 2025 — Aug 2025",
         "role": "Staff Software Engineer",
         "company": "Outreach",
-        "description": "Didn't stay long, left for a great opportunity as CTO at tickadoo."
+        "description": "Didn't stay long, left for a great opportunity as Lead Engineer at tickadoo."
       },
       {
         "side": "right",
         "date": "Apr 2024 — Jan 2025",
         "role": "Tribe Lead",
         "company": "Rossum",
-        "description": "Led one-third of engineering, restructuring into product-focused teams and coaching new leaders."
+        "description": "My only hands-off role — middle management. I lead roughly one third of engineering - a team of 15.\n\nI ran an initiative to align the team structure with the product structure so engineers can have end-to-end ownership of their domain. I also put in place some principles and processes that kept technical quality from being sacrificed under tight deadlines."
       },
       {
         "side": "left",
@@ -103,7 +156,7 @@
         "date": "Apr 2016 — Feb 2018",
         "role": "Software Developer",
         "company": "ZENTITY a.s.",
-        "description": "Managed ASP.NET web application; later migrated from SQL reporting to custom d3.js/Vue.js reporting."
+        "description": "Owned an ASP.NET web application end-to-end, including the Azure infrastructure it ran on — Azure SQL, Azure Table Storage, and Azure Active Directory. Replaced the legacy SSRS reports with an interactive Vue.js frontend that pulled data from a dedicated API and rendered responsive d3.js charts, complete with a sidebar filter so users could slice the data themselves."
       },
       {
         "side": "left",

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -4,6 +4,7 @@ import Layout from "../../layouts/Layout.astro";
 import IconEmail from "../../components/icons/IconEmail.astro";
 import IconGitHub from "../../components/icons/IconGitHub.astro";
 import IconLinkedIn from "../../components/icons/IconLinkedIn.astro";
+import OnThisPage from "../../components/OnThisPage.astro";
 import { locales, defaultLocale, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/about.json";
 import csStrings from "../../i18n/cs/about.json";
@@ -18,11 +19,18 @@ export function getStaticPaths() {
 
 const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
+
+const tocItems = [
+  { id: "hero", label: t.toc.overview },
+  { id: "manifesto", label: t.toc.manifesto },
+  { id: "skills", label: t.toc.skills },
+  { id: "career", label: t.toc.career },
+];
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="about" lang={lang}>
   <!-- Hero Section -->
-  <section class="max-w-7xl mx-auto px-4 md:px-8 mb-24 lg:mb-40">
+  <section id="hero" class="max-w-7xl mx-auto px-4 md:px-8 mb-12 lg:mb-16">
     <div class="flex flex-col md:flex-row items-end gap-12">
       <div class="w-full md:w-2/3">
         <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-8">
@@ -96,7 +104,10 @@ const t = translations[lang];
   </section>
 
   <!-- Manifesto Section -->
-  <section class="bg-surface-container-low py-24 mb-24 lg:mb-40 relative overflow-hidden border-y border-on-surface/5">
+  <section
+    id="manifesto"
+    class="bg-surface-container-highest dark:bg-surface-container-low py-12 lg:py-16 relative overflow-hidden border-t border-outline-variant dark:border-on-surface/5"
+  >
     <div class="absolute top-0 right-0 w-64 h-64 bg-primary/5 rounded-full blur-[100px] -mr-32 -mt-32"></div>
     <div class="max-w-7xl mx-auto px-4 md:px-8 relative z-10">
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-16">
@@ -155,8 +166,48 @@ const t = translations[lang];
     </div>
   </section>
 
+  <!-- Skills Section -->
+  <section
+    id="skills"
+    class="bg-surface-container dark:bg-surface-container-lowest py-12 lg:py-16 mb-16 lg:mb-24 relative overflow-hidden border-b border-outline-variant/60 dark:border-on-surface/5"
+  >
+    <div class="max-w-7xl mx-auto px-4 md:px-8">
+      <div class="text-center mb-10">
+        <h2 class="font-headline text-4xl md:text-5xl font-bold tracking-tighter mb-4">
+          {t.skills.title}
+        </h2>
+        <p class="font-body text-on-surface-variant max-w-2xl mx-auto">
+          {t.skills.subtitle}
+        </p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {
+          t.skills.categories.map((cat) => (
+            <div class="bg-surface-container p-8 rounded-xl border border-outline-variant/40">
+              <h3 class:list={["font-label text-sm uppercase tracking-widest mb-6 flex items-center gap-2", `text-${cat.color}`]}>
+                <Icon name={`material-symbols:${cat.icon.replace(/_/g, "-")}`} class="size-[18px]" aria-hidden="true" />
+                {cat.label}
+              </h3>
+              {"description" in cat && cat.description && (
+                <p class="font-body text-on-surface-variant text-sm leading-relaxed mb-5">{cat.description}</p>
+              )}
+              <ul class="space-y-3">
+                {cat.items.map((item) => (
+                  <li class="font-body text-on-surface-variant flex items-start gap-2">
+                    <span class:list={["w-1.5 h-1.5 rounded-full shrink-0 mt-2", `bg-${cat.color}`]} />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
   <!-- Career Journey Section -->
-  <section class="max-w-7xl mx-auto px-4 md:px-8 mb-40">
+  <section id="career" class="max-w-7xl mx-auto px-4 md:px-8 mb-40">
     <div class="text-center mb-24">
       <span class="font-label text-secondary uppercase tracking-widest text-sm mb-4 block">{t.career.label}</span>
       <h2 class="font-headline text-4xl md:text-5xl font-bold tracking-tighter">
@@ -200,7 +251,7 @@ const t = translations[lang];
                     {entry.company && <p class="font-label text-on-surface-variant mb-4">{entry.company}</p>}
                     {hasSubEntries && <p class="font-label text-on-surface-variant mb-6">{entry.yearsLabel}</p>}
                     {entry.description && !hasSubEntries && (
-                      <p class="font-body text-on-surface-variant text-sm leading-relaxed">{entry.description}</p>
+                      <p class="font-body text-on-surface-variant text-sm leading-relaxed whitespace-pre-line">{entry.description}</p>
                     )}
                     {hasSubEntries && (
                       <div class="space-y-6 text-left">
@@ -233,7 +284,7 @@ const t = translations[lang];
                     {entry.company && <p class="font-label text-on-surface-variant mb-4">{entry.company}</p>}
                     {hasSubEntries && <p class="font-label text-on-surface-variant mb-6">{entry.yearsLabel}</p>}
                     {entry.description && !hasSubEntries && (
-                      <p class="font-body text-on-surface-variant text-sm leading-relaxed">{entry.description}</p>
+                      <p class="font-body text-on-surface-variant text-sm leading-relaxed whitespace-pre-line">{entry.description}</p>
                     )}
                     {hasSubEntries && (
                       <div class="space-y-6 text-left">
@@ -258,4 +309,6 @@ const t = translations[lang];
       </div>
     </div>
   </section>
+
+  <OnThisPage title={t.toc.title} items={tocItems} desktop={false} />
 </Layout>

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -3,6 +3,7 @@ import { Icon } from "astro-icon/components";
 import Layout from "../../layouts/Layout.astro";
 import IconGitHub from "../../components/icons/IconGitHub.astro";
 import ArchitectureDiagram from "../../components/ArchitectureDiagram.astro";
+import OnThisPage from "../../components/OnThisPage.astro";
 import { locales, defaultLocale, type Locale } from "../../i18n/utils";
 import enStrings from "../../i18n/en/project.json";
 import csStrings from "../../i18n/cs/project.json";
@@ -17,6 +18,16 @@ export function getStaticPaths() {
 
 const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
+
+const tocItems = [
+  { id: "hero", label: t.toc.overview },
+  { id: "tech-stack", label: t.toc.techStack },
+  { id: "goals", label: t.toc.goals },
+  { id: "architecture", label: t.toc.architecture },
+  { id: "decisions", label: t.toc.decisions },
+  { id: "roadmap", label: t.toc.roadmap },
+  { id: "lessons-learned", label: t.toc.lessonsLearned },
+];
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="project" lang={lang}>
@@ -566,160 +577,6 @@ const t = translations[lang];
       </section>
     </div>
 
-    <!-- Mobile TOC — Sticky Bottom Tab Bar -->
-    <nav
-      id="toc-bar"
-      class="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-surface-container/95 backdrop-blur-sm border-t border-outline-variant/40 shadow-[0_-2px_8px_rgba(0,0,0,0.08)]"
-      aria-label={t.toc.title}
-    >
-      <div class="flex overflow-x-auto gap-1 px-3 py-2 scrollbar-hide items-center">
-        <span class="shrink-0 font-label text-[10px] uppercase tracking-widest text-on-surface-variant pr-1">{t.toc.title}</span>
-        <span class="shrink-0 w-px h-4 bg-outline-variant/40" aria-hidden="true"></span>
-        <a
-          href="#hero"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="hero">{t.toc.overview}</a
-        >
-        <a
-          href="#tech-stack"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="tech-stack">{t.toc.techStack}</a
-        >
-        <a
-          href="#goals"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="goals">{t.toc.goals}</a
-        >
-        <a
-          href="#architecture"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="architecture">{t.toc.architecture}</a
-        >
-        <a
-          href="#decisions"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="decisions">{t.toc.decisions}</a
-        >
-        <a
-          href="#roadmap"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="roadmap">{t.toc.roadmap}</a
-        >
-        <a
-          href="#lessons-learned"
-          class="toc-pill shrink-0 font-label text-xs px-3 py-1.5 rounded-full text-on-surface-variant hover:text-primary hover:bg-primary/10 transition-colors whitespace-nowrap"
-          data-toc-target="lessons-learned">{t.toc.lessonsLearned}</a
-        >
-      </div>
-    </nav>
-
-    <!-- TOC Rail (desktop only) -->
-    <aside class="hidden lg:block">
-      <nav class="sticky top-24 space-y-3" aria-label="Table of contents">
-        <h4 class="font-label text-xs uppercase tracking-widest text-on-surface-variant mb-4">
-          {t.toc.title}
-        </h4>
-        <a
-          href="#hero"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="hero">{t.toc.overview}</a
-        >
-        <a
-          href="#tech-stack"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="tech-stack">{t.toc.techStack}</a
-        >
-        <a
-          href="#goals"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="goals">{t.toc.goals}</a
-        >
-        <a
-          href="#architecture"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="architecture">{t.toc.architecture}</a
-        >
-        <a
-          href="#decisions"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="decisions">{t.toc.decisions}</a
-        >
-        <a
-          href="#roadmap"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="roadmap">{t.toc.roadmap}</a
-        >
-        <a
-          href="#lessons-learned"
-          class="toc-link block font-body text-sm text-on-surface-variant hover:text-primary transition-colors"
-          data-toc-target="lessons-learned">{t.toc.lessonsLearned}</a
-        >
-      </nav>
-    </aside>
+    <OnThisPage title={t.toc.title} items={tocItems} />
   </div>
 </Layout>
-
-<style>
-  .toc-link-active {
-    color: var(--color-primary);
-    font-weight: 600;
-    border-left: 2px solid var(--color-primary);
-    padding-left: 0.5rem;
-    margin-left: -0.625rem;
-  }
-  .toc-pill-active {
-    background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
-    color: var(--color-primary);
-    font-weight: 600;
-  }
-  /* Hide scrollbar for the pill bar */
-  .scrollbar-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-  /* Bottom padding so content isn't hidden behind the sticky bar */
-  @media (max-width: 1023px) {
-    body {
-      padding-bottom: 3.5rem;
-    }
-  }
-</style>
-
-<script>
-  const sections = document.querySelectorAll("section[id]");
-  const tocLinks = document.querySelectorAll(".toc-link");
-  const tocPills = document.querySelectorAll(".toc-pill");
-
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const id = entry.target.id;
-
-          // Desktop rail
-          tocLinks.forEach((link) => link.classList.remove("toc-link-active"));
-          const activeDesktop = document.querySelector(`.toc-link[data-toc-target="${id}"]`);
-          if (activeDesktop) activeDesktop.classList.add("toc-link-active");
-
-          // Mobile pill bar
-          tocPills.forEach((l) => l.classList.remove("toc-pill-active"));
-          const activePill = document.querySelector(`.toc-pill[data-toc-target="${id}"]`);
-          if (activePill) {
-            activePill.classList.add("toc-pill-active");
-            activePill.scrollIntoView({
-              behavior: "smooth",
-              block: "nearest",
-              inline: "center",
-            });
-          }
-        }
-      });
-    },
-    { rootMargin: "-20% 0px -70% 0px" },
-  );
-
-  sections.forEach((section) => observer.observe(section));
-</script>

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -31,7 +31,7 @@ const tocItems = [
 ---
 
 <Layout title={t.meta.title} description={t.meta.description} activePage="project" lang={lang}>
-  <div class="lg:grid lg:grid-cols-[1fr_220px] lg:gap-12 max-w-7xl mx-auto px-4 md:px-8 relative">
+  <div class="xl:grid xl:grid-cols-[1fr_220px] xl:gap-12 max-w-7xl mx-auto px-4 md:px-8 relative">
     <div>
       <!-- Hero / Intro Section -->
       <section id="hero" class="mb-24">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Safelist dynamic color classes used via interpolated class names (e.g. `bg-${cat.color}`). */
+@source inline("bg-primary bg-secondary bg-tertiary text-primary text-secondary text-tertiary");
+
 /* ============================================
    Self-hosted Google Fonts (Inter, Manrope, Space Grotesk)
    Only latin + latin-ext subsets (covers English + Czech).


### PR DESCRIPTION
## Summary
- **Skills section** added to the About page between Manifesto and Career, with four categories (Languages & Frameworks, Data & Storage, Cloud & Infrastructure, Architecture & Engineering). Cloud & Infrastructure also gets a description preamble framing end-to-end production ownership.
- **Reusable `OnThisPage` component** extracted from the Project page; About uses the mobile pill-bar variant. Sidebar/pill-bar breakpoint raised from `lg` (1024px) to `xl` (1280px) so tablets and small laptops keep the pill bar instead of being crammed by the 220px sidebar.
- **Career entry rewrites** for Tribe Lead, tickadoo (now *Lead Engineer (CTO)*, two paragraphs) and Zentity (full Azure stack + Vue.js/d3.js).
- **Light-mode contrast bump** on Manifesto, Skills, navbar and footer using `dark:` overrides — each surface tier now reads distinctly in light mode without changing dark mode.
- **Tailwind v4 safelist** for `bg-/text-{primary,secondary,tertiary}` because the dynamic `bg-${cat.color}` interpolation was getting stripped by JIT for `bg-secondary` (no static reference elsewhere), leaving Cloud & Infra dots transparent.

## Test plan
- [x] `npm test` passes (backend + frontend + E2E)
- [ ] Visually confirm About page in light and dark mode (Manifesto and Skills bands, mobile TOC pill bar, bullet dots in all four Skills categories)
- [ ] Verify Project page TOC still works after extraction to the shared component
- [ ] Resize through the 1024–1280 px range and confirm the TOC switches at 1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)