### PR TITLE
strong-types: theme-aware diagrams via -dark.svg + JS swap

### DIFF
--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -45,7 +45,8 @@
     "title": "Proč se obtěžovat se silnými typy?",
     "subtitle": "Přestaňte validovat vstup všude. Validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact.svg",
+      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact-dark.svg",
       "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek",
       "caption": "Validace se přesouvá na hranici. Vnitřní kód přestane stále dokola kontrolovat tytéž invarianty."
     },
@@ -76,7 +77,8 @@
     "title": "Rozložení balíčků",
     "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout.svg",
+      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout-dark.svg",
       "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck"
     }
   },
@@ -140,7 +142,8 @@
         "description": "Každý typ má Create (vyhodí výjimku při neplatném vstupu) a TryCreate (vrátí null). Stringové typy mají i plynulou formu rozšíření.",
         "code": "// Stringy — tři varianty volání\n// throws při neplatném vstupu\nNonEmptyString name = NonEmptyString.Create(input);\n// null při neplatném\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent rozšíření\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Čísla — vynucené znaménko nad INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sekvence — alespoň jeden prvek, Head bezpečné\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow-dark.svg",
           "alt": "Diagram porovnávající TryCreate (vrátí null při neplatném vstupu) a Create (vyhodí výjimku při neplatném vstupu)"
         }
       },
@@ -149,7 +152,8 @@
         "description": "Pattern matching na Success nebo Error — žádné výjimky, žádné out parametry.",
         "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition-dark.svg",
           "alt": "Diagram pipeline ukazující, jak hodnota Result<T, TError> prochází fázemi Map, MapError a FlatMap"
         }
       },
@@ -158,7 +162,8 @@
         "description": "Rozlišení \"neměnit\", \"nastavit na null\" a \"nastavit na hodnotu\" — letitý problém v REST API.",
         "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → pole neměnit\n// Some(null)   → vyprázdnit\n// Some(\"abc\")  → nastavit\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state-dark.svg",
           "alt": "Diagram tří stavů v PATCH: null (neměnit), Some(null) (vyprázdnit), Some(value) (nastavit)"
         }
       },
@@ -167,7 +172,8 @@
         "description": "Řetězení volitelných operací bez vnořených null kontrol. Implicitní operátory zařídí zabalení — vrátíte T nebo Maybe.None a funguje to.",
         "code": "// Producent: implicitní převod z T nebo Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, automaticky zabalí v Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, bez dvojitého zabalení\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition-dark.svg",
           "alt": "Diagram pipeline ukazující, jak Some a None hodnoty procházejí operacemi Map a FlatMap nad Maybe<T>"
         }
       }

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -45,8 +45,7 @@
     "title": "Proč se obtěžovat se silnými typy?",
     "subtitle": "Přestaňte validovat vstup všude. Validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact.svg",
-      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact-dark.svg",
+      "key": "impact",
       "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek",
       "caption": "Validace se přesouvá na hranici. Vnitřní kód přestane stále dokola kontrolovat tytéž invarianty."
     },
@@ -77,8 +76,7 @@
     "title": "Rozložení balíčků",
     "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout.svg",
-      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout-dark.svg",
+      "key": "packageLayout",
       "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck"
     }
   },
@@ -142,8 +140,7 @@
         "description": "Každý typ má Create (vyhodí výjimku při neplatném vstupu) a TryCreate (vrátí null). Stringové typy mají i plynulou formu rozšíření.",
         "code": "// Stringy — tři varianty volání\n// throws při neplatném vstupu\nNonEmptyString name = NonEmptyString.Create(input);\n// null při neplatném\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent rozšíření\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Čísla — vynucené znaménko nad INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sekvence — alespoň jeden prvek, Head bezpečné\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow-dark.svg",
+          "key": "trycreateCreateFlow",
           "alt": "Diagram porovnávající TryCreate (vrátí null při neplatném vstupu) a Create (vyhodí výjimku při neplatném vstupu)"
         }
       },
@@ -152,8 +149,7 @@
         "description": "Pattern matching na Success nebo Error — žádné výjimky, žádné out parametry.",
         "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition-dark.svg",
+          "key": "resultComposition",
           "alt": "Diagram pipeline ukazující, jak hodnota Result<T, TError> prochází fázemi Map, MapError a FlatMap"
         }
       },
