### PR TITLE
ci: detect stale slots in blue-green deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -340,11 +340,12 @@ jobs:
           BETTERSTACK_SOURCE_TOKEN: ${{ secrets.BETTERSTACK_BACKEND_SOURCETOKEN }}
           SENTRY_DSN: ${{ secrets.BACKEND_SENTRY_DSN }}
           IMAGE: ${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}:latest
+          EXPECTED_SHA: ${{ github.sha }}
         with:
           host: ${{ vars.OCI_HOST }}
           username: ${{ vars.OCI_USERNAME }}
           key: ${{ secrets.OCI_SSH_KEY }}
-          envs: DB_CONNECTION_STRING,SUPABASE_PROJECT_URL,SUPABASE_SERVICE_ROLE_KEY,TURNSTILE_SECRET_KEY,BETTERSTACK_SOURCE_TOKEN,SENTRY_DSN,IMAGE
+          envs: DB_CONNECTION_STRING,SUPABASE_PROJECT_URL,SUPABASE_SERVICE_ROLE_KEY,TURNSTILE_SECRET_KEY,BETTERSTACK_SOURCE_TOKEN,SENTRY_DSN,IMAGE,EXPECTED_SHA
           script: |
             set -euo pipefail
             MAX_ATTEMPTS=40
@@ -414,16 +415,21 @@ jobs:
             echo "Active: ${OLD:-<none>} → Deploying: $NEW on port $NEW_PORT"
 
             # ----- 3. Start the new slot -----
-            # The Quadlet-generated service does `podman run --rm`, so each
-            # start creates a fresh container from the (just-pulled) image.
+            # Stop first so the Quadlet `podman run --rm` actually recreates
+            # the container from the just-pulled image. Without the stop, a
+            # still-running slot from a prior deploy makes `start` a no-op
+            # and the old binary keeps serving.
             # Quadlet units cannot be `enable`d — boot autostart comes from
             # [Install] WantedBy=default.target in the .container file.
+            systemctl --user stop "kalandra-api-${NEW}.service" || true
             systemctl --user start "kalandra-api-${NEW}.service"
 
             # ----- 4. Health check the new slot directly (bypassing Caddy) -----
-            echo "Waiting for new slot on port $NEW_PORT..."
+            # Match the deployed commit, not just any healthy response, so
+            # a stale container from an earlier deploy can't pass this gate.
+            echo "Waiting for new slot on port $NEW_PORT (expecting commit $EXPECTED_SHA)..."
             ATTEMPTS=0
-            until curl -sf "http://localhost:${NEW_PORT}/health" > /dev/null 2>&1; do
+            until curl -sf "http://localhost:${NEW_PORT}/health" 2>/dev/null | grep -qF "$EXPECTED_SHA"; do
               ATTEMPTS=$((ATTEMPTS + 1))
               if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
                 echo "New slot failed to start. Container logs:"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -415,10 +415,10 @@ jobs:
             echo "Active: ${OLD:-<none>} → Deploying: $NEW on port $NEW_PORT"
 
             # ----- 3. Start the new slot -----
-            # Stop first so the Quadlet `podman run --rm` actually recreates
-            # the container from the just-pulled image. Without the stop, a
-            # still-running slot from a prior deploy makes `start` a no-op
-            # and the old binary keeps serving.
+            # Stop first: if the unit is already active from a prior deploy,
+            # `systemctl start` is a no-op and the old container keeps
+            # serving the old binary. Cycling the unit forces ExecStart to
+            # fire and create a new container from the just-pulled image.
             # Quadlet units cannot be `enable`d — boot autostart comes from
             # [Install] WantedBy=default.target in the .container file.
             systemctl --user stop "kalandra-api-${NEW}.service" || true


### PR DESCRIPTION
## Summary
- Stop the target slot before starting it, so Quadlet's `podman run --rm` actually recreates the container from the just-pulled image instead of no-op'ing against a still-running unit.
- Make the internal slot health check require the `/health` response to contain the deploying commit SHA, so a leftover container from an earlier deploy can't satisfy the gate.

## Why
Run [26083788523](https://github.com/KaliCZ/DemoPage/actions/runs/26083788523) failed at `Verify public endpoint` because `api.kalandra.tech/health` kept returning the previous commit `a25904e` instead of the new `61213e6`. Tracing the SSH log:

```
Active: blue → Deploying: green on port 8081
Waiting for new slot on port 8081...
New slot is healthy on port 8081.       ← 0.7s after start
Deployment complete — kalandra-api-green serving on port 8081.
```

A .NET API with Marten + Supabase warmup can't cold-start in 760 ms. The green slot was already running from a prior deploy, so `systemctl --user start kalandra-api-green.service` was a no-op, the port-only health check immediately passed, and Caddy got swapped onto the stale container.

Either change alone would have caught this; together they make the deploy step itself fail and roll back instead of leaving the public verify as the last line of defense.

## Test plan
- [ ] Merge and confirm next push deploys cleanly, with `Waiting for new slot on port N (expecting commit <sha>)...` visible in the SSH log
- [ ] Confirm `Verify public endpoint` passes on the first attempt