### PR TITLE
StrongTypes: Page visually more compact

### DIFF
--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -7,7 +7,7 @@
     "titlePrefix": "Pár malých typů, které dělají C# ",
     "titleHighlight": "bezpečnějším",
     "titleSuffix": ".",
-    "description": "Kalicz.StrongTypes je C# NuGet balíček, který přidává bezkódové validace vynucené překladačem. Typy jako NonEmptyString nebo Positive<int> přesouvají invarianty do typového systému a validace se odehrává na hranici — takže neplatná data se k vašim handlerům vůbec nedostanou.",
+    "description": "Kalicz.StrongTypes je C# NuGet balíček, který přidává bezkódové validace vynucené překladačem. Neplatná data se nikdy nedostanou do vašeho aplikačního kódu.",
     "primaryCta": "Zobrazit na GitHubu",
     "secondaryCta": "Zobrazit na NuGetu",
     "install": "dotnet add package Kalicz.StrongTypes",
@@ -43,7 +43,7 @@
   },
   "why": {
     "title": "Proč se obtěžovat se silnými typy?",
-    "subtitle": "Většina C# kódu se brání neplatnému vstupu tím, že ho znovu validuje všude. StrongTypes to obrací: validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
+    "subtitle": "Přestaňte validovat vstup všude. Validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
     "diagram": {
       "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
       "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek",

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -7,7 +7,7 @@
     "titlePrefix": "A few small types that make C# ",
     "titleHighlight": "safer",
     "titleSuffix": ".",
-    "description": "Kalicz.StrongTypes is a C# NuGet package that adds no-code validations enforced by the compiler. Wrapper types like NonEmptyString or Positive<int> move invariants into the type system, and validation happens at the boundary — so invalid data never reaches your handlers.",
+    "description": "Kalicz.StrongTypes is a C# NuGet package that adds no-code validations enforced by the compiler. Invalid data never reaches your application code.",
     "primaryCta": "View on GitHub",
     "secondaryCta": "View on NuGet",
     "install": "dotnet add package Kalicz.StrongTypes",
@@ -43,7 +43,7 @@
   },
   "why": {
     "title": "Why bother with strong types?",
-    "subtitle": "Most C# code defends against invalid input by re-validating it everywhere. StrongTypes flips that around: validate once, at the boundary, and let the compiler enforce the rest.",
+    "subtitle": "Stop validating input everywhere. Validate once, at the boundary, and let the compiler enforce the rest.",
     "diagram": {
       "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
       "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses",

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -132,7 +132,7 @@ const tocItems = [
       <h2 class="font-headline text-3xl font-bold mb-4 text-on-surface">
         {t.why.title}
       </h2>
-      <p class="font-body text-on-surface-variant mb-10 max-w-3xl text-lg leading-relaxed">
+      <p class="font-body text-on-surface-variant mb-10 text-lg leading-relaxed">
         {t.why.subtitle}
       </p>
 


### PR DESCRIPTION
## Summary
- Shorten the StrongTypes hero description and replace "your handlers" with "your application code" (broader — covers services, components, methods).
- Replace the why-section subtitle with a tighter one-liner and remove the `max-w-3xl` cap so it spans the full content column.
- Mirror both copy changes in the Czech translation.

The goal is to lift the impact diagram higher on the page so it's visible on initial load.

## Test plan
- [ ] Load `/strong-types` and verify the impact diagram is visible without scrolling on a typical desktop viewport.
- [ ] Load `/cs/strong-types` and verify the Czech copy reads naturally.
- [ ] Confirm the why subtitle stretches the full content width (no `max-w-3xl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)