@@ -162,8 +158,7 @@
         "description": "Rozlišení \"neměnit\", \"nastavit na null\" a \"nastavit na hodnotu\" — letitý problém v REST API.",
         "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → pole neměnit\n// Some(null)   → vyprázdnit\n// Some(\"abc\")  → nastavit\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state-dark.svg",
+          "key": "patchThreeState",
           "alt": "Diagram tří stavů v PATCH: null (neměnit), Some(null) (vyprázdnit), Some(value) (nastavit)"
         }
       },
@@ -172,8 +167,7 @@
         "description": "Řetězení volitelných operací bez vnořených null kontrol. Implicitní operátory zařídí zabalení — vrátíte T nebo Maybe.None a funguje to.",
         "code": "// Producent: implicitní převod z T nebo Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, automaticky zabalí v Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, bez dvojitého zabalení\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition-dark.svg",
+          "key": "maybeComposition",
           "alt": "Diagram pipeline ukazující, jak Some a None hodnoty procházejí operacemi Map a FlatMap nad Maybe<T>"
         }
       }

--- a/frontend/src/i18n/cs/strong-types.json
+++ b/frontend/src/i18n/cs/strong-types.json
@@ -46,8 +46,7 @@
     "subtitle": "Přestaňte validovat vstup všude. Validujte jednou, na hranici, a zbytek nechte vynutit překladač.",
     "diagram": {
       "key": "impact",
-      "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek",
-      "caption": "Validace se přesouvá na hranici. Vnitřní kód přestane stále dokola kontrolovat tytéž invarianty."
+      "alt": "Diagram ukazující, jak StrongTypes přesouvá validaci na hranici aplikace a zbytek kódu zůstává bez ochranných podmínek"
     },
     "points": [
       {
@@ -73,8 +72,6 @@
     ]
   },
   "packageLayout": {
-    "title": "Rozložení balíčků",
-    "description": "Jeden hlavní balíček, dva volitelné doplňky. Stáhněte si jen to, co potřebujete.",
     "diagram": {
       "key": "packageLayout",
       "alt": "Diagram tří NuGet balíčků: hlavní Kalicz.StrongTypes plus volitelné doplňky EfCore a FsCheck"

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -46,8 +46,7 @@
     "subtitle": "Stop validating input everywhere. Validate once, at the boundary, and let the compiler enforce the rest.",
     "diagram": {
       "key": "impact",
-      "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses",
-      "caption": "Validation moves to the boundary. Internal code stops re-checking the same invariants over and over."
+      "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses"
     },
     "points": [
       {
@@ -73,8 +72,6 @@
     ]
   },
   "packageLayout": {
-    "title": "Package layout",
-    "description": "One core package, two opt-in companions. Pull in only what you need.",
     "diagram": {
       "key": "packageLayout",
       "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages"

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -45,8 +45,7 @@
     "title": "Why bother with strong types?",
     "subtitle": "Stop validating input everywhere. Validate once, at the boundary, and let the compiler enforce the rest.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact.svg",
-      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact-dark.svg",
+      "key": "impact",
       "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses",
       "caption": "Validation moves to the boundary. Internal code stops re-checking the same invariants over and over."
     },
@@ -77,8 +76,7 @@
     "title": "Package layout",
     "description": "One core package, two opt-in companions. Pull in only what you need.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout.svg",
-      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout-dark.svg",
+      "key": "packageLayout",
       "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages"
     }
   },
@@ -139,8 +137,7 @@
         "description": "Each type has Create (throws on invalid) and TryCreate (returns null). String types also have a fluent extension form.",
         "code": "// Strings — three call styles\n// throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n// null if invalid\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent extension\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Numbers — sign-enforced over INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sequences — at least one element, Head safe\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow-dark.svg",
+          "key": "trycreateCreateFlow",
           "alt": "Flow diagram contrasting TryCreate (returns null on invalid input) and Create (throws on invalid input)"
         }
       },
@@ -149,8 +146,7 @@
         "description": "Pattern-match on Success or Error — no exceptions, no out parameters.",
         "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition-dark.svg",
+          "key": "resultComposition",
           "alt": "Pipeline diagram showing how a Result<T, TError> value flows through Map, MapError, and FlatMap stages"
         }
       },
