### PR TITLE
fix: silence two startup warnings (HTTP_PORTS conflict, transient DP keys)

### DIFF
--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -33,6 +33,5 @@ USER appuser
 COPY --from=build /app .
 
 EXPOSE 8080
-ENV ASPNETCORE_URLS=http://+:8080
 
 ENTRYPOINT ["dotnet", "Kalandra.Api.dll"]

--- a/backend/src/Kalandra.Api/Infrastructure/DataProtection/DataProtectionExtensions.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/DataProtection/DataProtectionExtensions.cs
@@ -1,0 +1,26 @@
+using Marten;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+
+namespace Kalandra.Api.Infrastructure.DataProtection;
+
+public static class DataProtectionExtensions
+{
+    // ApplicationName must be stable across deploys; otherwise rotated keys end up
+    // siloed under different discriminators and old payloads silently fail to decrypt.
+    private const string ApplicationName = "kalandra-api";
+
+    public static IServiceCollection AddAppDataProtection(this IServiceCollection services)
+    {
+        services.AddDataProtection()
+            .SetApplicationName(ApplicationName);
+
+        services.AddOptions<KeyManagementOptions>()
+            .Configure<IDocumentStore>((options, store) =>
+            {
+                options.XmlRepository = new MartenXmlRepository(store);
+            });
+
+        return services;
+    }
+}

--- a/backend/src/Kalandra.Api/Infrastructure/DataProtection/DataProtectionKey.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/DataProtection/DataProtectionKey.cs
@@ -1,0 +1,10 @@
+namespace Kalandra.Api.Infrastructure.DataProtection;
+
+// Marten-backed storage for ASP.NET Core data-protection keys. Keys must survive
+// container destruction so cookies/antiforgery payloads encrypted before a deploy
+// can still be decrypted after it.
+public class DataProtectionKey
+{
+    public string Id { get; set; } = default!;
+    public string Xml { get; set; } = default!;
+}

--- a/backend/src/Kalandra.Api/Infrastructure/DataProtection/MartenXmlRepository.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/DataProtection/MartenXmlRepository.cs
@@ -1,0 +1,29 @@
+using System.Xml.Linq;
+using Marten;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+
+namespace Kalandra.Api.Infrastructure.DataProtection;
+
+// IXmlRepository is sync by contract. Block on Marten's async APIs — the repository
+// is hit once at startup and again only on key rotation (~every 90 days by default),
+// outside any request context where sync-over-async would matter.
+public class MartenXmlRepository(IDocumentStore store) : IXmlRepository
+{
+    public IReadOnlyCollection<XElement> GetAllElements()
+    {
+        using var session = store.QuerySession();
+        var keys = session.Query<DataProtectionKey>().ToListAsync().GetAwaiter().GetResult();
+        return keys.Select(k => XElement.Parse(k.Xml)).ToArray();
+    }
+
+    public void StoreElement(XElement element, string friendlyName)
+    {
+        using var session = store.LightweightSession();
+        session.Store(new DataProtectionKey
+        {
+            Id = string.IsNullOrWhiteSpace(friendlyName) ? Guid.NewGuid().ToString() : friendlyName,
+            Xml = element.ToString(SaveOptions.DisableFormatting),
+        });
+        session.SaveChangesAsync().GetAwaiter().GetResult();
+    }
+}

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -1,6 +1,7 @@
 using HealthChecks.UI.Client;
 using Kalandra.Api.Infrastructure;
 using Kalandra.Api.Infrastructure.Auth;
