### PR TITLE
Add a test error thrown from a bundled chunk (source-map verification)

### DIFF
--- a/frontend/src/i18n/cs/admin-test-errors.json
+++ b/frontend/src/i18n/cs/admin-test-errors.json
@@ -16,7 +16,9 @@
     "throwError": "Vyvolat výjimku",
     "throwErrorDescription": "Volá POST /api/test-errors/throw — server okamžitě vyhodí výjimku.",
     "crashAfterData": "Chyba klienta po API volání",
-    "crashAfterDataDescription": "Načte GET /api/job-offers?pageSize=1, poté vyhodí JavaScript chybu na straně klienta."
+    "crashAfterDataDescription": "Načte GET /api/job-offers?pageSize=1, poté vyhodí JavaScript chybu na straně klienta.",
+    "crashBundled": "Chyba klienta ze sbaleného kódu",
+    "crashBundledDescription": "Vyhodí chybu z importovaného modulu minifikovaného Vite — případ, který v Sentry vyžaduje nahrané zdrojové mapy."
   },
   "results": {
     "triggered": "Chyba vyvolána — zkontrolujte dashboard sledování.",

--- a/frontend/src/i18n/en/admin-test-errors.json
+++ b/frontend/src/i18n/en/admin-test-errors.json
@@ -16,7 +16,9 @@
     "throwError": "Throw Exception",
     "throwErrorDescription": "Calls POST /api/test-errors/throw — the server throws immediately.",
     "crashAfterData": "Client Error After API Call",
-    "crashAfterDataDescription": "Fetches GET /api/job-offers?pageSize=1, then throws a client-side JavaScript error."
+    "crashAfterDataDescription": "Fetches GET /api/job-offers?pageSize=1, then throws a client-side JavaScript error.",
+    "crashBundled": "Client Error From Bundled Code",
+    "crashBundledDescription": "Throws from an imported, Vite-minified module — the case that needs uploaded source maps to read in Sentry."
   },
   "results": {
     "triggered": "Error triggered — check your observability dashboard.",

--- a/frontend/src/lib/test-errors.ts
+++ b/frontend/src/lib/test-errors.ts
@@ -1,0 +1,11 @@
+// Throws from bundled (Vite-minified) code so the Sentry source-map upload can be
+// verified end to end: without uploaded maps the resulting issue points at a minified
+// `_astro/*.js` frame; with maps it resolves back to this file. The nested call gives
+// the stack more than one in-app frame to resolve. Wired from the admin test-errors page.
+export function crashFromBundledModule(): never {
+  formatAndThrow("a bundled module");
+}
+
+function formatAndThrow(source: string): never {
+  throw new Error(`Test client-side error thrown from ${source}.`);
+}

--- a/frontend/src/pages/[...lang]/admin/test-errors.astro
+++ b/frontend/src/pages/[...lang]/admin/test-errors.astro
@@ -92,6 +92,23 @@ const c = commons[lang];
           {t.buttons.crashAfterData}
         </button>
       </div>
+
+      <div class="bg-surface-container-low rounded-2xl border border-outline-variant/10 p-8">
+        <div class="flex items-center gap-3 mb-4">
+          <Icon name="material-symbols:code" class="size-6 text-error" aria-hidden="true" />
+          <h2 class="font-headline text-xl font-bold text-on-surface">{t.buttons.crashBundled}</h2>
+        </div>
+        <p class="text-on-surface-variant font-body text-sm mb-6">{t.buttons.crashBundledDescription}</p>
+        <button
+          id="btn-crash-bundled"
+          type="button"
+          data-triggered-msg={t.results.triggered}
+          class="inline-flex items-center gap-2 px-6 py-3 bg-error text-on-error rounded-full font-body font-medium hover:bg-error/90 transition-colors cursor-pointer"
+        >
+          <Icon name="material-symbols:bolt" class="size-[18px]" aria-hidden="true" />
+          {t.buttons.crashBundled}
+        </button>
+      </div>
     </div>
   </section>
 </Layout>
@@ -162,4 +179,20 @@ const c = commons[lang];
       if (err instanceof Error && err.message.startsWith("Test client-side")) throw err;
     }
   });
+</script>
+
+<!-- Separate processed script. The throw must originate in a Vite-minified `_astro/*.js`
+     chunk (the case Sentry source maps fix), not this page's inline `define:vars` block.
+     The dynamic import is a Vite split point, so test-errors.ts becomes its own external
+     chunk — an inline import would get folded into the page and resolve to the HTML URL. -->
+<script>
+  const btn = document.getElementById("btn-crash-bundled");
+  if (btn) {
+    btn.addEventListener("click", async () => {
+      window.observability?.track("admin.test-errors.crash-bundled-clicked");
+      window.__showSnackbar?.(btn.dataset.triggeredMsg ?? "", "success", 2000);
+      const { crashFromBundledModule } = await import("../../../lib/test-errors");
+      crashFromBundledModule();
+    });
+  }
 </script>


### PR DESCRIPTION
## Summary

Adds a third button to the admin **Test Errors** page that throws a client-side error from a **Vite-minified `_astro/*.js` chunk** — so the upcoming Sentry source-map upload (#133 / PR #138) can actually be verified.

## Why

The existing *"Client Error After API Call"* button throws from the page's inline `define:vars` script. Astro can't bundle a `define:vars` script, so it emits it **verbatim into the page HTML**. Sentry then resolves those frames simply by fetching the live page — they read fine **with or without** source maps. That makes the button useless as a source-map test: it would look "resolved" even if no maps were ever uploaded.

To verify source maps you need a frame that originates in minified bundle code (e.g. `_astro/test-errors.DFOPP84O.js:1:NNN`), which is exactly what real app errors (Layout, components, `.ts` modules) look like.

## How

- New module [frontend/src/lib/test-errors.ts](frontend/src/lib/test-errors.ts) with a small nested throw (two in-app frames, so map resolution is exercised on more than one frame).
- New admin button wired by a **processed** `<script>` that pulls the module in via a **dynamic `import()`**. The dynamic import is a Vite split point, so the module lands in its own external minified chunk rather than being inlined into the page — an inline/static import would get folded into the HTML and resolve to the page URL, defeating the purpose.

Verified against the production build:
- `dist/_astro/test-errors.<hash>.js` contains the throw, minified (`throw new Error(\`Test client-side error thrown from ${r}.\`)`).
- The message does **not** appear inline in `dist/admin/test-errors/index.html`.

## Verification flow (the point of this PR)

1. Merge + deploy **this** PR → click "Client Error From Bundled Code" in prod → the Sentry issue shows a **minified** `_astro/*.js` frame (the "before" baseline, no maps yet).
2. Merge + deploy the source-maps PR (#138) → click again → the same frame now resolves to `src/lib/test-errors.ts`.

## Test plan

- [x] `npm --prefix frontend run build` — throw lands in an external `_astro/*.js` chunk, not inline HTML
- [x] `npm test` — full suite (backend + frontend + e2e 12/12) green
- [x] `prettier --check` clean
- [ ] After deploy: click the button in prod and confirm the Sentry frame is minified `_astro/*.js` (pre-source-maps baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)