@@ -159,8 +155,7 @@
         "description": "Distinguish \"don't touch\", \"clear to null\", and \"set to value\" — a long-standing pain point in REST APIs.",
         "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → don't touch the field\n// Some(null)   → clear it\n// Some(\"abc\")  → set it\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state-dark.svg",
+          "key": "patchThreeState",
           "alt": "Diagram of the three-state PATCH model: null (don't touch), Some(null) (clear), Some(value) (set)"
         }
       },
@@ -169,8 +164,7 @@
         "description": "Chain optional operations without nested null checks. Implicit operators handle the wrapping — you return a T or Maybe.None and it just works.",
         "code": "// Producer: implicit conversion from T or Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, auto-wraps in Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, no double-wrap\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition.svg",
-          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition-dark.svg",
+          "key": "maybeComposition",
           "alt": "Pipeline diagram showing Some and None values flowing through Map and FlatMap operations on Maybe<T>"
         }
       }

--- a/frontend/src/i18n/en/strong-types.json
+++ b/frontend/src/i18n/en/strong-types.json
@@ -45,7 +45,8 @@
     "title": "Why bother with strong types?",
     "subtitle": "Stop validating input everywhere. Validate once, at the boundary, and let the compiler enforce the rest.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/impact.svg",
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact.svg",
+      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/impact-dark.svg",
       "alt": "Diagram showing how StrongTypes pulls validation to the application boundary, leaving the rest of the code free of guard clauses",
       "caption": "Validation moves to the boundary. Internal code stops re-checking the same invariants over and over."
     },
@@ -76,7 +77,8 @@
     "title": "Package layout",
     "description": "One core package, two opt-in companions. Pull in only what you need.",
     "diagram": {
-      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/package-layout.svg",
+      "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout.svg",
+      "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/package-layout-dark.svg",
       "alt": "Diagram of the three NuGet packages: the core Kalicz.StrongTypes plus optional EfCore and FsCheck companion packages"
     }
   },
@@ -137,7 +139,8 @@
         "description": "Each type has Create (throws on invalid) and TryCreate (returns null). String types also have a fluent extension form.",
         "code": "// Strings — three call styles\n// throws if invalid\nNonEmptyString name = NonEmptyString.Create(input);\n// null if invalid\nNonEmptyString? safe = NonEmptyString.TryCreate(input);\n// fluent extension\nNonEmptyString? fluent = input.AsNonEmpty();\n\n// Numbers — sign-enforced over INumber<T>\nPositive<int> qty = Positive<int>.Create(5);\nNonNegative<decimal>? price = amount.AsNonNegative();\n\n// Sequences — at least one element, Head safe\nNonEmptyEnumerable<string> tags = [\"red\", \"blue\"];\nNonEmptyEnumerable<string>? maybe = list.AsNonEmpty();\nstring first = tags.Head;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/trycreate-create-flow.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/trycreate-create-flow-dark.svg",
           "alt": "Flow diagram contrasting TryCreate (returns null on invalid input) and Create (throws on invalid input)"
         }
       },
@@ -146,7 +149,8 @@
         "description": "Pattern-match on Success or Error — no exceptions, no out parameters.",
         "code": "Result<int, string> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : \"not a number\";\n\nvar result = Parse(input);\nif (result.Success is { } value)\n    Console.WriteLine($\"got {value}\");\nif (result.Error is { } msg)\n    Console.WriteLine($\"failed: {msg}\");",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/result-composition.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/result-composition-dark.svg",
           "alt": "Pipeline diagram showing how a Result<T, TError> value flows through Map, MapError, and FlatMap stages"
         }
       },
@@ -155,7 +159,8 @@
         "description": "Distinguish \"don't touch\", \"clear to null\", and \"set to value\" — a long-standing pain point in REST APIs.",
         "code": "public record PatchUser(Maybe<string>? Nickname);\n\n// null         → don't touch the field\n// Some(null)   → clear it\n// Some(\"abc\")  → set it\nif (request.Nickname is { } change)\n    user.Nickname = change.Value;",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/patch-three-state.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/patch-three-state-dark.svg",
           "alt": "Diagram of the three-state PATCH model: null (don't touch), Some(null) (clear), Some(value) (set)"
         }
       },
