### PR TITLE
ci: fix Dependabot NuGet by pointing at repo root (DemoPage.slnx)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,9 @@ updates:
           - "*"
 
   # Backend — NuGet packages across all csproj files in the solution.
+  # Points at repo root so Dependabot picks up DemoPage.slnx as the entry point.
   - package-ecosystem: nuget
-    directory: /backend
+    directory: /
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
## Summary
- Dependabot's NuGet ecosystem was configured at `directory: /backend`, but there's no `.sln`/`.slnx` there — only scattered csprojs under `src/` and `tests/`. The updater's discovery step needs an entry point (solution file) at the configured directory.
- Result: every weekly NuGet run since the config was added finished green with `Projects: []` and never opened a PR. That's why the recent `OpenTelemetry.Api 1.15.2` advisory (`GHSA-g94r-2vxg-569j`, patched in 1.15.3) wasn't auto-bumped.
- Fix: point at `/` so the root `DemoPage.slnx` is used as the entry point. It already references all five csprojs.

Evidence from the most recent NuGet run ([25379993776](https://github.com/KaliCZ/DemoPage/actions/runs/25379993776)):

```
INFO Discovering build files in workspace [/home/dependabot/dependabot-updater/repo/backend].
INFO   Discovering projects beneath [backend].
INFO     Entry points found:
INFO     No project files found.
INFO Discovery complete.
{ "Path": "backend", "IsSuccess": true, "Projects": [], ... }
```

## Test plan
- [ ] After merge, wait for the next weekly Dependabot NuGet run (Tuesdays ~13:42 UTC) and confirm a grouped `nuget` PR is opened (or that `Projects: [...]` is non-empty in the run log).
- [ ] Verify the PR includes the `OpenTelemetry.Api` and `OpenTelemetry.Exporter.OpenTelemetryProtocol` bumps to 1.15.3.

Follow-up (not in this PR): enable Dependabot security updates in repo Settings → Code security, so advisory-driven PRs land out-of-band instead of waiting for the weekly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)