### PR TITLE
About/CV: tickadoo ships every day, not every week

### DIFF
--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -580,7 +580,7 @@
               <p>Hands-on role leading a single-pizza team building an app for selling tickets from third-party providers.</p>
               <p>
                 Owning overall system architecture, feature design, backlog prioritization and engineering ways of working — while still
-                shipping production code every week.
+                shipping production code every day.
               </p>
             </div>
           </div>

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -170,7 +170,7 @@
         "date": "Čer 2025 — Současnost",
         "role": "Lead Engineer (CTO)",
         "company": "tickadoo",
-        "description": "Hands-on role vedoucí single-pizza tým, který staví aplikaci pro prodej vstupenek od externích poskytovatelů.\n\nZodpovídám za celkovou architekturu systému, návrh featur, prioritizaci backlogu a způsoby práce — a zároveň každý týden píšu produkční kód."
+        "description": "Hands-on role vedoucí single-pizza tým, který staví aplikaci pro prodej vstupenek od externích poskytovatelů.\n\nZodpovídám za celkovou architekturu systému, návrh featur, prioritizaci backlogu a způsoby práce — a zároveň každý den píšu produkční kód."
       },
       {
         "side": "left",

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -170,7 +170,7 @@
         "date": "Jun 2025 — Present",
         "role": "Lead Engineer (CTO)",
         "company": "tickadoo",
-        "description": "A hands-on role leading a single-pizza team building an app for selling tickets from third-party providers.\n\nOwning the overall system architecture, feature design, backlog prioritization and engineering ways of working — while still shipping production code every week."
+        "description": "A hands-on role leading a single-pizza team building an app for selling tickets from third-party providers.\n\nOwning the overall system architecture, feature design, backlog prioritization and engineering ways of working — while still shipping production code every day."
       },
       {
         "side": "left",


### PR DESCRIPTION
## Summary
- Tighten the tickadoo blurb on the About page (EN + CS) and the printable CV: "shipping production code every week" → "every day".

## Test plan
- [ ] Visual check on /about (EN and CS) that the tickadoo description reads "every day"
- [ ] Open frontend/cv/pavel-kalandra-cv.html and confirm the tickadoo paragraph reads "every day"

🤖 Generated with [Claude Code](https://claude.com/claude-code)