@@ -164,7 +169,8 @@
         "description": "Chain optional operations without nested null checks. Implicit operators handle the wrapping — you return a T or Maybe.None and it just works.",
         "code": "// Producer: implicit conversion from T or Maybe.None\nMaybe<int> Parse(string s) =>\n    int.TryParse(s, out var n) ? n : Maybe.None;\n\n// Map: T -> U, auto-wraps in Maybe\nMaybe<int> doubled = Parse(\"21\").Map(x => x * 2);\n// Some(42)\n\n// FlatMap: T -> Maybe<U>, no double-wrap\nMaybe<int> sum = Parse(\"1\").FlatMap(a =>\n    Parse(\"2\").Map(b => a + b));\n// Some(3)",
         "diagram": {
-          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.0.1/docs/diagrams/maybe-composition.svg",
+          "src": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition.svg",
+          "srcDark": "https://raw.githubusercontent.com/KaliCZ/StrongTypes/claude/blissful-elion-43aab7/docs/diagrams/maybe-composition-dark.svg",
           "alt": "Pipeline diagram showing Some and None values flowing through Map and FlatMap operations on Maybe<T>"
         }
       }

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -110,6 +110,28 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
         var theme = localStorage.getItem("theme");
         if (theme === "dark" || (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
           document.documentElement.classList.add("dark");
+          // Pre-paint swap of theme-aware images. As the body parses, swap
+          // any `[data-src-dark]` <img> to its dark variant before the
+          // browser paints the light one. MutationObserver callbacks fire
+          // as microtasks before the next paint, so the dark URL is what
+          // the preload-scanner and renderer see.
+          var swap = function (img) {
+            if (!img.dataset.srcLight) img.dataset.srcLight = img.getAttribute("src") || "";
+            var dark = img.dataset.srcDark;
+            if (dark && img.getAttribute("src") !== dark) img.setAttribute("src", dark);
+          };
+          var obs = new MutationObserver(function () {
+            document.querySelectorAll("img[data-src-dark]").forEach(swap);
+          });
+          obs.observe(document.documentElement, { childList: true, subtree: true });
+          document.addEventListener(
+            "DOMContentLoaded",
+            function () {
+              document.querySelectorAll("img[data-src-dark]").forEach(swap);
+              obs.disconnect();
+            },
+            { once: true },
+          );
         }
         // Pre-detect auth state from supabase's localStorage token to avoid header flash on navigation.
         // The supabase-js client persists session under a key like `sb-<project-ref>-auth-token`.

--- a/frontend/src/lib/strong-types-diagrams.ts
+++ b/frontend/src/lib/strong-types-diagrams.ts
@@ -2,7 +2,10 @@
 // locale — so they live here instead of in the i18n JSON files. Each entry has
 // a light and a dark variant; the page wires `srcDark` into the theme toggle
 // via `data-src-dark` so the diagram flips with the rest of the page.
-const branch = "claude/blissful-elion-43aab7";
+//
+// TODO: pin to a StrongTypes release tag once one ships. Tracking in
+// https://github.com/KaliCZ/DemoPage/issues/116
+const branch = "main";
 const baseUrl = `https://raw.githubusercontent.com/KaliCZ/StrongTypes/${branch}/docs/diagrams`;
 
 const diagram = (slug: string) => ({

--- a/frontend/src/lib/strong-types-diagrams.ts
+++ b/frontend/src/lib/strong-types-diagrams.ts
@@ -1,0 +1,22 @@
+// Diagram URLs for the /strong-types page. Not localized — same SVG for every
+// locale — so they live here instead of in the i18n JSON files. Each entry has
+// a light and a dark variant; the page wires `srcDark` into the theme toggle
+// via `data-src-dark` so the diagram flips with the rest of the page.
+const branch = "claude/blissful-elion-43aab7";
+const baseUrl = `https://raw.githubusercontent.com/KaliCZ/StrongTypes/${branch}/docs/diagrams`;
+
+const diagram = (slug: string) => ({
+  src: `${baseUrl}/${slug}.svg`,
+  srcDark: `${baseUrl}/${slug}-dark.svg`,
+});
+
+export const strongTypesDiagrams = {
+  impact: diagram("impact"),
+  packageLayout: diagram("package-layout"),
+  trycreateCreateFlow: diagram("trycreate-create-flow"),
+  resultComposition: diagram("result-composition"),
+  patchThreeState: diagram("patch-three-state"),
+  maybeComposition: diagram("maybe-composition"),
+} as const;
+
+export type StrongTypesDiagramKey = keyof typeof strongTypesDiagrams;

--- a/frontend/src/lib/theme-toggle.ts
+++ b/frontend/src/lib/theme-toggle.ts
@@ -9,11 +9,43 @@ function updateToggleIcons() {
   if (btnM) btnM.title = tip;
 }
 
-function toggleTheme() {
-  document.documentElement.classList.add("no-transitions");
-  const isDark = document.documentElement.classList.toggle("dark");
-  localStorage.setItem("theme", isDark ? "dark" : "light");
+// Swap any image marked with data-src-dark to its theme-appropriate src.
+// Runs synchronously inside the theme-flip callback so the new state is
+// captured by the view-transition snapshot.
+function swapThemedImages(willBeDark: boolean) {
+  const imgs = document.querySelectorAll<HTMLImageElement>("img[data-src-dark]");
+  imgs.forEach((img) => {
+    const darkSrc = img.dataset.srcDark;
+    if (!darkSrc) return;
+    if (!img.dataset.srcLight) img.dataset.srcLight = img.getAttribute("src") ?? "";
+    const lightSrc = img.dataset.srcLight;
+    const next = willBeDark ? darkSrc : lightSrc;
+    if (next && img.getAttribute("src") !== next) img.setAttribute("src", next);
+  });
+}
+
+function applyThemeFlip() {
+  const willBeDark = !document.documentElement.classList.contains("dark");
+  swapThemedImages(willBeDark);
+  document.documentElement.classList.toggle("dark", willBeDark);
+  localStorage.setItem("theme", willBeDark ? "dark" : "light");
   updateToggleIcons();
+}
+
+// Entry point: prefer the View Transitions API for a smooth full-page
+// crossfade; fall back to the original instant flip on older browsers.
+// The legacy `no-transitions` snap is only kept as the fallback path —
+// when view transitions run, we let the browser's snapshot/crossfade
+// handle the whole page so individual element transitions are redundant.
+function toggleTheme() {
+  type DocWithVT = Document & { startViewTransition?: (cb: () => void) => unknown };
+  const doc = document as DocWithVT;
+  if (typeof doc.startViewTransition === "function") {
+    doc.startViewTransition(applyThemeFlip);
+    return;
+  }
+  document.documentElement.classList.add("no-transitions");
+  applyThemeFlip();
   // Force reflow so the no-transitions class takes effect before we remove it
   document.documentElement.offsetHeight;
   document.documentElement.classList.remove("no-transitions");

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -9,6 +9,7 @@ import enStrings from "../../i18n/en/strong-types.json";
 import csStrings from "../../i18n/cs/strong-types.json";
 import enCommon from "../../i18n/en/common.json";
 import csCommon from "../../i18n/cs/common.json";
+import { strongTypesDiagrams, type StrongTypesDiagramKey } from "../../lib/strong-types-diagrams";
 
 const translations = { en: enStrings, cs: csStrings };
 const commonTranslations = { en: enCommon, cs: csCommon };
@@ -139,8 +140,8 @@ const tocItems = [
       <!-- Featured diagram. data-src-dark hooks the theme toggle so the SVG flips with the page. -->
       <figure class="mb-12 rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
         <img
-          src={t.why.diagram.src}
-          data-src-dark={t.why.diagram.srcDark}
+          src={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].src}
+          data-src-dark={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].srcDark}
           alt={t.why.diagram.alt}
           loading="lazy"
           decoding="async"
@@ -206,8 +207,8 @@ const tocItems = [
       <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
         <div class="p-6 flex items-center justify-center">
           <img
-            src={t.packageLayout.diagram.src}
-            data-src-dark={t.packageLayout.diagram.srcDark}
+            src={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].src}
+            data-src-dark={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].srcDark}
             alt={t.packageLayout.diagram.alt}
             loading="lazy"
             decoding="async"
@@ -248,8 +249,8 @@ const tocItems = [
                   {hasDiagram && (
                     <div class="p-6 flex items-center justify-center">
                       <img
-                        src={example.diagram!.src}
-                        data-src-dark={example.diagram!.srcDark}
+                        src={strongTypesDiagrams[example.diagram!.key as StrongTypesDiagramKey].src}
+                        data-src-dark={strongTypesDiagrams[example.diagram!.key as StrongTypesDiagramKey].srcDark}
                         alt={example.diagram!.alt}
                         loading="lazy"
                         decoding="async"

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -406,28 +406,24 @@ const tocItems = [
     });
   });
 
-  // Theme-aware diagram swap. Each diagram <img> ships with its light src in
-  // `src` and its dark counterpart in `data-src-dark`. We swap on the page's
-  // theme — driven by the `.dark` class on <html>, not OS preference, so the
-  // top-right toggle controls the diagrams the same way it controls everything
-  // else. Original light src is captured once and cached on the element so we
-  // can restore it cleanly when toggling back.
+  // Theme-aware diagram preload. Each diagram <img> declares its dark
+  // counterpart in `data-src-dark`; the actual src swap on toggle is owned
+  // by `theme-toggle.ts` so it can run inside `document.startViewTransition`
+  // and be captured in the view-transition snapshot. We only preload here
+  // so the swap is a cache hit, not a network round trip — and we sync the
+  // src on initial render in case the page loads with the dark theme already
+  // active (persisted in localStorage).
   const themedDiagrams = document.querySelectorAll<HTMLImageElement>("img[data-src-dark]");
   themedDiagrams.forEach((img) => {
     img.dataset.srcLight = img.getAttribute("src") ?? "";
+    if (img.dataset.srcDark) new Image().src = img.dataset.srcDark;
   });
-  function applyDiagramTheme() {
-    const dark = document.documentElement.classList.contains("dark");
+  if (document.documentElement.classList.contains("dark")) {
     themedDiagrams.forEach((img) => {
-      const next = dark ? (img.dataset.srcDark ?? img.dataset.srcLight ?? "") : (img.dataset.srcLight ?? "");
+      const next = img.dataset.srcDark;
       if (next && img.getAttribute("src") !== next) img.setAttribute("src", next);
     });
   }
-  applyDiagramTheme();
-  new MutationObserver(applyDiagramTheme).observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ["class"],
-  });
 
   lightboxClose?.addEventListener("click", () => lightbox?.close());
 

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -136,10 +136,11 @@ const tocItems = [
         {t.why.subtitle}
       </p>
 
-      <!-- Featured diagram. Wrapped in a forced light surface because the SVG colors are hardcoded. -->
-      <figure class="mb-12 bg-white rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
+      <!-- Featured diagram. data-src-dark hooks the theme toggle so the SVG flips with the page. -->
+      <figure class="mb-12 rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
         <img
           src={t.why.diagram.src}
+          data-src-dark={t.why.diagram.srcDark}
           alt={t.why.diagram.alt}
           loading="lazy"
           decoding="async"
@@ -203,9 +204,10 @@ const tocItems = [
 
       <!-- Package layout diagram. -->
       <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
-        <div class="bg-white p-6 flex items-center justify-center">
+        <div class="p-6 flex items-center justify-center">
           <img
             src={t.packageLayout.diagram.src}
+            data-src-dark={t.packageLayout.diagram.srcDark}
             alt={t.packageLayout.diagram.alt}
             loading="lazy"
             decoding="async"
@@ -244,9 +246,10 @@ const tocItems = [
                     set:text={example.code}
                   />
                   {hasDiagram && (
-                    <div class="bg-white p-6 flex items-center justify-center">
+                    <div class="p-6 flex items-center justify-center">
                       <img
                         src={example.diagram!.src}
+                        data-src-dark={example.diagram!.srcDark}
                         alt={example.diagram!.alt}
                         loading="lazy"
                         decoding="async"
@@ -318,7 +321,7 @@ const tocItems = [
     aria-label={t.lightbox.dialogLabel}
     class="m-auto p-0 border-0 bg-transparent rounded-xl shadow-2xl backdrop:bg-black/70 backdrop:backdrop-blur-sm max-w-[95vw] max-h-[95vh]"
   >
-    <div class="relative bg-white p-6 rounded-xl overflow-hidden min-w-[280px] min-h-[200px]">
+    <div class="relative bg-surface p-6 rounded-xl overflow-hidden min-w-[280px] min-h-[200px]">
       <button
         type="button"
         data-lightbox-close
@@ -401,6 +404,29 @@ const tocItems = [
         openLightbox(img);
       }
     });
+  });
+
+  // Theme-aware diagram swap. Each diagram <img> ships with its light src in
+  // `src` and its dark counterpart in `data-src-dark`. We swap on the page's
+  // theme — driven by the `.dark` class on <html>, not OS preference, so the
+  // top-right toggle controls the diagrams the same way it controls everything
+  // else. Original light src is captured once and cached on the element so we
+  // can restore it cleanly when toggling back.
+  const themedDiagrams = document.querySelectorAll<HTMLImageElement>("img[data-src-dark]");
+  themedDiagrams.forEach((img) => {
+    img.dataset.srcLight = img.getAttribute("src") ?? "";
+  });
+  function applyDiagramTheme() {
+    const dark = document.documentElement.classList.contains("dark");
+    themedDiagrams.forEach((img) => {
+      const next = dark ? (img.dataset.srcDark ?? img.dataset.srcLight ?? "") : (img.dataset.srcLight ?? "");
+      if (next && img.getAttribute("src") !== next) img.setAttribute("src", next);
+    });
+  }
+  applyDiagramTheme();
+  new MutationObserver(applyDiagramTheme).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
   });
 
   lightboxClose?.addEventListener("click", () => lightbox?.close());

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -406,24 +406,11 @@ const tocItems = [
     });
   });
 
