### PR TITLE
feat(frontend): two-flag language toggle with inline SVG flags

### DIFF
--- a/frontend/src/components/LanguagePicker.astro
+++ b/frontend/src/components/LanguagePicker.astro
@@ -1,0 +1,81 @@
+---
+import type { Locale } from "../i18n/utils";
+import { alternateLangUrl } from "../i18n/utils";
+
+interface Props {
+  lang: Locale;
+  activePage: string;
+  labels: {
+    language: string;
+    switchToEnglish: string;
+    switchToCzech: string;
+  };
+}
+
+const { lang, activePage, labels } = Astro.props;
+
+// Both flags are always shown so the available pair is visible at a glance; the
+// active locale is highlighted and the other dimmed. Flags are inline SVG (not
+// emoji) — emoji regional-indicator flags don't render on Windows.
+const options: { locale: Locale; label: string }[] = [
+  { locale: "en", label: labels.switchToEnglish },
+  { locale: "cs", label: labels.switchToCzech },
+];
+---
+
+<div class="inline-flex items-center gap-0.5 rounded-full border border-on-surface/30 p-0.5" role="group" aria-label={labels.language}>
+  {
+    options.map((opt) => {
+      const active = lang === opt.locale;
+      return (
+        <a
+          href={alternateLangUrl(opt.locale, activePage)}
+          hreflang={opt.locale}
+          title={opt.label}
+          aria-label={opt.label}
+          aria-current={active ? "true" : undefined}
+          class:list={[
+            "rounded-full px-1.5 py-1 transition",
+            active ? "bg-surface-container-high opacity-100" : "opacity-50 grayscale hover:opacity-100 hover:grayscale-0",
+          ]}
+        >
+          <span class="block w-5 h-3.5 overflow-hidden rounded-[2px] shadow-sm ring-1 ring-black/10">
+            {opt.locale === "cs" ? (
+              <svg viewBox="0 0 6 4" preserveAspectRatio="none" class="w-full h-full" aria-hidden="true">
+                <rect width="6" height="4" fill="#fff" />
+                <rect y="2" width="6" height="2" fill="#d7141a" />
+                <path d="M0 0l3 2-3 2z" fill="#11457e" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 60 30" preserveAspectRatio="none" class="w-full h-full" aria-hidden="true">
+                <rect width="60" height="30" fill="#fff" />
+                <g fill="#b22234">
+                  <rect width="60" y="0" height="2.308" />
+                  <rect width="60" y="4.615" height="2.308" />
+                  <rect width="60" y="9.231" height="2.308" />
+                  <rect width="60" y="13.846" height="2.308" />
+                  <rect width="60" y="18.462" height="2.308" />
+                  <rect width="60" y="23.077" height="2.308" />
+                  <rect width="60" y="27.692" height="2.308" />
+                </g>
+                <rect width="24" height="16.154" fill="#3c3b6e" />
+                <g fill="#fff">
+                  <circle cx="4" cy="3" r="0.9" />
+                  <circle cx="12" cy="3" r="0.9" />
+                  <circle cx="20" cy="3" r="0.9" />
+                  <circle cx="8" cy="6.5" r="0.9" />
+                  <circle cx="16" cy="6.5" r="0.9" />
+                  <circle cx="4" cy="10" r="0.9" />
+                  <circle cx="12" cy="10" r="0.9" />
+                  <circle cx="20" cy="10" r="0.9" />
+                  <circle cx="8" cy="13.5" r="0.9" />
+                  <circle cx="16" cy="13.5" r="0.9" />
+                </g>
+              </svg>
+            )}
+          </span>
+        </a>
+      );
+    })
+  }
+</div>

--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -1,7 +1,8 @@
 ---
 import { Icon } from "astro-icon/components";
 import type { Locale } from "../i18n/utils";
-import { localePath, alternateLangUrl } from "../i18n/utils";
+import { localePath } from "../i18n/utils";
+import LanguagePicker from "./LanguagePicker.astro";
 
 type ActivePage =
   | "home"
@@ -37,7 +38,9 @@ interface Props {
       mainNavigation: string;
       skipToContent: string;
       toggleDarkMode: string;
-      changeLanguage: string;
+      language: string;
+      switchToEnglish: string;
+      switchToCzech: string;
       openProjectsMenu: string;
     };
     theme: { switchToDark: string };
