### PR TITLE
Add blog with backend-backed comments, reactions, and RSS

### DIFF
--- a/DemoPage.slnx
+++ b/DemoPage.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="backend/src/Kalandra.Api/Kalandra.Api.csproj" />
+  <Project Path="backend/src/Kalandra.Blog/Kalandra.Blog.csproj" />
   <Project Path="backend/src/Kalandra.Infrastructure/Kalandra.Infrastructure.csproj" />
   <Project Path="backend/src/Kalandra.JobOffers/Kalandra.JobOffers.csproj" />
   <Project Path="backend/tests/Kalandra.Api.IntegrationTests/Kalandra.Api.IntegrationTests.csproj" />

--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -44,7 +44,7 @@ public partial class BlogController(
         if (TryParseSlug(slug) is not { } parsedSlug)
             return this.ValidationError("slug", BlogSlugError.InvalidSlug);
 
-        if (request.Content.Trim().AsNonEmpty().GetOrNull() is not { } content)
+        if (request.Content?.Trim().AsNonEmpty().GetOrNull() is not { } content)
             return this.ValidationError("content", AddBlogCommentError.ContentRequired);
 
         var command = new AddBlogCommentCommand(

--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -1,0 +1,120 @@
+using System.Text.RegularExpressions;
+using Kalandra.Api.Features.Blog.Contracts;
+using Kalandra.Api.Infrastructure;
+using Kalandra.Api.Infrastructure.Auth;
+using Kalandra.Blog.Commands;
+using Kalandra.Blog.Queries;
+using Kalandra.Infrastructure.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kalandra.Api.Features.Blog;
+
+[ApiController]
+[Route("api/blog")]
+[Produces("application/json")]
+public partial class BlogController(
+    ICurrentUserAccessor currentUser,
+    TimeProvider timeProvider,
+    AddBlogCommentHandler addCommentHandler,
+    ToggleBlogReactionHandler toggleReactionHandler,
+    ListBlogCommentsHandler listCommentsHandler,
+    GetBlogReactionsHandler getReactionsHandler) : ControllerBase
+{
+    // Slug grammar: lowercase letters, digits, dashes — bounded so a typo
+    // can't accidentally create a multi-megabyte stream ID. Same shape used
+    // on the frontend, where slugs come from blog post .astro file names.
+    [GeneratedRegex(@"^[a-z0-9][a-z0-9-]{0,79}$", RegexOptions.CultureInvariant)]
+    private static partial Regex SlugRegex();
+
+    private CurrentUser AppUser => currentUser.RequiredUser;
+
+    // ───── Add Comment ─────
+
+    [HttpPost("{slug}/comments")]
+    [Authorize]
+    [ProducesResponseType<BlogCommentResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<BlogCommentResponse>> AddComment(
+        string slug,
+        [FromBody] AddBlogCommentRequest request,
+        CancellationToken ct)
+    {
+        if (TryParseSlug(slug) is not { } parsedSlug)
+            return this.ValidationError("slug", BlogSlugError.InvalidSlug);
+
+        if (request.Content.Trim().AsNonEmpty().GetOrNull() is not { } content)
+            return this.ValidationError("content", AddBlogCommentError.ContentRequired);
+
+        var command = new AddBlogCommentCommand(
+            Slug: parsedSlug,
+            User: AppUser,
+            Content: content,
+            Timestamp: timeProvider.GetUtcNow());
+
+        var commentEvent = await addCommentHandler.HandleAsync(command, ct);
+        return BlogCommentResponse.Serialize(commentEvent);
+    }
+
+    // ───── Toggle Reaction ─────
+
+    [HttpPost("{slug}/reactions")]
+    [Authorize]
+    [ProducesResponseType<ToggleBlogReactionResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<ToggleBlogReactionResponse>> ToggleReaction(
+        string slug,
+        [FromBody] BlogReactionRequest request,
+        CancellationToken ct)
+    {
+        if (TryParseSlug(slug) is not { } parsedSlug)
+            return this.ValidationError("slug", BlogSlugError.InvalidSlug);
+
+        var command = new ToggleBlogReactionCommand(
+            Slug: parsedSlug,
+            User: AppUser,
+            Emoji: request.Emoji,
+            Timestamp: timeProvider.GetUtcNow());
+
+        var result = await toggleReactionHandler.HandleAsync(command, ct);
+        return new ToggleBlogReactionResponse(result.Emoji, result.Action);
+    }
+
+    // ───── List Comments ─────
+
+    [HttpGet("{slug}/comments")]
+    [AllowAnonymous]
+    [ProducesResponseType<ListBlogCommentsResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ListBlogCommentsResponse>> ListComments(string slug, CancellationToken ct)
+    {
+        if (TryParseSlug(slug) is not { } parsedSlug)
+            return this.ValidationError("slug", BlogSlugError.InvalidSlug);
+
+        var comments = await listCommentsHandler.HandleAsync(new ListBlogCommentsQuery(parsedSlug), ct);
+        return new ListBlogCommentsResponse(comments.Select(BlogCommentResponse.Serialize));
+    }
+
+    // ───── Get Reactions ─────
+
+    [HttpGet("{slug}/reactions")]
+    [AllowAnonymous]
+    [ProducesResponseType<BlogReactionsResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<BlogReactionsResponse>> GetReactions(string slug, CancellationToken ct)
+    {
+        if (TryParseSlug(slug) is not { } parsedSlug)
+            return this.ValidationError("slug", BlogSlugError.InvalidSlug);
+
+        // Anonymous viewers see counts but no user-specific reactions. The
+        // accessor returns null when no JWT is present.
+        var viewerId = currentUser.User?.Id;
+        var view = await getReactionsHandler.HandleAsync(new GetBlogReactionsQuery(parsedSlug, viewerId), ct);
+        return BlogReactionsResponse.Serialize(view);
+    }
+
+    private static NonEmptyString? TryParseSlug(string slug) =>
+        SlugRegex().IsMatch(slug) ? slug.AsNonEmpty().GetOrNull() : null;
+}

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentError.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentError.cs
@@ -1,0 +1,7 @@
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+/// <summary>
+/// API-layer error enum returned when a comment body fails validation.
+/// Stable wire contract — frontend reads the enum name as the i18n key.
+/// </summary>
+public enum AddBlogCommentError { ContentRequired }

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentRequest.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentRequest.cs
@@ -1,0 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+public record AddBlogCommentRequest([Required, MaxLength(5000)] string Content);

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentRequest.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/AddBlogCommentRequest.cs
@@ -2,4 +2,8 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Kalandra.Api.Features.Blog.Contracts;
 
-public record AddBlogCommentRequest([Required, MaxLength(5000)] string Content);
+// Content emptiness/trim is enforced inside the controller so the error code on
+// the wire is the stable enum name (`ContentRequired`), not the framework's
+// generic `[Required]` message. The MaxLength guard stays — it's a hard cap
+// on the stream payload, not part of the i18n error contract.
+public record AddBlogCommentRequest([MaxLength(5000)] string Content);

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogCommentResponse.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogCommentResponse.cs
@@ -1,0 +1,22 @@
+using Kalandra.Blog.Events;
+
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+public record BlogCommentResponse(
+    Guid Id,
+    Guid UserId,
+    string UserEmail,
+    string UserName,
+    string Content,
+    DateTimeOffset CreatedAt)
+{
+    public static BlogCommentResponse Serialize(BlogCommentAdded comment) => new(
+        Id: comment.CommentId,
+        UserId: comment.UserId,
+        UserEmail: comment.UserEmail,
+        UserName: comment.UserName,
+        Content: comment.Content,
+        CreatedAt: comment.Timestamp);
+}
+
+public record ListBlogCommentsResponse(IEnumerable<BlogCommentResponse> Comments);

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogReactionRequest.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogReactionRequest.cs
@@ -1,0 +1,5 @@
+using Kalandra.Blog.Entities;
+
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+public record BlogReactionRequest(BlogReactionEmoji Emoji);

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogReactionsResponse.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogReactionsResponse.cs
@@ -1,0 +1,24 @@
+using Kalandra.Blog.Commands;
+using Kalandra.Blog.Entities;
+using Kalandra.Blog.Queries;
+
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+public record BlogReactionCount(BlogReactionEmoji Emoji, int Count);
+
+public record BlogReactionsResponse(
+    IReadOnlyList<BlogReactionCount> Counts,
+    IReadOnlyList<BlogReactionEmoji> UserReactions)
+{
+    public static BlogReactionsResponse Serialize(BlogReactionsView view)
+    {
+        // Always emit one row per supported emoji so the client can render the
+        // bar in a stable order without locale-dependent dictionary iteration.
+        var counts = Enum.GetValues<BlogReactionEmoji>()
+            .Select(e => new BlogReactionCount(e, view.Counts.GetValueOrDefault(e, 0)))
+            .ToList();
+        return new BlogReactionsResponse(counts, view.UserReactions);
+    }
+}
+
+public record ToggleBlogReactionResponse(BlogReactionEmoji Emoji, BlogReactionAction Action);

--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogSlugError.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/BlogSlugError.cs
@@ -1,0 +1,7 @@
+namespace Kalandra.Api.Features.Blog.Contracts;
+
+/// <summary>
+/// API-layer error enum returned when a blog slug can't be parsed.
+/// Stable wire contract — frontend reads the enum name as the i18n key.
+/// </summary>
+public enum BlogSlugError { InvalidSlug }

--- a/backend/src/Kalandra.Api/Kalandra.Api.csproj
+++ b/backend/src/Kalandra.Api/Kalandra.Api.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Kalandra.Blog\Kalandra.Blog.csproj" />
     <ProjectReference Include="..\Kalandra.Infrastructure\Kalandra.Infrastructure.csproj" />
     <ProjectReference Include="..\Kalandra.JobOffers\Kalandra.JobOffers.csproj" />
   </ItemGroup>

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -1,6 +1,7 @@
 using HealthChecks.UI.Client;
 using Kalandra.Api.Infrastructure;
 using Kalandra.Api.Infrastructure.Auth;
+using Kalandra.Blog;
 using Kalandra.Infrastructure.Configuration;
 using Kalandra.JobOffers;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -43,6 +44,7 @@ builder.Services.AddTurnstile();
 builder.Services.AddAuthAdminServices();
 builder.Services.AddApiServices();
 builder.Services.AddJobOffersDomain();
+builder.Services.AddBlogDomain();
 RateLimits.Add(builder.Services, builder.Environment);
 
 builder.Services.AddResponseCompression(options =>

--- a/backend/src/Kalandra.Blog/BlogStreamId.cs
+++ b/backend/src/Kalandra.Blog/BlogStreamId.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Kalandra.Blog;
+
+/// <summary>
+/// Deterministic UUID v5 stream IDs for a blog post's comments and reactions.
+/// Each post slug maps to two independent streams so high-volume reaction
+/// events never bloat the comment-replay path (and vice versa).
+/// </summary>
+public static class BlogStreamId
+{
+    private static readonly Guid CommentsNamespace = Guid.Parse("3e1f7c2a-9b6d-4f8e-bf0a-1c2d3e4f5061");
+    private static readonly Guid ReactionsNamespace = Guid.Parse("8a2b9d4e-7c3f-4f1d-9e2c-5a6b7c8d9e07");
+
+    public static Guid ForComments(NonEmptyString slug) => UuidV5(CommentsNamespace, slug.Value);
+    public static Guid ForReactions(NonEmptyString slug) => UuidV5(ReactionsNamespace, slug.Value);
+
+    private static Guid UuidV5(Guid ns, string name)
+    {
+        var namespaceBytes = ns.ToByteArray();
+        var nameBytes = Encoding.UTF8.GetBytes(name);
+
+        var input = new byte[namespaceBytes.Length + nameBytes.Length];
+        namespaceBytes.CopyTo(input, 0);
+        nameBytes.CopyTo(input, namespaceBytes.Length);
+
+        var hash = SHA1.HashData(input);
+
+        hash[6] = (byte)((hash[6] & 0x0F) | 0x50); // version 5
+        hash[8] = (byte)((hash[8] & 0x3F) | 0x80); // variant RFC 4122
+
+        return new Guid(hash.AsSpan(0, 16));
+    }
+}

--- a/backend/src/Kalandra.Blog/Commands/AddBlogComment.cs
+++ b/backend/src/Kalandra.Blog/Commands/AddBlogComment.cs
@@ -1,0 +1,30 @@
+using Kalandra.Blog.Events;
+using Kalandra.Infrastructure.Auth;
+using Marten;
+
+namespace Kalandra.Blog.Commands;
+
+public record AddBlogCommentCommand(
+    NonEmptyString Slug,
+    CurrentUser User,
+    NonEmptyString Content,
+    DateTimeOffset Timestamp);
+
+public class AddBlogCommentHandler(IDocumentSession session)
+{
+    public async Task<BlogCommentAdded> HandleAsync(AddBlogCommentCommand command, CancellationToken ct)
+    {
+        var commentEvent = new BlogCommentAdded(
+            CommentId: Guid.NewGuid(),
+            Slug: command.Slug.Value,
+            UserId: command.User.Id,
+            UserEmail: command.User.Email.Address,
+            UserName: command.User.FullName,
+            Content: command.Content.Value,
+            Timestamp: command.Timestamp);
+
+        session.Events.Append(BlogStreamId.ForComments(command.Slug), commentEvent);
+        await session.SaveChangesAsync(ct);
+        return commentEvent;
+    }
+}

--- a/backend/src/Kalandra.Blog/Commands/ToggleBlogReaction.cs
+++ b/backend/src/Kalandra.Blog/Commands/ToggleBlogReaction.cs
@@ -1,0 +1,69 @@
+using Kalandra.Blog.Entities;
+using Kalandra.Blog.Events;
+using Kalandra.Infrastructure.Auth;
+using Marten;
+
+namespace Kalandra.Blog.Commands;
+
+/// <summary>
+/// Click-to-toggle reaction. If the user has not reacted with this emoji on this
+/// post, an add event is appended; otherwise a remove event is appended. The
+/// stream replay decides which it is, so concurrent toggles can't accidentally
+/// double-add or double-remove a reaction.
+/// </summary>
+public record ToggleBlogReactionCommand(
+    NonEmptyString Slug,
+    CurrentUser User,
+    BlogReactionEmoji Emoji,
+    DateTimeOffset Timestamp);
+
+public enum BlogReactionAction { Added, Removed }
+
+public record ToggleBlogReactionResult(BlogReactionAction Action, BlogReactionEmoji Emoji);
+
+public class ToggleBlogReactionHandler(IDocumentSession session)
+{
+    public async Task<ToggleBlogReactionResult> HandleAsync(
+        ToggleBlogReactionCommand command, CancellationToken ct)
+    {
+        var streamId = BlogStreamId.ForReactions(command.Slug);
+        var events = await session.Events.FetchStreamAsync(streamId, token: ct);
+
+        var hasReaction = false;
+        foreach (var e in events)
+        {
+            switch (e.Data)
+            {
+                case BlogReactionAdded added when added.UserId == command.User.Id && added.Emoji == command.Emoji:
+                    hasReaction = true;
+                    break;
+                case BlogReactionRemoved removed when removed.UserId == command.User.Id && removed.Emoji == command.Emoji:
+                    hasReaction = false;
+                    break;
+            }
+        }
+
+        if (hasReaction)
+        {
+            var removed = new BlogReactionRemoved(
+                Slug: command.Slug.Value,
+                UserId: command.User.Id,
+                Emoji: command.Emoji,
+                Timestamp: command.Timestamp);
+            session.Events.Append(streamId, removed);
+            await session.SaveChangesAsync(ct);
+            return new ToggleBlogReactionResult(BlogReactionAction.Removed, command.Emoji);
+        }
+        else
+        {
+            var added = new BlogReactionAdded(
+                Slug: command.Slug.Value,
+                UserId: command.User.Id,
+                Emoji: command.Emoji,
+                Timestamp: command.Timestamp);
+            session.Events.Append(streamId, added);
+            await session.SaveChangesAsync(ct);
+            return new ToggleBlogReactionResult(BlogReactionAction.Added, command.Emoji);
+        }
+    }
+}

--- a/backend/src/Kalandra.Blog/Entities/BlogReactionEmoji.cs
+++ b/backend/src/Kalandra.Blog/Entities/BlogReactionEmoji.cs
@@ -1,0 +1,16 @@
+namespace Kalandra.Blog.Entities;
+
+/// <summary>
+/// The fixed set of reactions a reader can leave on a blog post.
+/// Stored as the enum name in the event stream so renames are caught at
+/// build time. The frontend maps each value to its display character.
+/// </summary>
+public enum BlogReactionEmoji
+{
+    ThumbsUp,
+    Heart,
+    Rocket,
+    Eyes,
+    Tada,
+    Laugh,
+}

--- a/backend/src/Kalandra.Blog/Events/BlogCommentAdded.cs
+++ b/backend/src/Kalandra.Blog/Events/BlogCommentAdded.cs
@@ -1,0 +1,10 @@
+namespace Kalandra.Blog.Events;
+
+public record BlogCommentAdded(
+    Guid CommentId,
+    string Slug,
+    Guid UserId,
+    string UserEmail,
+    string UserName,
+    string Content,
+    DateTimeOffset Timestamp);

--- a/backend/src/Kalandra.Blog/Events/BlogReactionAdded.cs
+++ b/backend/src/Kalandra.Blog/Events/BlogReactionAdded.cs
@@ -1,0 +1,9 @@
+using Kalandra.Blog.Entities;
+
+namespace Kalandra.Blog.Events;
+
+public record BlogReactionAdded(
+    string Slug,
+    Guid UserId,
+    BlogReactionEmoji Emoji,
+    DateTimeOffset Timestamp);

--- a/backend/src/Kalandra.Blog/Events/BlogReactionRemoved.cs
+++ b/backend/src/Kalandra.Blog/Events/BlogReactionRemoved.cs
@@ -1,0 +1,9 @@
+using Kalandra.Blog.Entities;
+
+namespace Kalandra.Blog.Events;
+
+public record BlogReactionRemoved(
+    string Slug,
+    Guid UserId,
+    BlogReactionEmoji Emoji,
+    DateTimeOffset Timestamp);

--- a/backend/src/Kalandra.Blog/GlobalUsings.cs
+++ b/backend/src/Kalandra.Blog/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using StrongTypes;

--- a/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
+++ b/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kalicz.StrongTypes" Version="0.2.0" />
+    <PackageReference Include="Marten" Version="8.29.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kalandra.Infrastructure\Kalandra.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Kalandra.Blog/Queries/GetBlogReactions.cs
+++ b/backend/src/Kalandra.Blog/Queries/GetBlogReactions.cs
@@ -1,0 +1,53 @@
+using Kalandra.Blog.Entities;
+using Kalandra.Blog.Events;
+using Marten;
+
+namespace Kalandra.Blog.Queries;
+
+/// <summary>
+/// Reaction state on a post: total per emoji, plus the set of emoji the
+/// requesting user has reacted with. <paramref name="UserId"/> is null for
+/// anonymous viewers — the response shape is the same, just with no
+/// per-user reactions to highlight.
+/// </summary>
+public record GetBlogReactionsQuery(NonEmptyString Slug, Guid? UserId);
+
+public record BlogReactionsView(
+    IReadOnlyDictionary<BlogReactionEmoji, int> Counts,
+    IReadOnlyList<BlogReactionEmoji> UserReactions);
+
+public class GetBlogReactionsHandler(IQuerySession session)
+{
+    public async Task<BlogReactionsView> HandleAsync(GetBlogReactionsQuery query, CancellationToken ct)
+    {
+        var streamId = BlogStreamId.ForReactions(query.Slug);
+        var events = await session.Events.FetchStreamAsync(streamId, token: ct);
+
+        // Replay: a (user, emoji) pair is "active" iff the most recent event for
+        // that pair is an Added. Tracking presence per pair lets us derive both
+        // the totals and the requesting user's own set in one pass.
+        var active = new HashSet<(Guid UserId, BlogReactionEmoji Emoji)>();
+        foreach (var e in events)
+        {
+            switch (e.Data)
+            {
+                case BlogReactionAdded a:
+                    active.Add((a.UserId, a.Emoji));
+                    break;
+                case BlogReactionRemoved r:
+                    active.Remove((r.UserId, r.Emoji));
+                    break;
+            }
+        }
+
+        var counts = active
+            .GroupBy(p => p.Emoji)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var userReactions = query.UserId is { } uid
+            ? active.Where(p => p.UserId == uid).Select(p => p.Emoji).ToList()
+            : new List<BlogReactionEmoji>();
+
+        return new BlogReactionsView(counts, userReactions);
+    }
+}

--- a/backend/src/Kalandra.Blog/Queries/ListBlogComments.cs
+++ b/backend/src/Kalandra.Blog/Queries/ListBlogComments.cs
@@ -1,0 +1,20 @@
+using Kalandra.Blog.Events;
+using Marten;
+
+namespace Kalandra.Blog.Queries;
+
+public record ListBlogCommentsQuery(NonEmptyString Slug);
+
+public class ListBlogCommentsHandler(IQuerySession session)
+{
+    public async Task<IReadOnlyList<BlogCommentAdded>> HandleAsync(
+        ListBlogCommentsQuery query, CancellationToken ct)
+    {
+        var streamId = BlogStreamId.ForComments(query.Slug);
+        var events = await session.Events.FetchStreamAsync(streamId, token: ct);
+
+        return events
+            .Select(e => (BlogCommentAdded)e.Data)
+            .ToList();
+    }
+}

--- a/backend/src/Kalandra.Blog/ServiceRegistration.cs
+++ b/backend/src/Kalandra.Blog/ServiceRegistration.cs
@@ -1,0 +1,19 @@
+using Kalandra.Blog.Commands;
+using Kalandra.Blog.Queries;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kalandra.Blog;
+
+public static class ServiceRegistration
+{
+    public static IServiceCollection AddBlogDomain(this IServiceCollection services)
+    {
+        services.AddScoped<AddBlogCommentHandler>();
+        services.AddScoped<ToggleBlogReactionHandler>();
+
+        services.AddScoped<ListBlogCommentsHandler>();
+        services.AddScoped<GetBlogReactionsHandler>();
+
+        return services;
+    }
+}

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -1,0 +1,261 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Kalandra.Api.IntegrationTests.Helpers;
+
+namespace Kalandra.Api.IntegrationTests.Features.Blog;
+
+public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly HttpClient client = factory.CreateClient();
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    // ───── Auth gates ─────
+
+    [Fact]
+    public async Task AddComment_WithoutAuth_Returns401()
+    {
+        var slug = NewSlug();
+        var response = await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Hi" }, Ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ToggleReaction_WithoutAuth_Returns401()
+    {
+        var slug = NewSlug();
+        var response = await client.PostAsJsonAsync($"/api/blog/{slug}/reactions", new { emoji = "ThumbsUp" }, Ct);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ListComments_WithoutAuth_Returns200()
+    {
+        var slug = NewSlug();
+        var response = await client.GetAsync($"/api/blog/{slug}/comments", Ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await ParseJsonAsync(response);
+        Assert.Equal(0, json.GetProperty("comments").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task GetReactions_WithoutAuth_Returns200()
+    {
+        var slug = NewSlug();
+        var response = await client.GetAsync($"/api/blog/{slug}/reactions", Ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await ParseJsonAsync(response);
+        Assert.True(json.GetProperty("counts").GetArrayLength() >= 1);
+        Assert.Equal(0, json.GetProperty("userReactions").GetArrayLength());
+    }
+
+    // ───── Comments ─────
+
+    [Fact]
+    public async Task AddComment_AsSignedInUser_AppearsInList()
+    {
+        var slug = NewSlug();
+        var userId = Authenticate("commenter@test.com");
+
+        var addRes = await client.PostAsJsonAsync(
+            $"/api/blog/{slug}/comments",
+            new { content = "First!" }, Ct);
+        Assert.Equal(HttpStatusCode.OK, addRes.StatusCode);
+
+        var added = await ParseJsonAsync(addRes);
+        AssertValidGuid(added, "id");
+        Assert.Equal(userId.ToString(), added.GetProperty("userId").GetString());
+        Assert.Equal("commenter@test.com", added.GetProperty("userEmail").GetString());
+        Assert.Equal("First!", added.GetProperty("content").GetString());
+        AssertValidTimestamp(added, "createdAt");
+
+        // Anonymous reader can read
+        ClearAuth();
+        var listRes = await client.GetAsync($"/api/blog/{slug}/comments", Ct);
+        Assert.Equal(HttpStatusCode.OK, listRes.StatusCode);
+        var list = await ParseJsonAsync(listRes);
+        Assert.Equal(1, list.GetProperty("comments").GetArrayLength());
+        Assert.Equal("First!", list.GetProperty("comments")[0].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task AddComment_TrimsAndRejectsWhitespaceOnly()
+    {
+        var slug = NewSlug();
+        Authenticate();
+
+        var blankRes = await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "   " }, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, blankRes.StatusCode);
+        var blank = await ParseJsonAsync(blankRes);
+        AssertValidationError(blank, "content", "ContentRequired");
+
+        var goodRes = await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "  hi  " }, Ct);
+        Assert.Equal(HttpStatusCode.OK, goodRes.StatusCode);
+        var good = await ParseJsonAsync(goodRes);
+        Assert.Equal("hi", good.GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task ListComments_OnlyContainsCommentsForRequestedSlug()
+    {
+        var slugA = NewSlug();
+        var slugB = NewSlug();
+
+        Authenticate("a@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slugA}/comments", new { content = "from A" }, Ct);
+        await client.PostAsJsonAsync($"/api/blog/{slugB}/comments", new { content = "from B" }, Ct);
+
+        var aList = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slugA}/comments", Ct));
+        var bList = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slugB}/comments", Ct));
+
+        Assert.Equal(1, aList.GetProperty("comments").GetArrayLength());
+        Assert.Equal("from A", aList.GetProperty("comments")[0].GetProperty("content").GetString());
+        Assert.Equal(1, bList.GetProperty("comments").GetArrayLength());
+        Assert.Equal("from B", bList.GetProperty("comments")[0].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task AddComment_InvalidSlug_Returns400()
+    {
+        Authenticate();
+        var response = await client.PostAsJsonAsync(
+            "/api/blog/Invalid_SLUG!/comments",
+            new { content = "Hi" }, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await ParseJsonAsync(response);
+        AssertValidationError(json, "slug", "InvalidSlug");
+    }
+
+    // ───── Reactions ─────
+
+    [Fact]
+    public async Task ToggleReaction_AddsThenRemoves()
+    {
+        var slug = NewSlug();
+        var userId = Authenticate("react@test.com");
+
+        var addedRes = await client.PostAsJsonAsync(
+            $"/api/blog/{slug}/reactions",
+            new { emoji = "ThumbsUp" }, Ct);
+        Assert.Equal(HttpStatusCode.OK, addedRes.StatusCode);
+        Assert.Equal("Added", (await ParseJsonAsync(addedRes)).GetProperty("action").GetString());
+
+        // Counts now show 1
+        var afterAdd = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/reactions", Ct));
+        AssertEmojiCount(afterAdd, "ThumbsUp", 1);
+        Assert.Contains(
+            afterAdd.GetProperty("userReactions").EnumerateArray(),
+            e => e.GetString() == "ThumbsUp");
+
+        // Toggle off
+        var removedRes = await client.PostAsJsonAsync(
+            $"/api/blog/{slug}/reactions",
+            new { emoji = "ThumbsUp" }, Ct);
+        Assert.Equal(HttpStatusCode.OK, removedRes.StatusCode);
+        Assert.Equal("Removed", (await ParseJsonAsync(removedRes)).GetProperty("action").GetString());
+
+        var afterRemove = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/reactions", Ct));
+        AssertEmojiCount(afterRemove, "ThumbsUp", 0);
+        Assert.Equal(0, afterRemove.GetProperty("userReactions").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ToggleReaction_DifferentUsersAreTrackedSeparately()
+    {
+        var slug = NewSlug();
+
+        Authenticate("alice@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/reactions", new { emoji = "Heart" }, Ct);
+
+        Authenticate("bob@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/reactions", new { emoji = "Heart" }, Ct);
+
+        // Bob still authenticated — sees self in userReactions
+        var bobView = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/reactions", Ct));
+        AssertEmojiCount(bobView, "Heart", 2);
+        Assert.Single(bobView.GetProperty("userReactions").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task GetReactions_AnonymousViewerSeesNoUserReactions()
+    {
+        var slug = NewSlug();
+        Authenticate("solo@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/reactions", new { emoji = "Rocket" }, Ct);
+
+        ClearAuth();
+        var view = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/reactions", Ct));
+        AssertEmojiCount(view, "Rocket", 1);
+        Assert.Equal(0, view.GetProperty("userReactions").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task GetReactions_ReturnsAllSupportedEmoji()
+    {
+        var slug = NewSlug();
+        var view = await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/reactions", Ct));
+
+        // Stable wire contract: every supported emoji appears at zero, in declaration order.
+        var counts = view.GetProperty("counts");
+        var emojis = counts.EnumerateArray().Select(e => e.GetProperty("emoji").GetString()).ToArray();
+        Assert.Equal(new[] { "ThumbsUp", "Heart", "Rocket", "Eyes", "Tada", "Laugh" }, emojis);
+    }
+
+    // ───── Helpers ─────
+
+    private static string NewSlug() => $"post-{Guid.NewGuid():n}";
+
+    private Guid Authenticate(string email = "test@example.com", bool isAdmin = false)
+    {
+        var userId = Guid.NewGuid();
+        var token = JwtTestHelper.GenerateToken(userId, email, isAdmin);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return userId;
+    }
+
+    private void ClearAuth() => client.DefaultRequestHeaders.Authorization = null;
+
+    private static string AssertValidGuid(JsonElement parent, string propertyName)
+    {
+        var raw = parent.GetProperty(propertyName).GetString();
+        Assert.NotNull(raw);
+        Assert.NotEqual(Guid.Empty, Guid.Parse(raw));
+        return raw;
+    }
+
+    private static void AssertValidTimestamp(JsonElement parent, string propertyName)
+    {
+        var raw = parent.GetProperty(propertyName).GetString();
+        Assert.NotNull(raw);
+        Assert.True(
+            DateTimeOffset.TryParse(raw, out var parsed) && parsed > DateTimeOffset.UnixEpoch,
+            $"Expected valid timestamp for '{propertyName}', got '{raw}'");
+    }
+
+    private static void AssertValidationError(JsonElement json, string field, string expectedCode)
+    {
+        var errors = json.GetProperty("errors").GetProperty(field);
+        Assert.Contains(
+            errors.EnumerateArray(),
+            e => e.GetString() == expectedCode);
+    }
+
+    private static void AssertEmojiCount(JsonElement view, string emoji, int expectedCount)
+    {
+        var entry = view.GetProperty("counts")
+            .EnumerateArray()
+            .First(e => e.GetProperty("emoji").GetString() == emoji);
+        Assert.Equal(expectedCount, entry.GetProperty("count").GetInt32());
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var doc = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(), cancellationToken: CancellationToken.None);
+        return doc.RootElement;
+    }
+}

--- a/backend/tests/Kalandra.Api.IntegrationTests/Kalandra.Api.IntegrationTests.csproj
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Kalandra.Api.IntegrationTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Kalandra.Api\Kalandra.Api.csproj" />
+    <ProjectReference Include="..\..\src\Kalandra.Blog\Kalandra.Blog.csproj" />
     <ProjectReference Include="..\..\src\Kalandra.JobOffers\Kalandra.JobOffers.csproj" />
   </ItemGroup>
 

--- a/frontend/src/blog/posts.ts
+++ b/frontend/src/blog/posts.ts
@@ -1,0 +1,13 @@
+import type { BlogPostMeta } from "./types";
+
+// Each post .astro file under src/pages/[...lang]/blog/ exports a `post`
+// constant carrying its metadata. Importing them via `import.meta.glob`
+// keeps the listing, RSS, and per-post chrome in sync with the files on
+// disk — adding a post is just dropping in a new .astro file.
+const modules = import.meta.glob<{ post?: BlogPostMeta }>("/src/pages/**/blog/*.astro", { eager: true });
+
+export const allPosts: BlogPostMeta[] = Object.entries(modules)
+  .filter(([path]) => !path.endsWith("/index.astro"))
+  .map(([, m]) => m.post)
+  .filter((p): p is BlogPostMeta => !!p && !p.draft)
+  .sort((a, b) => +new Date(b.pubDate) - +new Date(a.pubDate));

--- a/frontend/src/blog/types.ts
+++ b/frontend/src/blog/types.ts
@@ -1,0 +1,25 @@
+import type { Locale } from "../i18n/utils";
+
+/**
+ * Metadata each blog post .astro file exports as `post`. Defines every
+ * field the listing page, post chrome, and the RSS feed need to render —
+ * the post body itself is owned by the .astro file's template.
+ */
+export interface BlogPostMeta {
+  /** URL slug — must match the .astro file name and the API slug grammar `[a-z0-9][a-z0-9-]{0,79}`. */
+  slug: string;
+  /** ISO 8601 publication timestamp. Used for sort order, RSS pubDate, and the human-readable date. */
+  pubDate: string;
+  /** ISO 8601 last-edit timestamp; defaults to pubDate when absent. */
+  updatedDate?: string;
+  /** Per-locale post title. */
+  title: Record<Locale, string>;
+  /** Per-locale plaintext summary used by the listing card and RSS description. */
+  summary: Record<Locale, string>;
+  /** Topical tags used by the listing chip row. */
+  tags: string[];
+  /** When true, the post is excluded from the index, RSS feed, and sitemap. */
+  draft?: boolean;
+  /** Optional canonical link for posts also published elsewhere. */
+  canonicalUrl?: string;
+}

--- a/frontend/src/components/BlogComments.astro
+++ b/frontend/src/components/BlogComments.astro
@@ -19,6 +19,9 @@ interface Props {
 }
 
 const { slug, lang, t } = Astro.props;
+
+// Empty in dev (Vite proxies /api → backend); absolute backend origin in built dists.
+const apiUrl = import.meta.env.PUBLIC_API_URL || "";
 ---
 
 <section
@@ -26,6 +29,7 @@ const { slug, lang, t } = Astro.props;
   data-blog-comments
   data-slug={slug}
   data-lang={lang}
+  data-api-url={apiUrl}
   data-load-failed={t.loadFailed}
   data-submitted={t.submitted}
   data-error-map={JSON.stringify(t.errors)}
@@ -94,6 +98,7 @@ const { slug, lang, t } = Astro.props;
   function setupComments(section: HTMLElement) {
     const slug = section.dataset.slug!;
     const lang = section.dataset.lang as "en" | "cs";
+    const apiBase = section.dataset.apiUrl ?? "";
     const loadFailedMsg = section.dataset.loadFailed || "Could not load comments.";
     const submittedMsg = section.dataset.submitted || "Comment posted.";
     const errorMap = JSON.parse(section.dataset.errorMap || "{}") as Record<string, Record<string, string>>;
@@ -130,7 +135,7 @@ const { slug, lang, t } = Astro.props;
 
     async function load() {
       try {
-        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/comments`);
+        const res = await fetch(`${apiBase}/api/blog/${encodeURIComponent(slug)}/comments`);
         if (!res.ok) throw new Error("load failed");
         const body = (await res.json()) as { comments: BlogCommentDto[] };
         renderAll(body.comments);
@@ -160,7 +165,7 @@ const { slug, lang, t } = Astro.props;
       submit.textContent = submit.dataset.labelSubmitting || "Posting…";
 
       try {
-        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/comments`, {
+        const res = await fetch(`${apiBase}/api/blog/${encodeURIComponent(slug)}/comments`, {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           body: JSON.stringify({ content }),

--- a/frontend/src/components/BlogComments.astro
+++ b/frontend/src/components/BlogComments.astro
@@ -1,0 +1,196 @@
+---
+import type { Locale } from "../i18n/utils";
+
+interface Props {
+  slug: string;
+  lang: Locale;
+  t: {
+    heading: string;
+    empty: string;
+    signedOutHint: string;
+    signedOutSignInCta: string;
+    placeholder: string;
+    submit: string;
+    submitting: string;
+    submitted: string;
+    loadFailed: string;
+    errors: Record<string, Record<string, string>>;
+  };
+}
+
+const { slug, lang, t } = Astro.props;
+---
+
+<section
+  class="border-t border-outline-variant/20 pt-8 mt-12"
+  data-blog-comments
+  data-slug={slug}
+  data-lang={lang}
+  data-load-failed={t.loadFailed}
+  data-submitted={t.submitted}
+  data-error-map={JSON.stringify(t.errors)}
+  aria-labelledby="comments-heading"
+>
+  <h2 id="comments-heading" class="font-headline text-xl font-bold mb-4">{t.heading}</h2>
+
+  <ol data-comments-list class="space-y-4 mb-6"></ol>
+  <p data-comments-empty class="hidden text-sm text-on-surface-variant mb-6">{t.empty}</p>
+
+  <!-- Signed-in form -->
+  <form data-comment-form class="signed-in-only space-y-3">
+    <label class="sr-only" for="comment-textarea">{t.placeholder}</label>
+    <textarea
+      id="comment-textarea"
+      data-comment-textarea
+      required
+      maxlength="5000"
+      rows="3"
+      placeholder={t.placeholder}
+      class="w-full rounded-xl border border-outline-variant/40 bg-surface-container-lowest px-4 py-3 text-sm leading-relaxed focus:outline-none focus:border-primary/60"
+    ></textarea>
+    <p data-comment-error class="hidden text-sm text-error" role="alert"></p>
+    <div class="flex justify-end">
+      <button
+        type="submit"
+        data-comment-submit
+        data-label-submit={t.submit}
+        data-label-submitting={t.submitting}
+        class="px-4 py-2 rounded-lg bg-primary text-on-primary text-sm font-semibold font-label hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+      >
+        {t.submit}
+      </button>
+    </div>
+  </form>
+
+  <!-- Signed-out CTA -->
+  <div class="signed-out-only flex items-center gap-3 rounded-xl border border-outline-variant/30 bg-surface-container-lowest px-4 py-3">
+    <p class="text-sm text-on-surface-variant flex-1">{t.signedOutHint}</p>
+    <button
+      type="button"
+      data-comment-signin
+      class="px-3 py-1.5 rounded-lg bg-primary text-on-primary text-sm font-semibold font-label hover:bg-primary/90 transition-colors cursor-pointer"
+    >
+      {t.signedOutSignInCta}
+    </button>
+  </div>
+</section>
+
+<script>
+  import { getApiError } from "../lib/api-errors";
+
+  interface BlogCommentDto {
+    id: string;
+    userId: string;
+    userEmail: string;
+    userName: string;
+    content: string;
+    createdAt: string;
+  }
+
+  function escapeHtml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  function setupComments(section: HTMLElement) {
+    const slug = section.dataset.slug!;
+    const lang = section.dataset.lang as "en" | "cs";
+    const loadFailedMsg = section.dataset.loadFailed || "Could not load comments.";
+    const submittedMsg = section.dataset.submitted || "Comment posted.";
+    const errorMap = JSON.parse(section.dataset.errorMap || "{}") as Record<string, Record<string, string>>;
+
+    const list = section.querySelector<HTMLOListElement>("[data-comments-list]")!;
+    const emptyState = section.querySelector<HTMLElement>("[data-comments-empty]")!;
+    const form = section.querySelector<HTMLFormElement>("[data-comment-form]")!;
+    const textarea = section.querySelector<HTMLTextAreaElement>("[data-comment-textarea]")!;
+    const submit = section.querySelector<HTMLButtonElement>("[data-comment-submit]")!;
+    const errorEl = section.querySelector<HTMLElement>("[data-comment-error]")!;
+    const signInBtn = section.querySelector<HTMLButtonElement>("[data-comment-signin]")!;
+
+    const dateFmt = new Intl.DateTimeFormat(lang === "cs" ? "cs-CZ" : "en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+
+    function renderComment(c: BlogCommentDto): string {
+      const when = dateFmt.format(new Date(c.createdAt));
+      return `
+        <li class="rounded-xl bg-surface-container-lowest border border-outline-variant/20 px-4 py-3">
+          <div class="flex items-center justify-between gap-3 mb-1">
+            <span class="font-label text-sm text-on-surface">${escapeHtml(c.userName)}</span>
+            <time class="text-xs text-on-surface-variant" datetime="${escapeHtml(c.createdAt)}">${escapeHtml(when)}</time>
+          </div>
+          <p class="text-sm leading-relaxed whitespace-pre-wrap">${escapeHtml(c.content)}</p>
+        </li>`;
+    }
+
+    function renderAll(comments: BlogCommentDto[]) {
+      list.innerHTML = comments.map(renderComment).join("");
+      emptyState.classList.toggle("hidden", comments.length > 0);
+    }
+
+    async function load() {
+      try {
+        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/comments`);
+        if (!res.ok) throw new Error("load failed");
+        const body = (await res.json()) as { comments: BlogCommentDto[] };
+        renderAll(body.comments);
+      } catch {
+        (window as any).__showSnackbar?.(loadFailedMsg, "error");
+      }
+    }
+
+    async function onSubmit(e: SubmitEvent) {
+      e.preventDefault();
+      errorEl.classList.add("hidden");
+
+      const content = textarea.value.trim();
+      if (!content) {
+        errorEl.textContent = errorMap?.content?.ContentRequired || "Comment can't be empty.";
+        errorEl.classList.remove("hidden");
+        return;
+      }
+
+      const token = await (window as any).__getAccessToken?.();
+      if (!token) {
+        (window as any).__openAuthDialog?.();
+        return;
+      }
+
+      submit.disabled = true;
+      submit.textContent = submit.dataset.labelSubmitting || "Posting…";
+
+      try {
+        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ content }),
+        });
+
+        if (!res.ok) {
+          const apiError = await getApiError(res, errorMap);
+          if (apiError?.message) {
+            errorEl.textContent = apiError.message;
+            errorEl.classList.remove("hidden");
+          } else {
+            (window as any).__showSnackbar?.("Comment failed. Please try again.", "error");
+          }
+          return;
+        }
+
+        textarea.value = "";
+        (window as any).__showSnackbar?.(submittedMsg, "success");
+        await load();
+      } finally {
+        submit.disabled = false;
+        submit.textContent = submit.dataset.labelSubmit || "Post comment";
+      }
+    }
+
+    form.addEventListener("submit", onSubmit);
+    signInBtn.addEventListener("click", () => (window as any).__openAuthDialog?.());
+
+    load();
+  }
+
+  document.querySelectorAll<HTMLElement>("[data-blog-comments]").forEach(setupComments);
+</script>

--- a/frontend/src/components/BlogPostLayout.astro
+++ b/frontend/src/components/BlogPostLayout.astro
@@ -1,0 +1,165 @@
+---
+import Layout from "../layouts/Layout.astro";
+import BlogReactions from "./BlogReactions.astro";
+import BlogComments from "./BlogComments.astro";
+import type { Locale } from "../i18n/utils";
+import type { BlogPostMeta } from "../blog/types";
+import enBlog from "../i18n/en/blog.json";
+import csBlog from "../i18n/cs/blog.json";
+
+interface Props {
+  post: BlogPostMeta;
+  lang: Locale;
+}
+
+const { post, lang } = Astro.props;
+const t = lang === "cs" ? csBlog : enBlog;
+
+const dateFmt = new Intl.DateTimeFormat(lang === "cs" ? "cs-CZ" : "en-US", { dateStyle: "long" });
+const published = dateFmt.format(new Date(post.pubDate));
+const updated = post.updatedDate && post.updatedDate !== post.pubDate ? dateFmt.format(new Date(post.updatedDate)) : null;
+
+const title = post.title[lang];
+const summary = post.summary[lang];
+---
+
+<Layout
+  title={`${title} | Pavel Kalandra`}
+  description={summary}
+  activePage="blog"
+  pagePath={`blog/${post.slug}`}
+  rssUrl="/rss.xml"
+  lang={lang}
+>
+  <article class="max-w-3xl mx-auto px-4 md:px-8">
+    <header class="mb-10">
+      <h1 class="font-headline text-4xl md:text-5xl font-extrabold tracking-tighter leading-[1.1] mb-4">
+        {title}
+      </h1>
+      <p class="font-body text-lg text-on-surface-variant leading-relaxed mb-4">{summary}</p>
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-on-surface-variant">
+        <time datetime={post.pubDate}>{t.post.publishedOn}: <span class="text-on-surface">{published}</span></time>
+        {
+          updated && (
+            <time datetime={post.updatedDate}>
+              {t.post.updatedOn}: <span class="text-on-surface">{updated}</span>
+            </time>
+          )
+        }
+      </div>
+      {
+        post.tags.length > 0 && (
+          <ul class="flex flex-wrap gap-2 mt-4" aria-label={t.post.tagsLabel}>
+            {post.tags.map((tag) => (
+              <li class="text-xs font-label uppercase tracking-widest px-2 py-1 rounded-md bg-surface-container-high text-on-surface-variant">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    </header>
+
+    <div class="prose prose-lg max-w-none blog-prose">
+      <slot />
+    </div>
+
+    <BlogReactions slug={post.slug} lang={lang} t={t.reactions} />
+    <BlogComments slug={post.slug} lang={lang} t={t.comments} />
+  </article>
+</Layout>
+
+<style>
+  /* Lightweight typography for Markdown-like blog content. Keeps the chrome
+     consistent with the rest of the site without pulling in @tailwindcss/typography. */
+  .blog-prose :global(p) {
+    margin: 1rem 0;
+    line-height: 1.75;
+    color: var(--color-on-surface);
+  }
+  .blog-prose :global(h2) {
+    font-family: var(--font-headline);
+    font-size: 1.75rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .blog-prose :global(h3) {
+    font-family: var(--font-headline);
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
+  }
+  .blog-prose :global(a) {
+    color: var(--color-primary);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .blog-prose :global(a:hover) {
+    text-decoration-thickness: 2px;
+  }
+  .blog-prose :global(ul),
+  .blog-prose :global(ol) {
+    margin: 1rem 0;
+    padding-left: 1.5rem;
+  }
+  .blog-prose :global(ul) {
+    list-style-type: disc;
+  }
+  .blog-prose :global(ol) {
+    list-style-type: decimal;
+  }
+  .blog-prose :global(li) {
+    margin: 0.25rem 0;
+    line-height: 1.7;
+  }
+  .blog-prose :global(blockquote) {
+    border-left: 3px solid var(--color-primary);
+    margin: 1.25rem 0;
+    padding: 0.25rem 1rem;
+    color: var(--color-on-surface-variant);
+    font-style: italic;
+  }
+  .blog-prose :global(code) {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 0.9em;
+    background: color-mix(in oklab, var(--color-surface-container-high) 70%, transparent);
+    padding: 0.1em 0.4em;
+    border-radius: 0.35rem;
+  }
+  .blog-prose :global(pre) {
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    background: var(--color-surface-container-high);
+    border: 1px solid color-mix(in oklab, var(--color-outline-variant) 30%, transparent);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+    line-height: 1.5;
+  }
+  .blog-prose :global(pre code) {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: 0.875rem;
+  }
+  .blog-prose :global(figure) {
+    margin: 1.75rem 0;
+  }
+  .blog-prose :global(figcaption) {
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--color-on-surface-variant);
+    margin-top: 0.5rem;
+  }
+  .blog-prose :global(img),
+  .blog-prose :global(svg) {
+    max-width: 100%;
+    height: auto;
+    margin: 1rem auto;
+    display: block;
+    border-radius: 0.5rem;
+  }
+</style>

--- a/frontend/src/components/BlogReactions.astro
+++ b/frontend/src/components/BlogReactions.astro
@@ -26,12 +26,17 @@ const reactions = [
   { code: "Tada", char: "🎉" },
   { code: "Laugh", char: "😄" },
 ] as const;
+
+// In dev (npm run dev), PUBLIC_API_URL is empty and Vite proxies /api → backend.
+// In built dists this is the absolute backend origin (e.g. https://api.kalandra.tech).
+const apiUrl = import.meta.env.PUBLIC_API_URL || "";
 ---
 
 <section
   class="border-t border-outline-variant/20 pt-8 mt-12"
   data-blog-reactions
   data-slug={slug}
+  data-api-url={apiUrl}
   data-load-failed={t.loadFailed}
   data-submit-failed={t.submitFailed}
   aria-labelledby="reactions-heading"
@@ -77,6 +82,7 @@ const reactions = [
   // button opens the auth dialog instead of submitting.
   async function setupReactions(section: HTMLElement) {
     const slug = section.dataset.slug!;
+    const apiBase = section.dataset.apiUrl ?? "";
     const loadFailedMsg = section.dataset.loadFailed || "Could not load reactions.";
     const submitFailedMsg = section.dataset.submitFailed || "Reaction failed.";
 
@@ -96,7 +102,7 @@ const reactions = [
         const token = await (window as any).__getAccessToken?.();
         const headers: Record<string, string> = {};
         if (token) headers["Authorization"] = `Bearer ${token}`;
-        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/reactions`, { headers });
+        const res = await fetch(`${apiBase}/api/blog/${encodeURIComponent(slug)}/reactions`, { headers });
         if (!res.ok) throw new Error("load failed");
         const body = (await res.json()) as {
           counts: Array<{ emoji: string; count: number }>;
@@ -133,7 +139,7 @@ const reactions = [
       countEl.textContent = String(wasPressed ? Math.max(prevCount - 1, 0) : prevCount + 1);
 
       try {
-        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/reactions`, {
+        const res = await fetch(`${apiBase}/api/blog/${encodeURIComponent(slug)}/reactions`, {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           body: JSON.stringify({ emoji }),

--- a/frontend/src/components/BlogReactions.astro
+++ b/frontend/src/components/BlogReactions.astro
@@ -1,0 +1,164 @@
+---
+import type { Locale } from "../i18n/utils";
+
+interface Props {
+  slug: string;
+  lang: Locale;
+  t: {
+    heading: string;
+    signedOutHint: string;
+    loadFailed: string;
+    submitFailed: string;
+    labels: Record<string, string>;
+  };
+}
+
+const { slug, lang, t } = Astro.props;
+
+// Mirrors Kalandra.Blog.Entities.BlogReactionEmoji on the backend.
+// The character is purely presentational and lives on the frontend so the
+// API contract stays a stable enum name (e.g. "ThumbsUp"), not Unicode.
+const reactions = [
+  { code: "ThumbsUp", char: "👍" },
+  { code: "Heart", char: "❤️" },
+  { code: "Rocket", char: "🚀" },
+  { code: "Eyes", char: "👀" },
+  { code: "Tada", char: "🎉" },
+  { code: "Laugh", char: "😄" },
+] as const;
+---
+
+<section
+  class="border-t border-outline-variant/20 pt-8 mt-12"
+  data-blog-reactions
+  data-slug={slug}
+  data-load-failed={t.loadFailed}
+  data-submit-failed={t.submitFailed}
+  aria-labelledby="reactions-heading"
+>
+  <h2 id="reactions-heading" class="font-headline text-xl font-bold mb-4">{t.heading}</h2>
+
+  <div class="flex flex-wrap gap-3" role="group" aria-label={t.heading}>
+    {
+      reactions.map((r) => (
+        <button
+          type="button"
+          data-reaction={r.code}
+          aria-pressed="false"
+          aria-label={t.labels[r.code]}
+          title={t.labels[r.code]}
+          class="reaction-btn flex items-center gap-2 px-3 py-1.5 rounded-full border border-outline-variant/40 bg-surface-container-lowest hover:bg-surface-container-high transition-colors text-sm font-label cursor-pointer"
+        >
+          <span aria-hidden="true" class="text-base leading-none">
+            {r.char}
+          </span>
+          <span data-reaction-count class="text-on-surface-variant">
+            0
+          </span>
+        </button>
+      ))
+    }
+  </div>
+
+  <p class="signed-out-only mt-3 text-sm text-on-surface-variant">{t.signedOutHint}</p>
+</section>
+
+<style>
+  .reaction-btn[aria-pressed="true"] {
+    background-color: color-mix(in oklab, var(--color-primary) 12%, transparent);
+    border-color: color-mix(in oklab, var(--color-primary) 50%, transparent);
+    color: var(--color-primary);
+  }
+</style>
+
+<script>
+  // Fetches reaction state for the current post and wires click-to-toggle on
+  // every emoji button. Unauthenticated viewers get counts only — clicking a
+  // button opens the auth dialog instead of submitting.
+  async function setupReactions(section: HTMLElement) {
+    const slug = section.dataset.slug!;
+    const loadFailedMsg = section.dataset.loadFailed || "Could not load reactions.";
+    const submitFailedMsg = section.dataset.submitFailed || "Reaction failed.";
+
+    const buttons = section.querySelectorAll<HTMLButtonElement>("[data-reaction]");
+
+    function getCountEl(emoji: string) {
+      const btn = section.querySelector<HTMLButtonElement>(`[data-reaction="${emoji}"]`);
+      return btn?.querySelector<HTMLElement>("[data-reaction-count]") ?? null;
+    }
+
+    function getButton(emoji: string) {
+      return section.querySelector<HTMLButtonElement>(`[data-reaction="${emoji}"]`) ?? null;
+    }
+
+    async function loadState() {
+      try {
+        const token = await (window as any).__getAccessToken?.();
+        const headers: Record<string, string> = {};
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/reactions`, { headers });
+        if (!res.ok) throw new Error("load failed");
+        const body = (await res.json()) as {
+          counts: Array<{ emoji: string; count: number }>;
+          userReactions: string[];
+        };
+        for (const c of body.counts) {
+          const el = getCountEl(c.emoji);
+          if (el) el.textContent = String(c.count);
+        }
+        const myReactions = new Set(body.userReactions);
+        for (const btn of buttons) {
+          btn.setAttribute("aria-pressed", myReactions.has(btn.dataset.reaction!) ? "true" : "false");
+        }
+      } catch {
+        (window as any).__showSnackbar?.(loadFailedMsg, "error");
+      }
+    }
+
+    async function toggle(emoji: string) {
+      const token = await (window as any).__getAccessToken?.();
+      if (!token) {
+        (window as any).__openAuthDialog?.();
+        return;
+      }
+
+      const btn = getButton(emoji);
+      const countEl = getCountEl(emoji);
+      if (!btn || !countEl) return;
+
+      // Optimistic update — reverted on failure.
+      const wasPressed = btn.getAttribute("aria-pressed") === "true";
+      const prevCount = parseInt(countEl.textContent || "0", 10);
+      btn.setAttribute("aria-pressed", wasPressed ? "false" : "true");
+      countEl.textContent = String(wasPressed ? Math.max(prevCount - 1, 0) : prevCount + 1);
+
+      try {
+        const res = await fetch(`/api/blog/${encodeURIComponent(slug)}/reactions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ emoji }),
+        });
+        if (!res.ok) throw new Error("submit failed");
+      } catch {
+        // Revert
+        btn.setAttribute("aria-pressed", wasPressed ? "true" : "false");
+        countEl.textContent = String(prevCount);
+        (window as any).__showSnackbar?.(submitFailedMsg, "error");
+      }
+    }
+
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", () => toggle(btn.dataset.reaction!));
+    });
+
+    await loadState();
+
+    // Refresh state when auth changes — counts are anonymous-readable, so
+    // signing in must show the user's own reactions immediately.
+    window.addEventListener("auth-change", loadState);
+  }
+
+  document.querySelectorAll<HTMLElement>("[data-blog-reactions]").forEach((section) => {
+    setupReactions(section);
+  });
+</script>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -13,7 +13,8 @@ type ActivePage =
   | "admin/test-errors"
   | "profile"
   | "privacy"
-  | "terms";
+  | "terms"
+  | "blog";
 
 interface Props {
   activePage: ActivePage;
@@ -24,6 +25,7 @@ interface Props {
       about: string;
       project: string;
       hireMe: string;
+      blog: string;
       mySubmissions: string;
       admin: string;
       adminTestErrors: string;
@@ -45,8 +47,13 @@ const navItems = [
   { label: t.nav.home, page: "home" as const },
   { label: t.nav.about, page: "about" as const },
   { label: t.nav.project, page: "project" as const },
+  { label: t.nav.blog, page: "blog" as const },
   { label: t.nav.hireMe, page: "hire-me" as const },
 ];
+
+// Blog post pages still highlight the "Blog" nav link — same shape as
+// admin/* pages, where the parent section stays current.
+const isPageActive = (page: string) => activePage === page || activePage.startsWith(`${page}/`);
 ---
 
 <!-- Skip to content (accessibility) -->
@@ -141,11 +148,11 @@ const navItems = [
           <a
             href={localePath(lang, page)}
             class:list={[
-              activePage === page
+              isPageActive(page)
                 ? "text-primary border-b-2 border-primary pb-1"
                 : "text-on-surface-variant hover:text-on-surface transition-colors border-b-2 border-transparent pb-1",
             ]}
-            aria-current={activePage === page ? "page" : undefined}
+            aria-current={isPageActive(page) ? "page" : undefined}
           >
             {label}
           </a>

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "indexTitle": "Blog | Pavel Kalandra",
+    "indexDescription": "Články o vývoji, leadershipu a nástrojích, které tvořím."
+  },
+  "index": {
+    "heading": "Blog",
+    "intro": "Poznámky o inženýrských rozhodnutích, vydáních a nástrojích, které vyvíjím. Odebírejte přes",
+    "rssLink": "RSS",
+    "empty": "Zatím tu nic není — první článek dorazí brzy.",
+    "readMore": "Přečíst článek",
+    "draftLabel": "Koncept"
+  },
+  "post": {
+    "publishedOn": "Publikováno",
+    "updatedOn": "Aktualizováno",
+    "tagsLabel": "Štítky"
+  },
+  "reactions": {
+    "heading": "Reakce",
+    "signedOutHint": "Pro reakci se přihlaste",
+    "loadFailed": "Nepodařilo se načíst reakce.",
+    "submitFailed": "Reakce selhala. Zkuste to prosím znovu.",
+    "labels": {
+      "ThumbsUp": "Líbí",
+      "Heart": "Miluju",
+      "Rocket": "Raketa",
+      "Eyes": "Oči",
+      "Tada": "Oslava",
+      "Laugh": "Smích"
+    }
+  },
+  "comments": {
+    "heading": "Komentáře",
+    "empty": "Buďte první, kdo zanechá komentář.",
+    "signedOutHint": "Pro psaní komentáře se přihlaste.",
+    "signedOutSignInCta": "Přihlásit se",
+    "placeholder": "Napište svůj komentář…",
+    "submit": "Odeslat komentář",
+    "submitting": "Odesílání…",
+    "submitted": "Komentář byl publikován.",
+    "loadFailed": "Nepodařilo se načíst komentáře.",
+    "errors": {
+      "content": {
+        "ContentRequired": "Komentář nesmí být prázdný."
+      },
+      "slug": {
+        "InvalidSlug": "Tento článek nyní nepřijímá komentáře."
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -4,6 +4,7 @@
     "about": "O mně",
     "project": "Projekt",
     "hireMe": "Najměte mě",
+    "blog": "Blog",
     "mySubmissions": "Mé nabídky",
     "admin": "Administrace",
     "adminTestErrors": "Testování chyb"

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "indexTitle": "Blog | Pavel Kalandra",
+    "indexDescription": "Posts on engineering, leadership, and tools I'm building."
+  },
+  "index": {
+    "heading": "Blog",
+    "intro": "Notes on engineering decisions, releases, and tools I'm building. Subscribe via",
+    "rssLink": "RSS",
+    "empty": "Nothing here yet — first post coming soon.",
+    "readMore": "Read post",
+    "draftLabel": "Draft"
+  },
+  "post": {
+    "publishedOn": "Published",
+    "updatedOn": "Updated",
+    "tagsLabel": "Tags"
+  },
+  "reactions": {
+    "heading": "Reactions",
+    "signedOutHint": "Sign in to react",
+    "loadFailed": "Could not load reactions.",
+    "submitFailed": "Reaction failed. Please try again.",
+    "labels": {
+      "ThumbsUp": "Like",
+      "Heart": "Love",
+      "Rocket": "Rocket",
+      "Eyes": "Eyes",
+      "Tada": "Celebrate",
+      "Laugh": "Laugh"
+    }
+  },
+  "comments": {
+    "heading": "Comments",
+    "empty": "Be the first to leave a comment.",
+    "signedOutHint": "Sign in to post a comment.",
+    "signedOutSignInCta": "Sign in",
+    "placeholder": "Share your thoughts…",
+    "submit": "Post comment",
+    "submitting": "Posting…",
+    "submitted": "Comment posted.",
+    "loadFailed": "Could not load comments.",
+    "errors": {
+      "content": {
+        "ContentRequired": "Comment can't be empty."
+      },
+      "slug": {
+        "InvalidSlug": "This post can't accept comments right now."
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -4,6 +4,7 @@
     "about": "About Me",
     "project": "Project",
     "hireMe": "Hire Me",
+    "blog": "Blog",
     "mySubmissions": "My Submissions",
     "admin": "Admin",
     "adminTestErrors": "Test Errors"

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -23,7 +23,16 @@ interface Props {
     | "admin/test-errors"
     | "profile"
     | "privacy"
-    | "terms";
+    | "terms"
+    | "blog";
+  /**
+   * Path used for canonical / alternate URLs when it differs from
+   * `activePage` (e.g. blog posts at `blog/<slug>` while still
+   * highlighting the "blog" nav link).
+   */
+  pagePath?: string;
+  /** Optional <link rel="alternate" type="application/rss+xml"> URL. */
+  rssUrl?: string;
   lang?: Locale;
 }
 
@@ -31,14 +40,18 @@ const {
   title,
   description = "Pavel Kalandra — CTO & Software Engineering Leader. Personal showcase built in public at kalandra.tech.",
   activePage,
+  pagePath,
+  rssUrl,
   lang = "en",
 } = Astro.props;
+
+const canonicalPagePath = pagePath ?? activePage;
 
 const t = lang === "cs" ? csCommon : enCommon;
 
 const siteUrl = "https://www.kalandra.tech";
-const enUrl = activePage === "home" ? `${siteUrl}/` : `${siteUrl}/${activePage}`;
-const csUrl = activePage === "home" ? `${siteUrl}/cs/` : `${siteUrl}/cs/${activePage}`;
+const enUrl = canonicalPagePath === "home" ? `${siteUrl}/` : `${siteUrl}/${canonicalPagePath}`;
+const csUrl = canonicalPagePath === "home" ? `${siteUrl}/cs/` : `${siteUrl}/cs/${canonicalPagePath}`;
 const canonicalUrl = lang === "cs" ? csUrl : enUrl;
 ---
 
@@ -59,6 +72,7 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
     <link rel="alternate" hreflang="cs" href={csUrl} />
     <link rel="alternate" hreflang="x-default" href={enUrl} />
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
+    {rssUrl && <link rel="alternate" type="application/rss+xml" title="kalandra.tech blog" href={rssUrl} />}
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/frontend/src/pages/[...lang]/blog/index.astro
+++ b/frontend/src/pages/[...lang]/blog/index.astro
@@ -1,0 +1,73 @@
+---
+import { Icon } from "astro-icon/components";
+import Layout from "../../../layouts/Layout.astro";
+import { locales, defaultLocale, localePath, type Locale } from "../../../i18n/utils";
+import { allPosts } from "../../../blog/posts";
+import enBlog from "../../../i18n/en/blog.json";
+import csBlog from "../../../i18n/cs/blog.json";
+
+const translations = { en: enBlog, cs: csBlog };
+
+export function getStaticPaths() {
+  return locales.map((lang) => ({
+    params: { lang: lang === defaultLocale ? undefined : lang },
+  }));
+}
+
+const lang = (Astro.params.lang ?? defaultLocale) as Locale;
+const t = translations[lang];
+
+const dateFmt = new Intl.DateTimeFormat(lang === "cs" ? "cs-CZ" : "en-US", { dateStyle: "long" });
+---
+
+<Layout title={t.meta.indexTitle} description={t.meta.indexDescription} activePage="blog" rssUrl="/rss.xml" lang={lang}>
+  <section class="max-w-3xl mx-auto px-4 md:px-8">
+    <header class="mb-12">
+      <h1 class="font-headline text-5xl md:text-6xl font-extrabold tracking-tighter leading-[1.1] mb-4">
+        {t.index.heading}
+      </h1>
+      <p class="font-body text-lg text-on-surface-variant leading-relaxed">
+        {t.index.intro}
+        <a href="/rss.xml" class="text-primary hover:underline inline-flex items-center gap-1" rel="alternate" type="application/rss+xml">
+          <Icon name="material-symbols:rss-feed" class="size-4" aria-hidden="true" />
+          {t.index.rssLink}
+        </a>.
+      </p>
+    </header>
+
+    {
+      allPosts.length === 0 ? (
+        <p class="text-on-surface-variant">{t.index.empty}</p>
+      ) : (
+        <ol class="space-y-8" aria-label={t.index.heading}>
+          {allPosts.map((post) => (
+            <li class="bg-surface-container-lowest border border-outline-variant/20 rounded-xl p-6 hover:border-primary/30 transition-colors">
+              <a href={localePath(lang, `blog/${post.slug}`)} class="group block">
+                <div class="flex items-center gap-3 text-xs text-on-surface-variant mb-2">
+                  <time datetime={post.pubDate}>{dateFmt.format(new Date(post.pubDate))}</time>
+                  {post.tags.length > 0 && (
+                    <ul class="flex flex-wrap gap-2" aria-label={t.post.tagsLabel}>
+                      {post.tags.map((tag) => (
+                        <li class="font-label uppercase tracking-widest px-2 py-0.5 rounded-md bg-surface-container-high">{tag}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <h2 class="font-headline text-2xl font-bold mb-2 group-hover:text-primary transition-colors">{post.title[lang]}</h2>
+                <p class="text-on-surface-variant leading-relaxed mb-4">{post.summary[lang]}</p>
+                <span class="font-label text-sm uppercase tracking-widest text-primary inline-flex items-center gap-1">
+                  {t.index.readMore}
+                  <Icon
+                    name="material-symbols:arrow-forward"
+                    class="size-4 group-hover:translate-x-1 transition-transform"
+                    aria-hidden="true"
+                  />
+                </span>
+              </a>
+            </li>
+          ))}
+        </ol>
+      )
+    }
+  </section>
+</Layout>

--- a/frontend/src/pages/[...lang]/blog/strongtypes-1-0.astro
+++ b/frontend/src/pages/[...lang]/blog/strongtypes-1-0.astro
@@ -1,0 +1,205 @@
+---
+import BlogPostLayout from "../../../components/BlogPostLayout.astro";
+import { locales, defaultLocale, type Locale } from "../../../i18n/utils";
+import type { BlogPostMeta } from "../../../blog/types";
+
+export const post: BlogPostMeta = {
+  slug: "strongtypes-1-0",
+  pubDate: "2026-04-23T15:32:00Z",
+  updatedDate: "2026-04-23T16:47:00Z",
+  title: {
+    en: "Shipping StrongTypes 1.0 — small types, fewer bugs",
+    cs: "Vyšlo StrongTypes 1.0 — malé typy, méně chyb",
+  },
+  summary: {
+    en: "StrongTypes 1.0 is out: NonEmptyString, sign-bound numerics, NonEmptyEnumerable, Maybe and Result for C#. The library you reach for when nullable and Try just aren't enough.",
+    cs: "Vyšlo StrongTypes 1.0: NonEmptyString, číselné typy se znaménkovým invariantem, NonEmptyEnumerable, Maybe a Result pro C#. Knihovna, po které sáhnete, když nullable a Try už nestačí.",
+  },
+  tags: ["csharp", "library", "release"],
+};
+
+export function getStaticPaths() {
+  return locales.map((lang) => ({
+    params: { lang: lang === defaultLocale ? undefined : lang },
+  }));
+}
+
+const lang = (Astro.params.lang ?? defaultLocale) as Locale;
+
+// Diagrams live in the StrongTypes repo. Linking the raw GitHub URLs keeps
+// this post in lock-step with the library docs — when a diagram is updated
+// upstream, the post picks it up without a frontend redeploy.
+const repo = "https://github.com/KaliCZ/StrongTypes";
+const diagram = (name: string) => `${repo}/raw/main/docs/diagrams/${name}.svg`;
+---
+
+<BlogPostLayout post={post} lang={lang}>
+  <p>
+    <a href={`${repo}/releases/tag/1.0.0`} target="_blank" rel="noopener"><strong>StrongTypes 1.0</strong></a> is out on NuGet. It's the first
+    stable cut of a small library I've been using to make everyday C# code safer — without dragging in a full algebraic-types framework. Three
+    packages: <code>Kalicz.StrongTypes</code> (core types and JSON converters),
+    <code>Kalicz.StrongTypes.EfCore</code> (EF Core mapping), and <code>Kalicz.StrongTypes.FsCheck</code> (property-based testing).
+  </p>
+
+  <figure>
+    <img
+      src={diagram("impact")}
+      alt="Validation pushed to the boundary: with strong types invalid input fails before it reaches the domain."
+      loading="lazy"
+    />
+    <figcaption>Strong types push validation to the API boundary.</figcaption>
+  </figure>
+
+  <h2>Why a 1.0?</h2>
+  <p>
+    The core idea: parse, don't validate. A
+    <code>NonEmptyString</code> is a string that is never null, empty, or whitespace-only — guaranteed at construction. A
+    <code>Positive&lt;int&gt;</code> is an int that is strictly greater than zero — guaranteed at construction. Once the parse succeeds, every
+    downstream method gets to assume the invariant. No more <code>if (string.IsNullOrWhiteSpace(...))</code>
+    sprinkled through the domain.
+  </p>
+  <p>
+    Every type ships with a <code>System.Text.Json</code> converter attached via <code>[JsonConverter]</code>, so invalid JSON fails at
+    deserialization — in ASP.NET Core, that's before your endpoint method even runs. No extra
+    <code>JsonSerializerOptions</code>, no manual converter registration.
+  </p>
+
+  <figure>
+    <img src={diagram("package-layout")} alt="The three NuGet packages and how they depend on each other." loading="lazy" />
+    <figcaption>Three packages so you only pull in what you actually use.</figcaption>
+  </figure>
+
+  <h2>The factory pattern</h2>
+  <p>
+    Every validated type uses the same shape: <code>Create</code> throws on bad input,
+    <code>TryCreate</code> returns null. The <code>As…</code> / <code>To…</code> string extensions mirror that split, so the call site decides
+    how to handle bad input.
+  </p>
+
+  <figure>
+    <img
+      src={diagram("trycreate-create-flow")}
+      alt="TryCreate returns null on invalid input; Create throws ArgumentException."
+      loading="lazy"
+    />
+    <figcaption>Pick the factory that matches how you want to handle bad input.</figcaption>
+  </figure>
+
+  <pre><code>{`NonEmptyString? maybe = NonEmptyString.TryCreate(input); // null when null/empty/whitespace
+NonEmptyString  must  = NonEmptyString.Create(input);   // throws ArgumentException
+NonEmptyString? sugar = userInput.AsNonEmpty();         // same as TryCreate, fluently
+
+Positive<int>? p   = Positive<int>.TryCreate(value);
+NonNegative<decimal> nn = NonNegative<decimal>.Create(amount);`}</code></pre>
+
+  <h2>NonEmptyEnumerable&lt;T&gt;</h2>
+  <p>
+    Same idea, applied to sequences. <code>NonEmptyEnumerable&lt;T&gt;</code> is a read-only sequence that is guaranteed to contain at least one
+    element — so <code>.Head</code> is always defined, <code>.Max()</code> never throws, and invariant-preserving LINQ operations like <code
+      >Select</code
+    >, <code>SelectMany</code>, <code>Distinct</code> and
+    <code>Concat</code> return another <code>NonEmptyEnumerable&lt;TResult&gt;</code> rather than decaying to plain
+    <code>IEnumerable</code>.
+  </p>
+
+  <figure>
+    <img
+      src={diagram("covariance")}
+      alt="The covariant out T parameter lets a NonEmptyEnumerable<Dog> upcast to INonEmptyEnumerable<Animal>."
+      loading="lazy"
+    />
+    <figcaption>The interface is covariant, so collection types upcast naturally.</figcaption>
+  </figure>
+
+  <h2>Maybe&lt;T&gt; for the cases nullable can't model</h2>
+  <p>
+    StrongTypes is deliberately not trying to replace <code>T?</code>. Plain nullables already cover most optional logic once you reach for <code
+      >Map</code
+    > / <code>MapTrue</code> / <code>MapFalse</code> to compose them. Where they fall over is HTTP <code>PATCH</code>: a request needs to
+    distinguish three intents — <em>don't touch this field</em>,
+    <em>clear it to null</em>, and <em>set it to a new value</em>. Plain <code>T?</code> collapses the first two.
+    <code>Maybe&lt;T&gt;?</code> keeps them apart.
+  </p>
+
+  <figure>
+    <img
+      src={diagram("patch-three-state")}
+      alt="The three states a PATCH field can be in: untouched, cleared, or set. Maybe<T>? maps onto all three."
+      loading="lazy"
+    />
+    <figcaption>The three states a PATCH field can be in.</figcaption>
+  </figure>
+
+  <pre><code>{`public record PatchRequest(Maybe<string>? NullableValue);
+
+[HttpPatch("{id:guid}")]
+public async Task<IActionResult> Patch(Guid id, PatchRequest request)
+{
+    var entity = await Db.FindAsync<MyEntity>(id);
+    if (entity is null) return NotFound();
+
+    // null means "skipped". Maybe.None means "deliberately set to null".
+    if (request.NullableValue is { } nv)
+        entity.NullableValue = nv.Value;
+
+    await Db.SaveChangesAsync();
+    return Ok();
+}`}</code></pre>
+
+  <p>
+    The struct also composes monadically through <code>Map</code>, <code>FlatMap</code> and <code>Where</code>, with LINQ query syntax
+    falling out for free.
+  </p>
+
+  <figure>
+    <img
+      src={diagram("maybe-composition")}
+      alt="A pipeline of Map / FlatMap / Where operations on Maybe, where None short-circuits the whole chain."
+      loading="lazy"
+    />
+    <figcaption>None short-circuits the whole chain — no explicit null checks.</figcaption>
+  </figure>
+
+  <h2>Result&lt;T, TError&gt; for failure paths</h2>
+  <p>
+    <code>Result&lt;T, TError&gt;</code> makes the failure path explicit in the type signature instead of hiding it behind exceptions. <code
+      >Result&lt;T&gt;</code
+    > is shorthand for <code>Result&lt;T, Exception&gt;</code>, so signatures can read <code>public Result&lt;User&gt; Load(...)</code> without
+    naming the error type.
+  </p>
+
+  <figure>
+    <img
+      src={diagram("result-composition")}
+      alt="A pipeline of Map / MapError / FlatMap operations on Result, with success and error flowing on independent tracks."
+      loading="lazy"
+    />
+    <figcaption>Success and error flow on independent tracks.</figcaption>
+  </figure>
+
+  <pre><code>{`public Result<int, string> Parse(string s) =>
+    int.TryParse(s, out var n) ? n : "not a number";
+
+Result<int, string> r = Parse(input);
+if (r.Success is { } value) return Ok(value);
+if (r.Error   is { } msg)   return BadRequest(msg);`}</code></pre>
+
+  <p>
+    There are also async overloads for every operation, <code>Result.Catch</code> for wrapping throwing calls, and
+    <code>Result.Aggregate</code> for combining several validations into a single result that collects every error rather than failing on the
+    first.
+  </p>
+
+  <h2>Where it fits in this site</h2>
+  <p>
+    The backend that powers this site is also using StrongTypes — every API request parses raw strings into
+    <code>NonEmptyString</code>, <code>MailAddress</code>, or a <code>Try&lt;T, TError&gt;</code> result before it reaches a handler. Once the
+    parse passes, the domain code never has to recheck. It's a small library doing one job: making the easy thing the right thing.
+  </p>
+  <p>
+    You can grab StrongTypes 1.0 from
+    <a href="https://www.nuget.org/packages/Kalicz.StrongTypes/" target="_blank" rel="noopener">NuGet</a> or read the full
+    <a href={`${repo}#readme`} target="_blank" rel="noopener">README</a>. Issues, PRs, and ideas are welcome on
+    <a href={repo} target="_blank" rel="noopener">GitHub</a>.
+  </p>
+</BlogPostLayout>

--- a/frontend/src/pages/rss.xml.ts
+++ b/frontend/src/pages/rss.xml.ts
@@ -1,0 +1,78 @@
+import type { APIRoute } from "astro";
+import { allPosts } from "../blog/posts";
+import type { BlogPostMeta } from "../blog/types";
+
+// Hand-rolled RSS 2.0 feed — the standard isn't large enough to justify a
+// dependency, and Astro's static endpoints make this a one-file build step.
+// Summary-only on purpose (description, not content:encoded): the goal is to
+// drive readers to the site, not to ship the whole article in the feed.
+
+export const GET: APIRoute = ({ site }) => {
+  if (!site) throw new Error("astro.config `site` must be set for RSS feed generation.");
+  const xml = buildRssXml(site, allPosts);
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=600",
+    },
+  });
+};
+
+function buildRssXml(site: URL, posts: BlogPostMeta[]): string {
+  const siteHref = trimTrailingSlash(site.href);
+  const feedUrl = `${siteHref}/rss.xml`;
+  const lastBuildDate = posts.length > 0 ? new Date(posts[0].pubDate) : new Date();
+
+  const items = posts.map((post) => buildItem(siteHref, post)).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml("kalandra.tech blog")}</title>
+    <link>${escapeXml(siteHref + "/blog")}</link>
+    <description>${escapeXml("Posts on engineering, leadership, and tools I'm building.")}</description>
+    <language>en-us</language>
+    <lastBuildDate>${toRfc822(lastBuildDate)}</lastBuildDate>
+    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+}
+
+function buildItem(siteHref: string, post: BlogPostMeta): string {
+  const link = `${siteHref}/blog/${post.slug}`;
+  const guid = post.canonicalUrl ?? link;
+  // English title and summary for the feed; per-locale variants stay in the
+  // post's metadata for the on-site rendering. RSS readers don't have a clean
+  // way to express alternate-language items, so we ship the canonical English.
+  const title = post.title.en;
+  const description = post.summary.en;
+
+  const categories = post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`).join("\n");
+
+  return `    <item>
+      <title>${escapeXml(title)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="${post.canonicalUrl ? "false" : "true"}">${escapeXml(guid)}</guid>
+      <pubDate>${toRfc822(new Date(post.pubDate))}</pubDate>
+      <description>${escapeXml(description)}</description>
+${categories}
+    </item>`;
+}
+
+function trimTrailingSlash(s: string) {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+function toRfc822(date: Date): string {
+  // RFC 822 is what the RSS 2.0 spec mandates for pubDate / lastBuildDate.
+  // toUTCString() is already RFC 7231-compliant, which is a strict subset of
+  // RFC 822 (the only meaningful difference is the use of "GMT" instead of
+  // "+0000", and that's accepted everywhere).
+  return date.toUTCString();
+}

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * E2E test for the signed-in blog interactions:
+ *   1. Reaction toggle: click adds (aria-pressed=true, count +1); click again removes (back to start).
+ *   2. Comment post: textarea → submit → comment appears in the list and persists across reload.
+ *
+ * Each run uses a fresh test user and posts a unique-tagged comment so concurrent
+ * runs don't see each other's data. The reaction assertions are written
+ * relative to the pre-test count rather than absolute, since the strongtypes-1-0
+ * post is shared state on the live API.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const POST_PATH = "/blog/strongtypes-1-0";
+
+const testUser = {
+  email: `e2e-blog-${Date.now()}@test.local`,
+  password: "test-password-123",
+  fullName: "E2E Blog User",
+};
+
+async function signIn(page: Page) {
+  await page.evaluate(
+    async ({ email, password }) => {
+      const supabase = await (window as { __supabaseReady?: Promise<unknown> }).__supabaseReady;
+      if (!supabase) throw new Error("Supabase client not available on window.__supabaseReady");
+      const { error } = await (
+        supabase as {
+          auth: { signInWithPassword: (c: { email: string; password: string }) => Promise<{ error: { message: string } | null }> };
+        }
+      ).auth.signInWithPassword({ email, password });
+      if (error) throw new Error(`Sign-in failed: ${error.message}`);
+    },
+    { email: testUser.email, password: testUser.password },
+  );
+}
+
+test.describe("Blog signed-in flow", () => {
+  test.beforeAll(async ({ request }) => {
+    const response = await request.post(`${SUPABASE_URL}/auth/v1/admin/users`, {
+      headers: {
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        apikey: SUPABASE_SERVICE_ROLE_KEY,
+        "Content-Type": "application/json",
+      },
+      data: {
+        email: testUser.email,
+        password: testUser.password,
+        email_confirm: true,
+        user_metadata: { full_name: testUser.fullName },
+      },
+    });
+    expect(response.ok(), `Failed to create test user: ${await response.text()}`).toBeTruthy();
+  });
+
+  test("reaction toggle: add then remove returns to starting count", async ({ page }) => {
+    await page.goto(POST_PATH);
+
+    const button = page.locator('[data-reaction="ThumbsUp"]');
+    const count = button.locator("[data-reaction-count]");
+    await expect(button).toBeVisible();
+    await signIn(page);
+
+    // After auth-change the component refreshes state. A fresh test user has no
+    // prior reaction on this post, so wait for that to settle before clicking.
+    await expect(button).toHaveAttribute("aria-pressed", "false");
+    const initialCount = parseInt(((await count.textContent()) ?? "0").trim(), 10);
+
+    // 1. Add reaction
+    await button.click();
+    await expect(button).toHaveAttribute("aria-pressed", "true");
+    await expect(count).toHaveText(new RegExp(`^\\s*${initialCount + 1}\\s*$`));
+
+    // 2. Remove reaction (toggle off)
+    await button.click();
+    await expect(button).toHaveAttribute("aria-pressed", "false");
+    await expect(count).toHaveText(new RegExp(`^\\s*${initialCount}\\s*$`));
+  });
+
+  test("comment post: appears in list and persists across reload", async ({ page }) => {
+    const commentText = `E2E test comment ${Date.now()} ${Math.random().toString(36).slice(2, 8)}`;
+
+    await page.goto(POST_PATH);
+    await signIn(page);
+
+    // Form is gated on auth — wait for it to become visible after sign-in.
+    const form = page.locator("[data-comment-form]");
+    await expect(form).toBeVisible();
+
+    await page.locator("[data-comment-textarea]").fill(commentText);
+    await page.locator("[data-comment-submit]").click();
+
+    // The new comment renders in the list with the user's display name.
+    const list = page.locator("[data-comments-list]");
+    await expect(list.locator("li", { hasText: commentText })).toBeVisible();
+    await expect(list.locator("li", { hasText: commentText })).toContainText(testUser.fullName);
+
+    // Persists across reload (proves the backend round-tripped, not just a DOM insertion).
+    await page.reload();
+    await expect(page.locator("[data-comments-list] li", { hasText: commentText })).toBeVisible();
+  });
+});

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -43,6 +43,41 @@ test.describe("Page rendering", () => {
     await page.goto("/project");
     await expect(page).toHaveTitle(/Project/);
   });
+
+  test("blog index lists posts and links to RSS", async ({ page }) => {
+    await page.goto("/blog");
+    await expect(page).toHaveTitle(/Blog/);
+    await expect(page.getByRole("heading", { name: "Blog", level: 1 })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Shipping StrongTypes 1\.0/ })).toBeVisible();
+    await expect(page.locator('link[rel="alternate"][type="application/rss+xml"]')).toHaveAttribute("href", "/rss.xml");
+  });
+
+  test("blog post renders chrome and signed-out reaction hint", async ({ page }) => {
+    await page.goto("/blog/strongtypes-1-0");
+    await expect(page).toHaveTitle(/StrongTypes 1\.0/);
+    await expect(page.getByRole("heading", { name: "Reactions" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Comments" })).toBeVisible();
+    await expect(page.getByText("Sign in to react")).toBeVisible();
+    await expect(page.getByText("Sign in to post a comment.")).toBeVisible();
+  });
+
+  test("blog post links to upstream StrongTypes diagrams", async ({ page }) => {
+    await page.goto("/blog/strongtypes-1-0");
+    const diagramImg = page.locator('img[src*="github.com/KaliCZ/StrongTypes/raw/main/docs/diagrams/"]').first();
+    await expect(diagramImg).toBeVisible();
+  });
+
+  test("rss feed includes the StrongTypes post", async ({ request }) => {
+    const res = await request.get("/rss.xml");
+    expect(res.status()).toBe(200);
+    // Static hosts serve .xml as application/xml; the live edge config can
+    // upgrade it to application/rss+xml. Either is valid for RSS readers.
+    expect(res.headers()["content-type"]).toMatch(/application\/(rss\+)?xml/);
+    const xml = await res.text();
+    expect(xml).toContain("<rss");
+    expect(xml).toContain("Shipping StrongTypes 1.0");
+    expect(xml).toContain("https://www.kalandra.tech/blog/strongtypes-1-0");
+  });
 });
 
 test.describe("Navigation", () => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "npm run test:backend && npm run test:frontend && npm run test:e2e",
     "test:backend": "dotnet test --verbosity normal",
     "test:frontend": "cd frontend && npm run test:install && npm test",
-    "test:e2e:build": "cd frontend && npm run build",
+    "test:e2e:build": "cd frontend && cross-env PUBLIC_API_URL=http://localhost:5000 npm run build",
     "test:e2e": "npm run dev:db && npm run dev:supabase && npm run test:e2e:build && concurrently --kill-others --success first --names backend,serve,test --prefix-colors blue,yellow,green \"cd backend/src/Kalandra.Api && dotnet run\" \"wait-on http://localhost:5000/health && serve frontend/dist -l 4321\" \"wait-on http://localhost:5000/health && wait-on http://localhost:4321 && cd frontend && npm run test:e2e\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- New blog domain: post pages under `[...lang]/blog/`, shared `BlogPostLayout`, `/rss.xml` endpoint, listing index, and a metadata contract (`pubDate`, `updatedDate`, `tags`, `draft`, `canonicalUrl`) that #92 and #109 will both reuse.
- New `Kalandra.Blog` backend module: append-only event streams per post slug for comments and reactions (separate UUIDv5 streams so high-volume reactions don't share a replay path with comments), reaction toggle add/remove semantics on replay.
- New `BlogController` with `[Authorize]` POST endpoints and anonymous GETs, plus a parallel API error enum (`AddBlogCommentError`, `BlogSlugError`) so the wire contract stays a stable enum name the frontend's i18n map can key off.
- First post: [Shipping StrongTypes 1.0](frontend/src/pages/%5B...lang%5D/blog/strongtypes-1-0.astro), pulling diagrams straight from the upstream repo.

## Test plan

- [x] Backend integration tests: 12 cases in `BlogApiTests` cover auth gates (401 on POST without auth, 200 on GET), comment add → list flow, slug isolation, whitespace trim, invalid-slug 400, reaction toggle add/remove with multi-user accounting, anonymous viewer correctness, and the wire contract for the emoji enum.
- [x] Signed-out E2E: blog index lists posts and links to RSS, post page renders chrome with the signed-out hint, RSS feed includes the post.
- [x] Signed-in E2E (`blog-flow.spec.ts`): reaction toggle (add → pressed + count +1; toggle off → unpressed + back to start), comment post (appears with display name, persists across reload).

## Notes

- Closes #91
- Spotted and fixed during the merge: blog components were calling `/api/...` directly. That works in dev (Vite proxies) but would break in production where the API is on a different origin. They now use `PUBLIC_API_URL` like every other API caller in the codebase. Same fix applied to the local `test:e2e:build` script so it builds with `PUBLIC_API_URL=http://localhost:5000` to match CI.
- Validation contract: dropped `[Required]` from `AddBlogCommentRequest`. Framework auto-validation was short-circuiting before the controller's own check, returning a `Content` (PascalCase) key with the generic message rather than the stable `content` / `ContentRequired` the frontend looks up.
- Follow-up: #92 (sitemap from blog metadata) and #109 (JSON-LD structured data so search engines see comment/reaction counts) both build on the metadata glob this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)