### PR TITLE
Enforce editorconfig analyzer severities in the deploy build

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -7,6 +7,7 @@
 **/*.user
 **/*.suo
 **/TestResults/
+tests/
 .git
 .gitignore
 README.md

--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -14,7 +14,9 @@ COPY src/Kalandra.JobOffers/Kalandra.JobOffers.csproj src/Kalandra.JobOffers/
 
 RUN dotnet restore src/Kalandra.Api/Kalandra.Api.csproj -a $TARGETARCH
 
-# Now copy the rest of the sources and publish.
+# Now copy the rest of the sources and publish. The .editorconfig sits at the
+# context root so analyzer severities (e.g. CS8509 as error) apply in-container.
+COPY .editorconfig .
 COPY src/ src/
 RUN dotnet publish src/Kalandra.Api/Kalandra.Api.csproj \
     -c Release \

--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -14,10 +14,9 @@ COPY src/Kalandra.JobOffers/Kalandra.JobOffers.csproj src/Kalandra.JobOffers/
 
 RUN dotnet restore src/Kalandra.Api/Kalandra.Api.csproj -a $TARGETARCH
 
-# Now copy the rest of the sources and publish. The .editorconfig sits at the
-# context root so analyzer severities (e.g. CS8509 as error) apply in-container.
-COPY .editorconfig .
-COPY src/ src/
+# Copy the rest of the context (sources + root config such as .editorconfig, so
+# analyzer severities apply in-container). .dockerignore defines what's excluded.
+COPY . .
 RUN dotnet publish src/Kalandra.Api/Kalandra.Api.csproj \
     -c Release \
     -a $TARGETARCH \


### PR DESCRIPTION
## Problem

The `backend-deploy` job builds the Docker image with `context: backend`, but the Dockerfile only copied `src/…` into the image. The root `.editorconfig` (marked `root = true`) was never present above the sources, so EditorConfig auto-discovery found nothing during the in-container `dotnet publish` and every custom severity fell back to the compiler default:

- `CS8509` (incomplete switch over **named** enum values) → `warning` instead of `error`
- `CS8524` (incomplete switch over the **unnamed** out-of-range value) → `warning` instead of `suggestion`

That's why `CS8524` warnings surfaced on `main` even though the editorconfig downgrades them, and — more importantly — why a genuinely non-exhaustive switch over named values would *not* fail the deploy build. The host CI jobs already honor the editorconfig (the file is on disk above the sources there); only the containerized build ignored it.

## Fix

Adopt the canonical .NET Docker pattern instead of opting in file-by-file:

- csproj-first `dotnet restore` (cache layer unchanged) → `COPY . .` for the publish phase, with `.dockerignore` as the single declarative exclusion boundary. This auto-includes `.editorconfig` and any future root-level build config (`Directory.Build.props`, `nuget.config`, …) without remembering a new `COPY`.
- Exclude `tests/` via `.dockerignore` since the image never builds them, keeping the context lean and the publish cache layer tight.

## Notes

- `global.json` lives at the repo root, outside the `backend/` context, and is intentionally left out — the base image tag `sdk:10.0-alpine` is the effective SDK pin and satisfies its `rollForward: latestFeature`.
- The sites that triggered the diagnostic all reported `CS8524` (they already handle every named value), so `CS8509` won't fire and the build stays green while `CS8524` drops to a suggestion.
- Not verified locally (`dotnet` isn't available in the dev container and `npm test` needs the Aspire stack); CI verifies on this PR.
- Unrelated to the original run failure that prompted the investigation — that was a transient GitHub Actions Cache 504, fixed by a re-run.

https://claude.ai/code/session_01WHEndQdeQPjaxQ74m3xyBr