### PR TITLE
About: expand Rossum tenure with roadmap and leader-coaching detail

### DIFF
--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -603,10 +603,12 @@
               <div class="exp-dates">Apr 2024 — Jan 2025</div>
             </div>
             <div class="exp-desc">
-              <p>My only hands-off role — middle management. Led roughly one third of engineering, a team of 15.</p>
+              <p>My only hands-off role — middle management. Led roughly one third of engineering — a team of 15.</p>
               <p>
-                Ran an initiative to align the team structure with the product structure so engineers could have end-to-end ownership of
-                their domain. Put in place principles and processes that kept technical quality from being sacrificed under tight deadlines.
+                Ran an initiative to align team structure with product structure so engineers could have end-to-end ownership of their
+                domain. Put principles and processes in place that kept technical quality from being sacrificed under tight deadlines. Built
+                a transparent roadmap to manage stakeholder delivery expectations and discuss staffing requirements. Hired and coached new
+                leaders.
               </p>
             </div>
           </div>

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -184,7 +184,7 @@
         "date": "Dub 2024 — Led 2025",
         "role": "Tribe Lead",
         "company": "Rossum",
-        "description": "Moje jediná hands-off role — middle management. Vedl jsem zhruba třetinu engineeringu — tým 15 lidí.\n\nVedl jsem iniciativu, která sladila strukturu týmů se strukturou produktu, aby inženýři mohli mít end-to-end vlastnictví své domény. Také jsem zavedl principy a procesy, které zajistily, že technická kvalita nepadla za oběť napjatým termínům."
+        "description": "Moje jediná hands-off role — middle management. Vedl jsem zhruba třetinu engineeringu — tým 15 lidí.\n\nVedl jsem iniciativu, která sladila strukturu týmů se strukturou produktu, aby inženýři mohli mít end-to-end vlastnictví své domény. Zavedl jsem principy a procesy, které zajistily, že technická kvalita nepadla za oběť napjatým termínům. Postavil jsem transparentní roadmapu, abych řídil očekávání stakeholderů ohledně dodávek a otevřel diskuzi o personálních potřebách. Najímal a koučoval jsem nové lídry."
       },
       {
         "side": "left",

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -184,7 +184,7 @@
         "date": "Apr 2024 — Jan 2025",
         "role": "Tribe Lead",
         "company": "Rossum",
-        "description": "My only hands-off role — middle management. I lead roughly one third of engineering - a team of 15.\n\nI ran an initiative to align the team structure with the product structure so engineers can have end-to-end ownership of their domain. I also put in place some principles and processes that kept technical quality from being sacrificed under tight deadlines."
+        "description": "My only hands-off role — middle management. Led roughly one third of engineering — a team of 15.\n\nI ran an initiative to align team structure with product structure so engineers could have end-to-end ownership of their domain. I put principles and processes in place that kept technical quality from being sacrificed under tight deadlines. I built a transparent roadmap to manage stakeholder delivery expectations and discuss staffing requirements. I hired and coached new leaders."
       },
       {
         "side": "left",


### PR DESCRIPTION
## Summary
- Aligns the website Rossum entry with the fuller LinkedIn version of the same role.
- Adds two facets that were missing: building a transparent roadmap to manage stakeholder delivery expectations and staffing conversations, and hiring + coaching new leaders.
- Updates English About JSON, Czech About JSON, and the CV HTML in lockstep so the on-site narrative, the printable CV, and the LinkedIn profile tell the same story.

## Voice notes
- Kept the per-medium voice split intentional: About JSON keeps first-person ("I ran...", "I built...") matching the existing About copy; CV uses verb-led résumé bullets ("Ran...", "Built...") matching the existing CV style.
- Cleaned `Put in place principles and processes` → `Put principles and processes in place` (LinkedIn paste had `put down ... in place` which doubled up; existing site copy already used the cleaner phrasing).

## Test plan
- [x] `npm test` — 11/12 e2e passed; the single failure (`avatar-flow.spec.ts › upload avatar → verify in profile, nav, and comments`) is unrelated to a content-only string change and looks like a pre-existing flake. Worth a separate look outside this PR.
- [ ] Verify Rossum block renders on the About page (EN + CS).
- [ ] Verify the CV PDF regenerates with the expanded Rossum description on the next `npm run build:cv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)