### PR TITLE
About: rework Manifesto into Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Personal showcase website at [www.kalandra.tech](https://www.kalandra.tech). Ser
 ## What's here
 
 - [**Home**](https://www.kalandra.tech) — intro and navigation
-- [**About Me**](https://www.kalandra.tech/about) — career timeline, manifesto, links
+- [**About Me**](https://www.kalandra.tech/about) — career timeline, values, links
 - [**Project**](https://www.kalandra.tech/project) — live roadmap tracking the build progress of this site
 - [**Hire Me**](https://www.kalandra.tech/hire-me) — job offer submission form (requires sign-in)
 - [**Job Offers**](https://www.kalandra.tech/job-offers) — submitted offers with status tracking and admin review

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -20,7 +20,7 @@
   "toc": {
     "title": "Na této stránce",
     "overview": "Přehled",
-    "manifesto": "Manifest",
+    "values": "Hodnoty",
     "skills": "Dovednosti",
     "personal": "O mně",
     "career": "Kariéra"
@@ -67,38 +67,36 @@
       }
     ]
   },
-  "manifesto": {
-    "title": "Můj manifest",
-    "subtitle": "Navrhuji systémy, které nejen fungují dnes, ale elegantně se vyvíjejí v čase.",
+  "values": {
+    "title": "Moje hodnoty",
     "pillars": [
       {
-        "icon": "architecture",
+        "icon": "tune",
         "color": "primary",
-        "title": "Odolná architektura",
-        "description": "Systémy, které se elegantně přizpůsobují měnícím se potřebám byznysu."
+        "title": "Soustřeď se na produkt, ušetříš na údržbě",
+        "description": "Každý systém, který nasadíš, si necháš navždy. Stavěj jednoduše, když to jde, a komplexně, když to musí být. Microservices nejsou výchozí volba — buď jsou nutnost, nebo overkill."
+      },
+      {
+        "icon": "visibility",
+        "color": "tertiary",
+        "title": "Transparentnost a upřímnost",
+        "description": "Těžká rozhodnutí potřebují kompletní informace. To, co se v týmu neřekne nahlas, se pomlouvá v zákulisí."
+      },
+      {
+        "icon": "handshake",
+        "color": "secondary",
+        "title": "Týmový hráč",
+        "description": "Přijď každý den s úmyslem něco zlepšit — kód, testy, kolegův den. Spolehni se na ostatní a buď spolehlivý pro ně."
       },
       {
         "icon": "groups",
-        "color": "tertiary",
-        "title": "Autonomní týmy",
-        "description": "Kultura, kde každý inženýr cítí zodpovědnost za svou práci a má prostor růst."
-      }
-    ],
-    "accordions": [
-      {
         "color": "primary",
-        "title": "Umožněte si škálovat",
-        "content": "Software by neměl být složitý. Každý kus softwaru vyžaduje údržbu a učení. Pokud vám neusnadňuje život, postavte ho jinak. Nebo ho nestavte vůbec. Nezasekněte se v režimu opravování. Využijte čas na tvorbu hodnoty."
-      },
-      {
-        "color": "tertiary",
-        "title": "Buďte šťastní ze své práce",
-        "content": "Většina inženýrů dělá tuto práci, protože milují tvorbu. Dejte jim trochu volnosti a sledujte, jak váš software roste. Motivovat inženýry by nemělo být těžké."
-      },
-      {
-        "color": "secondary",
-        "title": "Zaměřte se na DX",
-        "content": "Spojením těch dvou bodů dostanete jednoduchý závěr. Opravte to, co inženýry trápí, a oni vám na oplátku vylepší produkt. Všichni vyhrávají. Všichni jsou spokojení."
+        "title": "Autonomní týmy",
+        "description": "Kultura, kde každý inženýr vlastní svou doménu end-to-end a má prostor zanechat stopu.",
+        "paragraphs": [
+          "Slaď strukturu týmů se strukturou produktu, aby inženýři vlastnili doménu end-to-end, ne jen backlog. Zodpovědnost a vlastnictví jdou ruku v ruce. To je opravdový empowerment.",
+          "Dej týmu jasnou vizi, vyhraď čas na bugy a eskalace a 10–20 % času nech volných, aby si inženýři mohli zkoušet vlastní nápady. Řešit problémy je zábava; být kódící opicí bez slova ne."
+        ]
       }
     ]
   },

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -20,7 +20,7 @@
   "toc": {
     "title": "On this page",
     "overview": "Overview",
-    "manifesto": "Manifesto",
+    "values": "Values",
     "skills": "Skills",
     "personal": "About me",
     "career": "Career"
@@ -67,38 +67,36 @@
       }
     ]
   },
-  "manifesto": {
-    "title": "My Manifesto",
-    "subtitle": "Designing systems that don't just work today, but evolve gracefully over time.",
+  "values": {
+    "title": "My Values",
     "pillars": [
       {
-        "icon": "architecture",
+        "icon": "tune",
         "color": "primary",
-        "title": "Resilient Architecture",
-        "description": "Systems that evolve gracefully as business needs shift."
+        "title": "Focus on your product, save on maintenance",
+        "description": "Every system you ship is a system you keep forever. Build simple when possible, go complex when necessary. Microservices aren't a default — they're either a must-have or overkill."
+      },
+      {
+        "icon": "visibility",
+        "color": "tertiary",
+        "title": "Transparency and honesty",
+        "description": "Hard decisions need full information. What teams don't say openly, they gossip about privately."
+      },
+      {
+        "icon": "handshake",
+        "color": "secondary",
+        "title": "A Teamplayer",
+        "description": "Show up every day with the intent to improve something — code, tests, a teammate's day. Rely on others, and be reliable for others."
       },
       {
         "icon": "groups",
-        "color": "tertiary",
-        "title": "Empowered Teams",
-        "description": "Autonomous cultures where every engineer has ownership and a path to mastery."
-      }
-    ],
-    "accordions": [
-      {
         "color": "primary",
-        "title": "Allow yourself to scale",
-        "content": "Software shouldn't be hard. Every piece of software requires maintenance and learning. If it doesn't make your life easier, build it different. Or don't build it at all. Don't get stuck in maintenance mode. Use your time for building value."
-      },
-      {
-        "color": "tertiary",
-        "title": "Be happy about your work",
-        "content": "Most engineers do this job because they love building. Give them some free time and just watch how they make your software grow. Motivating engineers shouldn't be difficult."
-      },
-      {
-        "color": "secondary",
-        "title": "Focus on DX",
-        "content": "By applying the two points above, you get a simple implication. Fix what's bothering the engineers and they will make your product better in return. Everybody wins. Everybody's happy."
+        "title": "Empowered teams",
+        "description": "Autonomous cultures where every engineer has end-to-end ownership and room to leave a mark.",
+        "paragraphs": [
+          "Align team structure with product structure so engineers own a domain end-to-end, not just the backlog. Accountability and responsibility go hand in hand. That's empowerment.",
+          "Give the team a clear vision, budget time for bugs and escalations, and leave 10–20% unbooked so engineers can chase their own ideas. Solving problems is fun; being a coding monkey with no say isn't."
+        ]
       }
     ]
   },

--- a/frontend/src/pages/[...lang]/about.astro
+++ b/frontend/src/pages/[...lang]/about.astro
@@ -23,7 +23,7 @@ const t = translations[lang];
 
 const tocItems = [
   { id: "hero", label: t.toc.overview },
-  { id: "manifesto", label: t.toc.manifesto },
+  { id: "values", label: t.toc.values },
   { id: "skills", label: t.toc.skills },
   { id: "personal", label: t.toc.personal },
   { id: "career", label: t.toc.career },
@@ -115,65 +115,67 @@ const tocItems = [
     </div>
   </section>
 
-  <!-- Manifesto Section -->
+  <!-- Values Section -->
   <section
-    id="manifesto"
+    id="values"
     class="bg-surface-container-highest dark:bg-surface-container-low py-12 lg:py-16 relative overflow-hidden border-t border-outline-variant dark:border-on-surface/5"
   >
     <div class="absolute top-0 right-0 w-64 h-64 bg-primary/5 rounded-full blur-[100px] -mr-32 -mt-32"></div>
     <div class="max-w-7xl mx-auto px-4 md:px-8 relative z-10">
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-16">
-        <!-- Left Column -->
-        <div>
-          <h2 class="font-headline text-4xl font-extrabold mb-8 tracking-tight">
-            {t.manifesto.title}
-          </h2>
-          <p class="text-on-surface-variant text-lg leading-relaxed mb-12">
-            {t.manifesto.subtitle}
-          </p>
-          <ul class="space-y-8">
-            {
-              t.manifesto.pillars.map((pillar) => (
+      <h2 class="font-headline text-4xl font-extrabold mb-12 tracking-tight">
+        {t.values.title}
+      </h2>
+      <!-- Asymmetric two-column layout: short pillars stack on the left, the
+           long-form Empowered Teams pillar (with its lede + two paragraphs)
+           occupies the right column on its own. The split is driven by the
+           presence of `paragraphs` on the data, so adding/removing long
+           pillars adapts the layout without rewiring it. -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16">
+        <ul class="space-y-10">
+          {
+            t.values.pillars
+              .filter((pillar) => !("paragraphs" in pillar))
+              .map((pillar) => (
                 <li class="flex gap-4">
                   <Icon
                     name={`material-symbols:${pillar.icon.replace(/_/g, "-")}`}
-                    class:list={["size-[30px] shrink-0", `text-${pillar.color}`]}
+                    class:list={["size-[30px] shrink-0 mt-1", `text-${pillar.color}`]}
                     aria-hidden="true"
                   />
-                  <div>
+                  <div class="flex-1">
                     <h3 class="font-bold text-xl mb-2">{pillar.title}</h3>
                     <p class="text-on-surface-variant leading-relaxed">{pillar.description}</p>
                   </div>
                 </li>
               ))
-            }
-          </ul>
-        </div>
-        <!-- Right Column (Expandable sections) -->
-        <div class="flex flex-col justify-center">
-          <div class="space-y-4">
-            {
-              t.manifesto.accordions.map((accordion) => (
-                <details class="group bg-surface-container-lowest rounded-xl border border-outline-variant/20 shadow-sm">
-                  <summary
-                    class:list={[
-                      "p-6 cursor-pointer font-label text-base flex justify-between items-center select-none",
-                      `text-${accordion.color}`,
-                    ]}
-                  >
-                    <span>{accordion.title}</span>
-                    <Icon
-                      name="material-symbols:expand-more"
-                      class="size-3.5 transition-transform group-open:rotate-180"
-                      aria-hidden="true"
-                    />
-                  </summary>
-                  <div class="px-6 pb-6 text-on-surface-variant leading-relaxed">{accordion.content}</div>
-                </details>
+          }
+        </ul>
+        <ul class="space-y-10">
+          {
+            t.values.pillars
+              .filter((pillar) => "paragraphs" in pillar && pillar.paragraphs)
+              .map((pillar) => (
+                <li class="flex gap-4">
+                  <Icon
+                    name={`material-symbols:${pillar.icon.replace(/_/g, "-")}`}
+                    class:list={["size-[30px] shrink-0 mt-1", `text-${pillar.color}`]}
+                    aria-hidden="true"
+                  />
+                  <div class="flex-1">
+                    <h3 class="font-bold text-xl mb-2">{pillar.title}</h3>
+                    <p class="text-on-surface-variant leading-relaxed">{pillar.description}</p>
+                    {"paragraphs" in pillar && pillar.paragraphs && (
+                      <div class="mt-4 space-y-4">
+                        {pillar.paragraphs.map((para) => (
+                          <p class="text-on-surface-variant leading-relaxed">{para}</p>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </li>
               ))
-            }
-          </div>
-        </div>
+          }
+        </ul>
       </div>
     </div>
   </section>
@@ -225,7 +227,7 @@ const tocItems = [
     </div>
   </section>
 
-  <!-- Personal Section. Third band in the sequence Manifesto → Skills → Personal,
+  <!-- Personal Section. Third band in the sequence Values → Skills → Personal,
        using the lighter shade so it alternates with Skills (which uses the
        middle shade). The band's bottom border acts as the divider that closes
        off the colored-bands zone before the transparent Career timeline. Cards


### PR DESCRIPTION
## Summary

- **Renamed** the *Manifesto* section to *Values* — the old name promised more edge than the copy delivered.
- **Replaced** the two-column pillars + collapsible accordions structure with four declarative values, all visible (no content hidden behind clicks).
- **Asymmetric 3+1 layout**: three short pillars in the left column, *Empowered teams* alone in the right with its lede + two paragraphs — driven by whether a pillar has `paragraphs` data, so adding/removing long pillars adapts the layout automatically.
- Voice tightened to match the CV (opinionated, with edges someone could disagree with). The four values:
  1. **Focus on your product, save on maintenance** — *Microservices aren't a default — they're either a must-have or overkill.*
  2. **Transparency and honesty** — *What teams don't say openly, they gossip about privately.*
  3. **A Teamplayer** — *Rely on others, and be reliable for others.*
  4. **Empowered teams** — autonomy, vision + 10–20% slack, *"Solving problems is fun; being a coding monkey with no say isn't."*
- Czech translations updated to keep the same opinionated voice (will be reviewed).
- README pointer updated (`career timeline, manifesto, links` → `career timeline, values, links`).

## Test plan

- [x] Verified rendering at desktop (1280×800) and mobile (375×812) — 2-column on desktop, single column on mobile.
- [x] Verified TOC pill renamed (`Manifesto` → `Values`) and active-state still tracks scrolling.
- [x] Verified both EN and CS render correctly.
- [x] Verified all four pillars render with their icons; *Empowered teams* shows its lede + two distinct paragraphs.
- [x] No console errors.
- [ ] Pavel to review the Czech translations.

## Notes

The full test suite has one unrelated flake on `tests/e2e/avatar-flow.spec.ts:51` (avatar upload flow) — touches nothing in this PR. The other 11 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)