-  // Theme-aware diagram preload. Each diagram <img> declares its dark
-  // counterpart in `data-src-dark`; the actual src swap on toggle is owned
-  // by `theme-toggle.ts` so it can run inside `document.startViewTransition`
-  // and be captured in the view-transition snapshot. We only preload here
-  // so the swap is a cache hit, not a network round trip — and we sync the
-  // src on initial render in case the page loads with the dark theme already
-  // active (persisted in localStorage).
-  const themedDiagrams = document.querySelectorAll<HTMLImageElement>("img[data-src-dark]");
-  themedDiagrams.forEach((img) => {
-    img.dataset.srcLight = img.getAttribute("src") ?? "";
+  // Preload the dark variant so toggling is a cache hit. Initial-render src
+  // selection is handled pre-paint by the inline script in Layout.astro.
+  document.querySelectorAll<HTMLImageElement>("img[data-src-dark]").forEach((img) => {
     if (img.dataset.srcDark) new Image().src = img.dataset.srcDark;
   });
-  if (document.documentElement.classList.contains("dark")) {
-    themedDiagrams.forEach((img) => {
-      const next = img.dataset.srcDark;
-      if (next && img.getAttribute("src") !== next) img.setAttribute("src", next);
-    });
-  }
 
   lightboxClose?.addEventListener("click", () => lightbox?.close());
 

--- a/frontend/src/pages/[...lang]/strong-types.astro
+++ b/frontend/src/pages/[...lang]/strong-types.astro
@@ -138,22 +138,15 @@ const tocItems = [
       </p>
 
       <!-- Featured diagram. data-src-dark hooks the theme toggle so the SVG flips with the page. -->
-      <figure class="mb-12 rounded-xl border border-outline-variant/40 shadow-sm overflow-hidden">
-        <img
-          src={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].src}
-          data-src-dark={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].srcDark}
-          alt={t.why.diagram.alt}
-          loading="lazy"
-          decoding="async"
-          data-zoomable
-          class="block w-full h-auto p-6 cursor-zoom-in transition-transform hover:scale-[1.01]"
-        />
-        <figcaption
-          class="px-6 pb-5 pt-1 text-sm text-on-surface-variant border-t border-outline-variant/30 bg-surface-container-low font-body italic"
-        >
-          {t.why.diagram.caption}
-        </figcaption>
-      </figure>
+      <img
+        src={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].src}
+        data-src-dark={strongTypesDiagrams[t.why.diagram.key as StrongTypesDiagramKey].srcDark}
+        alt={t.why.diagram.alt}
+        loading="lazy"
+        decoding="async"
+        data-zoomable
+        class="block w-full h-auto mb-12 cursor-zoom-in transition-transform hover:scale-[1.01]"
+      />
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {
@@ -204,23 +197,15 @@ const tocItems = [
       </div>
 
       <!-- Package layout diagram. -->
-      <figure class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
-        <div class="p-6 flex items-center justify-center">
-          <img
-            src={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].src}
-            data-src-dark={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].srcDark}
-            alt={t.packageLayout.diagram.alt}
-            loading="lazy"
-            decoding="async"
-            data-zoomable
-            class="block max-w-full h-auto cursor-zoom-in transition-transform hover:scale-[1.01]"
-          />
-        </div>
-        <figcaption class="p-6 border-t border-outline-variant/30">
-          <h3 class="font-headline font-bold text-on-surface mb-1">{t.packageLayout.title}</h3>
-          <p class="font-body text-sm text-on-surface-variant leading-relaxed">{t.packageLayout.description}</p>
-        </figcaption>
-      </figure>
+      <img
+        src={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].src}
+        data-src-dark={strongTypesDiagrams[t.packageLayout.diagram.key as StrongTypesDiagramKey].srcDark}
+        alt={t.packageLayout.diagram.alt}
+        loading="lazy"
+        decoding="async"
+        data-zoomable
+        class="block max-w-full mx-auto h-auto cursor-zoom-in transition-transform hover:scale-[1.01]"
+      />
     </section>
 
     <!-- Examples -->
