### PR TITLE
small update

### DIFF
--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -467,8 +467,8 @@
               <li>C# / .NET (ASP.NET Core, EF Core, WPF)</li>
               <li>JavaScript / TypeScript (Vue.js / Astro)</li>
               <li>Go</li>
-              <li>Tailwind / Bootstrap</li>
               <li>Python</li>
+              <li>Tailwind / Bootstrap</li>
             </ul>
           </div>
 

--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -468,7 +468,7 @@
               <li>JavaScript / TypeScript (Vue.js / Astro)</li>
               <li>Go</li>
               <li>Python</li>
-              <li>Tailwind / Bootstrap</li>
+              <li>HTML / CSS (Tailwind, Bootstrap)</li>
             </ul>
           </div>
 

--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -468,6 +468,7 @@
               <li>JavaScript / TypeScript (Vue.js / Astro)</li>
               <li>Go</li>
               <li>Tailwind / Bootstrap</li>
+              <li>Python</li>
             </ul>
           </div>
 

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -117,7 +117,8 @@
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
           "Tailwind / Bootstrap",
-          "HTML / CSS"
+          "HTML / CSS",
+          "Python"
         ]
       },
       {

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -116,9 +116,9 @@
           "C# / .NET (ASP.NET Core, EF Core, WPF)",
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
+          "Python",
           "Tailwind / Bootstrap",
-          "HTML / CSS",
-          "Python"
+          "HTML / CSS"
         ]
       },
       {

--- a/frontend/src/i18n/cs/about.json
+++ b/frontend/src/i18n/cs/about.json
@@ -117,8 +117,7 @@
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
           "Python",
-          "Tailwind / Bootstrap",
-          "HTML / CSS"
+          "HTML / CSS (Tailwind, Bootstrap)"
         ]
       },
       {

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -117,7 +117,8 @@
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
           "Tailwind / Bootstrap",
-          "HTML / CSS"
+          "HTML / CSS",
+          "Python"
         ]
       },
       {

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -116,9 +116,9 @@
           "C# / .NET (ASP.NET Core, EF Core, WPF)",
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
+          "Python",
           "Tailwind / Bootstrap",
-          "HTML / CSS",
-          "Python"
+          "HTML / CSS"
         ]
       },
       {

--- a/frontend/src/i18n/en/about.json
+++ b/frontend/src/i18n/en/about.json
@@ -117,8 +117,7 @@
           "JavaScript / TypeScript (Vue.js / Astro)",
           "Go",
           "Python",
-          "Tailwind / Bootstrap",
-          "HTML / CSS"
+          "HTML / CSS (Tailwind, Bootstrap)"
         ]
       },
       {


### PR DESCRIPTION
## Summary
- Add Python to the Languages & Frameworks list
- Collapse Tailwind / Bootstrap into the HTML / CSS line

Applied to both EN and CS About page translations and the CV HTML.

## Test plan
- [ ] Visual check of About page (EN + CS) skills section
- [ ] Visual check of CV HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)