### PR TITLE
Fix Sentry source maps: emit .map files from vite.build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -536,8 +536,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CI_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-          # No SENTRY_URL: the org auth token embeds its own region endpoint and routes there
-          # automatically. Setting one is ignored (and warns) — the EU project resolves via the token.
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -536,9 +536,8 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CI_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-          # Org is in Sentry's EU region; the plugin's API calls default to the US silo, so point
-          # them at the EU endpoint explicitly (the DSN host is ingest.de.sentry.io).
-          SENTRY_URL: https://de.sentry.io/
+          # No SENTRY_URL: the org auth token embeds its own region endpoint and routes there
+          # automatically. Setting one is ignored (and warns) — the EU project resolves via the token.
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -424,10 +424,8 @@ Plus these repository **variables** (Settings → Variables → Actions) used by
 | `SENTRY_ORG` | Sentry organisation slug (visible in the URL — `https://<org>.sentry.io`). Optional with an org auth token, which already carries the org. |
 | `SENTRY_PROJECT` | Slug of the **frontend (Browser JavaScript)** project |
 
-The deploy job also sets `SENTRY_URL=https://de.sentry.io/` (hardcoded in the workflow) because the
-org lives in Sentry's EU region — the DSN host is `ingest.de.sentry.io`. The org auth token is
-region-aware for the upload itself, but the plugin's release API calls default to the US silo, so
-the endpoint is pinned explicitly. Change it only if the project moves regions.
+The org lives in Sentry's EU region (the DSN host is `ingest.de.sentry.io`), but no `SENTRY_URL` is
+set — the org auth token embeds its own region endpoint and the upload routes there automatically.
 
 The **frontend** Sentry DSN is committed in `frontend/.env` — browser DSNs are public credentials
 (protected by the per-project Allowed Domains list in Sentry, not by secrecy) so a GitHub secret
@@ -518,7 +516,6 @@ Inputs (see §4.1):
 
 - `SENTRY_CI_TOKEN` (secret, mapped to `SENTRY_AUTH_TOKEN` at build time) — required for upload. Missing → upload is skipped silently.
 - `SENTRY_PROJECT` (and optionally `SENTRY_ORG`) repo vars — point the upload at the right Sentry project.
-- `SENTRY_URL` (hardcoded in the workflow) — pins the EU region endpoint.
 
 `astro.config.mjs` sets `build.sourcemap: 'hidden'` only when the auth
 token is present, so dev (`npm run aspire`) and CI builds don't generate

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -66,11 +66,6 @@ export default defineConfig({
   },
   build: {
     inlineStylesheets: "always",
-    // 'hidden' emits .map files but strips the sourceMappingURL comment from the bundle, so the
-    // browser doesn't request them. Sentry resolves stack traces via the uploaded copies instead.
-    // Only meaningful when the Sentry upload plugin is active — otherwise the .map files would be
-    // generated and thrown away. Keep `false` in dev/CI to skip the cost.
-    sourcemap: sentryAuthToken ? "hidden" : false,
   },
   integrations: [
     icon(),
@@ -95,6 +90,13 @@ export default defineConfig({
     },
   },
   vite: {
+    build: {
+      // 'hidden' emits .map files but strips the sourceMappingURL comment from the bundle, so the
+      // browser never requests them; Sentry resolves stack traces via the uploaded copies (matched
+      // by debug ID). Must live under `vite.build` — Astro's own `build` key ignores `sourcemap`.
+      // Only meaningful when the upload plugin below is active; keep `false` in dev/CI to skip the cost.
+      sourcemap: sentryAuthToken ? "hidden" : false,
+    },
     plugins: [
       tailwindcss(),
       ...(sentryAuthToken && sentryOrg && sentryProject


### PR DESCRIPTION
## Summary

Source-map upload (#138) ran on the first prod deploy and the maps appeared in Sentry, but **every stack frame stayed minified**. Root cause: the build was generating **no `.map` files at all**, so the plugin uploaded JS-with-debug-IDs but no maps to resolve against.

## Root cause

`build.sourcemap: 'hidden'` was set on **Astro's top-level `build`** key — but `sourcemap` isn't an Astro `build` option (Astro's are `format`/`client`/`server`/`assets`/`inlineStylesheets`), so it was silently ignored and Vite never emitted maps. The Vite sourcemap option has to live under **`vite.build`**.

The deploy log made it explicit — for every artifact:
```
~/<debug-id>-NN.js (no sourcemap found, debug id <debug-id>)
  - warning: could not determine a source map reference ...
```

## Fix

- Move `sourcemap: sentryAuthToken ? 'hidden' : false` from `build` → `vite.build` in [astro.config.mjs](frontend/astro.config.mjs).
- Drop `SENTRY_URL` from the deploy job. The deploy log showed the org auth token embeds its own region endpoint and the upload routed to EU regardless — the explicit URL was ignored and only produced a `WARN`.

## Verification (local, `SENTRY_AUTH_TOKEN` set so `sourcemap:'hidden'` activates)

- Before: `0` `.map` files emitted. After: `20`.
- `dist/_astro/test-errors.<hash>.js.map` exists, references `src/lib/test-errors.ts`, and contains the original `crashFromBundledModule` source.
- JS has no `sourceMappingURL` comment (correct `hidden` behaviour).
- No-token / CI build still emits `0` maps (gating intact).

## Test plan

- [x] `npm --prefix frontend run build` with token → maps emitted with original source; without token → none
- [x] `npm test` — full suite (backend + frontend + e2e 12/12) green
- [x] `prettier --check` clean (frontend scope)
- [ ] After deploy: trigger a **fresh** "Client Error From Bundled Code" in prod → frame resolves to `src/lib/test-errors.ts` (note: events ingested before this deploy stay minified — Sentry doesn't re-process them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)