@@ -236,7 +221,7 @@ const tocItems = [
           t.examples.items.map((example) => {
             const hasDiagram = "diagram" in example && example.diagram;
             return (
-              <div class="bg-surface-container rounded-xl border border-outline-variant/40 overflow-hidden">
+              <div class="rounded-xl border border-outline-variant/40 overflow-hidden">
                 <div class="px-6 pt-5 pb-3 border-b border-outline-variant/30">
                   <h3 class="font-headline font-bold text-on-surface text-lg">{example.title}</h3>
                   <p class="font-body text-sm text-on-surface-variant mt-1 leading-relaxed">{example.description}</p>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -176,12 +176,32 @@ details > summary + * {
   will-change: opacity;
 }
 
-/* Suppress transitions during theme toggle to prevent flash */
+/* Suppress transitions during theme toggle to prevent flash. Only used on
+   the legacy fallback path in `theme-toggle.ts`; modern browsers go through
+   `document.startViewTransition` and don't need this. */
 .no-transitions,
 .no-transitions *,
 .no-transitions *::before,
 .no-transitions *::after {
   transition: none !important;
+}
+
+/* Theme-toggle view transition. Smooth crossfade of the entire viewport
+   when `theme-toggle.ts` flips `.dark`. Default ::view-transition-old /
+   ::view-transition-new pair already crossfades; we just slow it slightly
+   and ease it so the swap reads less like a snap. */
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 280ms;
+    animation-timing-function: ease-in-out;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
 }
 
 /* ============================================


### PR DESCRIPTION
Pairs with [StrongTypes#85](https://github.com/KaliCZ/StrongTypes/pull/85), which ships dark-mode-capable variants of every diagram in `docs/diagrams/`.

## Summary

- Each diagram \`<img>\` on the strong-types page now carries both \`src\` (light SVG) and \`data-src-dark\` (dark SVG).
- A small \`MutationObserver\` on \`<html>\`'s class list watches for the existing top-right toggle adding or removing \`.dark\` and swaps the diagram src accordingly. No coupling to OS \`prefers-color-scheme\` — the diagrams follow the page setting like everything else on the page.
- Dropped \`bg-white\` wrappers around the diagram \`<figure>\` blocks since the dark SVGs paint their own dark canvas. The lightbox dialog also moves from \`bg-white\` to \`bg-surface\` so it stays readable in both modes.
- \`srcDark\` field added next to each \`src\` in \`frontend/src/i18n/{en,cs}/strong-types.json\`.

## Caveat — needs URL repointing before merge

The diagram URLs currently point to the StrongTypes branch (\`claude/blissful-elion-43aab7\`) while the matching PR is in review. Once that merges and a new tag ships, the URLs in both i18n JSONs need to be repointed (\`v1.0.1\` → next release tag) so the demo isn't pinned to a personal branch.

## Test plan

- [ ] Navigate to \`/strong-types\` (en) and \`/cs/strong-types\`. All six diagrams render in light mode by default.
- [ ] Click the theme toggle (top right). Every diagram src swaps to its \`-dark.svg\` counterpart and the dark canvas matches the rest of the page.
- [ ] Toggle back. Diagrams revert to light variants without page reload.
- [ ] Lightbox: click any diagram. The expanded view also shows the current theme's variant (because we clone the live \`<img>\` with its current src).
- [ ] OS dark mode + page light toggle: diagrams stay light. (No more \`prefers-color-scheme\` mismatch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)