@@ -107,16 +110,12 @@ const navItems: NavItem[] = [
         <Icon name="material-symbols:dark-mode" class="size-[18px] dark-hidden" aria-hidden="true" />
         <Icon name="material-symbols:light-mode" class="size-[18px] hidden dark-visible" aria-hidden="true" />
       </button>
-      <!-- Language picker (mobile) — only two languages, so the flag switches directly. -->
-      <a
-        href={alternateLangUrl(lang === "cs" ? "en" : "cs", activePage)}
-        class="p-1 cursor-pointer"
-        title={t.a11y.changeLanguage}
-        aria-label={t.a11y.changeLanguage}
-        hreflang={lang === "cs" ? "en" : "cs"}
-      >
-        <span class:list={["fi fis inline-block w-4 h-3 rounded-sm", lang === "cs" ? "fi-cz" : "fi-us"]} aria-hidden="true"></span>
-      </a>
+      <!-- Language picker (mobile) -->
+      <LanguagePicker
+        lang={lang}
+        activePage={activePage}
+        labels={{ language: t.a11y.language, switchToEnglish: t.a11y.switchToEnglish, switchToCzech: t.a11y.switchToCzech }}
+      />
       <!-- Auth (mobile) -->
       <button
         id="auth-sign-in-mobile"
@@ -207,16 +206,12 @@ const navItems: NavItem[] = [
         <Icon name="material-symbols:dark-mode" class="size-5 dark-hidden" aria-hidden="true" />
         <Icon name="material-symbols:light-mode" class="size-5 hidden dark-visible" aria-hidden="true" />
       </button>
-      <!-- Language picker (desktop) — only two languages, so the flag switches directly. -->
-      <a
-        href={alternateLangUrl(lang === "cs" ? "en" : "cs", activePage)}
-        class="px-2.5 py-1.5 rounded-lg text-on-surface-variant hover:text-primary hover:bg-surface-container-high transition-colors cursor-pointer"
-        title={t.a11y.changeLanguage}
-        aria-label={t.a11y.changeLanguage}
-        hreflang={lang === "cs" ? "en" : "cs"}
-      >
-        <span class:list={["fi fis inline-block w-5 h-3.5 rounded-sm", lang === "cs" ? "fi-cz" : "fi-us"]} aria-hidden="true"></span>
-      </a>
+      <!-- Language picker (desktop) -->
+      <LanguagePicker
+        lang={lang}
+        activePage={activePage}
+        labels={{ language: t.a11y.language, switchToEnglish: t.a11y.switchToEnglish, switchToCzech: t.a11y.switchToCzech }}
+      />
       <!-- Auth (desktop) -->
       <div id="auth-container-desktop" class="flex items-center">
         <button

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -41,7 +41,9 @@
     "skipToContent": "Přeskočit na obsah",
     "mainNavigation": "Hlavní navigace",
     "toggleDarkMode": "Přepnout tmavý režim",
-    "changeLanguage": "Přepnout do angličtiny",
+    "language": "Jazyk",
+    "switchToEnglish": "Přepnout do angličtiny",
+    "switchToCzech": "Přepnout do češtiny",
     "openProjectsMenu": "Rychlé odkazy na konkrétní projekty",
     "breadcrumb": "Drobečková navigace"
   },

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -41,7 +41,9 @@
     "skipToContent": "Skip to content",
     "mainNavigation": "Main navigation",
     "toggleDarkMode": "Toggle dark mode",
-    "changeLanguage": "Switch to Czech",
+    "language": "Language",
+    "switchToEnglish": "Switch to English",
+    "switchToCzech": "Switch to Czech",
     "openProjectsMenu": "Quick links to specific projects",
     "breadcrumb": "Breadcrumb"
   },

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -85,19 +85,6 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
         </>
       )
     }
-    <!-- Flag icons: loaded non-render-blocking via the media swap trick.
-         The browser fetches the stylesheet at low priority because it thinks it's
-         for print, then the onload handler switches it to `media="all"` so styles
-         apply. The <noscript> fallback ensures it still works without JS. -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css"
-      media="print"
-      onload="this.media='all'"
-    />
-    <noscript>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css" />
-    </noscript>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <title>{title}</title>


### PR DESCRIPTION
## What

Replaces the single-flag language switcher with a **two-flag pill toggle** — both locales shown at once, the active one highlighted and the other dimmed/grayscale — extracted into a reusable `LanguagePicker.astro` component (used by both the mobile and desktop navbar, removing the previous duplication).

Also **drops the `flag-icons` CDN dependency** in favor of inline SVG flags.

## Why inline SVG instead of flag-icons

For a fixed two-locale toggle, pulling a ~260-flag third-party CDN stylesheet to render 2 flags was over-dependency. Inline SVG:

- removes an external render-path request (jsdelivr) plus the `media="print"` swap hack and `<noscript>` fallback in `Layout.astro`;
- renders crisply at any DPI / OS scaling / browser zoom (vector, re-rasterized at device resolution) — emoji or raster sprites would blur;
- avoids the flash where flags pop in after the CSS loads;
- `rem`-based sizing scales with the user's font-size preference (accessibility);
- matches the approach now used in the hampap repo (US flag SVG copied from there, keeping English = US flag).

## Accessibility

Each flag is a labeled link (`hreflang`, `aria-label`, `aria-current` on the active locale) wrapped in a `role="group"` with an `aria-label`. New a11y strings (`language`, `switchToEnglish`, `switchToCzech`) replace the old directional `changeLanguage` key in both `en` and `cs` `common.json`.

## Verification

- `npm run build` — clean
- Full frontend Playwright suite (12 tests) — all pass, including the language-switcher test
- Prettier — clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)