### PR TITLE
Fix pre-commit prettier hook + add root format wrappers

### DIFF
--- a/frontend/.githooks/pre-commit
+++ b/frontend/.githooks/pre-commit
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 # Auto-format staged frontend files with Prettier before committing.
+# Aborts the commit if Prettier fails.
+set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Collect staged files that Prettier can format (relative to repo root)
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR | grep '^frontend/' | grep -E '\.(astro|ts|js|json|css|mjs)$')
+# Staged files Prettier should format, relative to repo root.
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR \
+  | grep '^frontend/' \
+  | grep -E '\.(astro|ts|js|json|css|mjs)$' || true)
 
 if [ -z "$STAGED" ]; then
   exit 0
 fi
 
-# Run Prettier --write using absolute paths so it works from any CWD
-echo "$STAGED" | sed "s|^|$REPO_ROOT/|" | xargs npx --prefix "$REPO_ROOT/frontend" prettier --write --ignore-unknown
+# Prettier must run from frontend/ so it can resolve prettier-plugin-astro
+# from frontend/node_modules. Pass paths relative to frontend/.
+echo "$STAGED" | sed 's|^frontend/||' \
+  | (cd "$REPO_ROOT/frontend" && xargs npx prettier --write --ignore-unknown)
 
-# Re-stage the formatted files
+# Re-stage the formatted files.
 echo "$STAGED" | xargs git add
-
-exit 0

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -108,11 +108,7 @@
         "icon": "code",
         "color": "primary",
         "label": "Jazyky a frameworky",
-        "items": [
-          "C# / .NET / ASP.NET Core / WPF",
-          "JavaScript / TypeScript / Vue.js / Astro",
-          "Go"
-        ]
+        "items": ["C# / .NET / ASP.NET Core / WPF", "JavaScript / TypeScript / Vue.js / Astro", "Go"]
       },
       {
         "icon": "database",
@@ -141,12 +137,7 @@
         "icon": "hub",
         "color": "primary",
         "label": "Architektura a inženýrství",
-        "items": [
-          "Architektura systémů",
-          "Dekompozice modulárního monolitu",
-          "Optimalizace výkonu",
-          "REST / GraphQL / gRPC"
-        ]
+        "items": ["Architektura systémů", "Dekompozice modulárního monolitu", "Optimalizace výkonu", "REST / GraphQL / gRPC"]
       },
       {
         "icon": "lightbulb",

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -108,11 +108,7 @@
         "icon": "code",
         "color": "primary",
         "label": "Languages & Frameworks",
-        "items": [
-          "C# / .NET / ASP.NET Core / WPF",
-          "JavaScript / TypeScript / Vue.js / Astro",
-          "Go"
-        ]
+        "items": ["C# / .NET / ASP.NET Core / WPF", "JavaScript / TypeScript / Vue.js / Astro", "Go"]
       },
       {
         "icon": "database",
@@ -141,12 +137,7 @@
         "icon": "hub",
         "color": "primary",
         "label": "Architecture & Engineering",
-        "items": [
-          "System Architecture",
-          "Modular monolith decomposition",
-          "Performance optimization",
-          "REST / GraphQL / gRPC"
-        ]
+        "items": ["System Architecture", "Modular monolith decomposition", "Performance optimization", "REST / GraphQL / gRPC"]
       },
       {
         "icon": "lightbulb",

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -201,9 +201,7 @@ const tocItems = [
                       <span class:list={["w-1.5 h-1.5 rounded-full shrink-0 mt-2", `bg-${cat.color}`]} />
                       <div class="flex-1">
                         <span>{title}</span>
-                        {description && (
-                          <p class="font-body text-on-surface-variant/70 text-xs leading-snug mt-1">{description}</p>
-                        )}
+                        {description && <p class="font-body text-on-surface-variant/70 text-xs leading-snug mt-1">{description}</p>}
                       </div>
                     </li>
                   );

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dev:stop": "cd backend && docker compose down && supabase stop",
     "dev:wipe": "cd backend && docker compose down -v && supabase stop --no-backup",
     "build:frontend": "cd frontend && npm run build",
+    "format": "cd frontend && npm run format",
+    "format:check": "cd frontend && npm run format:check",
     "test": "npm run test:backend && npm run test:frontend && npm run test:e2e",
     "test:backend": "dotnet test --verbosity normal",
     "test:frontend": "cd frontend && npm run test:install && npm test",


### PR DESCRIPTION
## Summary
- Fix pre-commit hook so Prettier failures actually block the commit. The hook ran `npx --prefix .../frontend prettier ...` from the repo root; `--prefix` only controls install location, not plugin resolution, so prettier couldn't find `prettier-plugin-astro` and exited 1 — but the hook unconditionally ended with `exit 0`, swallowing the failure.
- Hook now `cd`s into `frontend/` (so plugins resolve from `frontend/node_modules`), uses `set -euo pipefail`, and drops the trailing `exit 0`.
- Add root `format` / `format:check` wrappers so contributors can run prettier from the repo root, matching the existing `build:frontend` / `test:frontend` pattern.
- Apply the formatting fixes prettier reported on the About page strings (overlaps harmlessly with kali/about — same diff).

## Test plan
- [x] Reproduce original failure: `npx --prefix "$(pwd)/frontend" prettier --write --ignore-unknown frontend/package.json` → exits 1 with `prettier-plugin-astro` error.
- [x] New invocation works: `(cd frontend && npx prettier --write --ignore-unknown package.json)` → exit 0.
- [x] Hook blocks on failure: temporarily replace plugin name in `.prettierrc` with a non-existent one, stage a frontend file, `git commit` → exit 1, no commit created.
- [x] Hook auto-formats on success: stage a `.ts` file with ugly whitespace (`console.log(   "spaces"   );`), `git commit` → committed file is reformatted (`console.log("spaces");`).
- [x] No-op when no frontend files staged: hook exits 0 without invoking prettier.
- [x] Root wrappers: `npm run format` and `npm run format:check` work from repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)