+using Kalandra.Api.Infrastructure.DataProtection;
 using Kalandra.Infrastructure.Configuration;
 using Kalandra.JobOffers;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -37,6 +38,7 @@ var supabaseConfig = SupabaseConfig.AddSingleton(builder.Services, builder.Confi
 TurnstileConfig.AddSingleton(builder.Services, builder.Configuration);
 
 builder.Services.AddAppMarten(builder.Configuration, builder.Environment);
+builder.Services.AddAppDataProtection();
 Auth.Add(builder.Services, supabaseConfig);
 builder.Services.AddAppCors(builder.Environment);
 builder.Services.AddMemoryCache();

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Infrastructure/DataProtectionTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Infrastructure/DataProtectionTests.cs
@@ -1,0 +1,30 @@
+using Kalandra.Api.Infrastructure.DataProtection;
+using Kalandra.Api.IntegrationTests.Helpers;
+using Marten;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kalandra.Api.IntegrationTests.Features.Infrastructure;
+
+public class DataProtectionTests(TestWebApplicationFactory factory) : IClassFixture<TestWebApplicationFactory>
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Protect_Unprotect_RoundTrips_And_PersistsKey()
+    {
+        using var scope = factory.Services.CreateScope();
+        var protector = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector("test-purpose");
+
+        var protectedText = protector.Protect("hello");
+        var unprotectedText = protector.Unprotect(protectedText);
+
+        Assert.Equal("hello", unprotectedText);
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        await using var session = store.QuerySession();
+        var keyCount = await session.Query<DataProtectionKey>().CountAsync(Ct);
+        Assert.True(keyCount > 0, "Expected at least one key to be persisted in Marten.");
+    }
+}

--- a/infra/quadlet/kalandra-api-blue.container
+++ b/infra/quadlet/kalandra-api-blue.container
@@ -17,7 +17,7 @@ Image=ghcr.io/kalicz/demopage/api:latest
 ContainerName=kalandra-api-blue
 Network=host
 EnvironmentFile=%h/kalandra-api.env
-Environment=ASPNETCORE_URLS=http://+:8080
+Environment=ASPNETCORE_HTTP_PORTS=8080
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Pull=missing
 

--- a/infra/quadlet/kalandra-api-green.container
+++ b/infra/quadlet/kalandra-api-green.container
@@ -17,7 +17,7 @@ Image=ghcr.io/kalicz/demopage/api:latest
 ContainerName=kalandra-api-green
 Network=host
 EnvironmentFile=%h/kalandra-api.env
-Environment=ASPNETCORE_URLS=http://+:8081
+Environment=ASPNETCORE_HTTP_PORTS=8081
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Pull=missing
 


### PR DESCRIPTION
## Summary
- Replace `ASPNETCORE_URLS` with `ASPNETCORE_HTTP_PORTS` in Dockerfile + Quadlets. The base `aspnet:10.0-alpine` image already exports `HTTP_PORTS=8080`, so layering `URLS` on top triggered an "Overriding HTTP_PORTS …" warning on every boot. Same effective binding (`http://*:<port>`), one variable.
- Persist ASP.NET Core data-protection keys to Postgres via a Marten-backed `IXmlRepository`. Without this, every deploy destroys the container and the keys with it, silently invalidating any payload encrypted by `IDataProtector` from the previous container.

## Why now
Both warnings show up on every deploy in BetterStack (logger: `Microsoft.AspNetCore.Hosting.Diagnostics` and `Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager`).

The HTTP_PORTS one is cosmetic noise. The data-protection one is a silent footgun: for a JWT-auth API like ours the blast radius today is small (no antiforgery, no cookie auth), but anyone adding a `[DataProtection]`-backed feature later would see it quietly break on every deploy with the new "destroy on stop" behavior from #128.

## Implementation
- `DataProtectionKey` — Marten document with `Id` (friendly name) + `Xml` (the key element). Lives in `Kalandra.Api/Infrastructure/DataProtection/` since it's a composition concern, not a domain concept (and `Kalandra.Infrastructure` is a leaf project with no Marten dep).
- `MartenXmlRepository : IXmlRepository` — opens ad-hoc query/lightweight sessions from `IDocumentStore`. The interface is sync; Marten's APIs are async, so we block. Repository is hit once at startup and again only on key rotation (~90 days by default).
- `AddAppDataProtection()` sets a stable `ApplicationName` and wires the repository into `KeyManagementOptions`.
- Integration test does a `Protect`/`Unprotect` round-trip and asserts at least one key was persisted to Marten.

## Test plan
- [x] `npm test` — 75 backend tests + 12 E2E pass
- [ ] After merge: confirm the next deploy produces no `Overriding HTTP_PORTS` and no `Storing keys in a directory` warnings in BetterStack
- [ ] Confirm `mt_doc_dataprotectionkey` table exists in prod and contains at least one row after first boot