### PR TITLE
feat(infra): host disk-space watchdog + daily health digest to Slack

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -24,6 +24,7 @@ For architecture, tech stack, and decision log, see the [Project page](https://w
   - [3.1 Supabase Project](#31-supabase-project)
   - [3.2 Oracle Cloud VM](#32-oracle-cloud-vm)
     - [OS Updates and Reboots](#os-updates-and-reboots)
+    - [Host Monitoring](#host-monitoring)
     - [Reboot Survival](#reboot-survival)
   - [3.3 Shared Caddy Reverse Proxy](#33-shared-caddy-reverse-proxy)
     - [3.3.1 Provision the shared proxy](#331-provision-the-shared-proxy-once-per-machine)
@@ -265,6 +266,15 @@ documented alongside their unit files in
 [`infra/host/os-updates.md`](../infra/host/os-updates.md). It's all additive host
 ops — none of it touches the running stack, which survives reboots on its own
 (see [Reboot Survival](#reboot-survival)).
+
+#### Host Monitoring
+
+Two optional Slack alerters: a **disk-space watchdog** (early warning before
+container images fill the disk) and a **daily health digest** (CPU/memory
+average, peak, and busy-minute count from `sysstat`, plus disk usage). They post
+to separate channels — alerts vs. stats — via two webhooks in the shared
+`/etc/slack-notify.env`. Documented with their unit files in
+[`infra/host/monitoring.md`](../infra/host/monitoring.md).
 
 #### Authenticate to GHCR
 
@@ -539,8 +549,9 @@ repo now expects. Run as `opc`, from a checkout of the branch being deployed.
    ```
 
 `linger` and the `ip_unprivileged_port_start` sysctl are already in place from
-the original setup. The additive host bits — automatic updates, the reboot
-banner, and the Slack notifier ([`infra/host/os-updates.md`](../infra/host/os-updates.md)) —
+the original setup. The additive host bits — automatic updates and the reboot
+notifier ([`infra/host/os-updates.md`](../infra/host/os-updates.md)), plus the
+disk and health alerters ([`infra/host/monitoring.md`](../infra/host/monitoring.md)) —
 can be done any time.
 
 > **Sequencing:** do steps 1–5 right around merging the deploy PR — migrate the

--- a/infra/host/disk-notify.service
+++ b/infra/host/disk-notify.service
@@ -1,0 +1,11 @@
+# Posts a Slack alert when a host filesystem is running low. Triggered by disk-notify.timer.
+# System-level (root) so it runs regardless of who's logged in. Install: see infra/host/monitoring.md.
+[Unit]
+Description=Notify Slack when a host filesystem crosses its usage threshold
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/slack-notify.env
+ExecStart=/usr/local/bin/disk-notify.sh

--- a/infra/host/disk-notify.sh
+++ b/infra/host/disk-notify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run on a timer (disk-notify.timer): post to Slack when any local filesystem
+# crosses a usage threshold. The host pulls a lot of container images, so this
+# is the early warning before the disk fills and podman/Caddy start failing.
+#
+# The webhook URL comes from /etc/slack-notify.env (WEBHOOK_URL=...), shared
+# with the other host alerters so there's one secret to manage.
+#
+# Like reboot-notify, the timer checks often and this script throttles the
+# *notifications* to one per THROTTLE window so a lingering full disk doesn't
+# spam the channel. The marker is cleared once usage drops back under the
+# threshold, so the next episode pings immediately.
+set -euo pipefail
+
+[ -n "${WEBHOOK_URL:-}" ] || { echo "WEBHOOK_URL not set in /etc/slack-notify.env" >&2; exit 0; }
+
+THRESHOLD=${DISK_THRESHOLD:-85}   # percent used; alert when a filesystem reaches this
+STATE=/var/lib/disk-notify/last-notified
+THROTTLE=$((24 * 3600))           # seconds between repeat pings while a disk stays over threshold
+
+# Pseudo/overlay filesystems either aren't real storage or are double-counted
+# against their backing fs (container overlays), so leave them out.
+PSEUDO='-x tmpfs -x devtmpfs -x squashfs -x overlay -x efivarfs'
+
+# Blocks and inodes can each independently exhaust a filesystem; check both.
+# -P keeps the columns stable across both reports: $4 free, $5 used%, $6 mount.
+scan() {  # $1 = extra df flags (h | ih), $2 = label
+    df -P"$1" $PSEUDO | awk -v t="$THRESHOLD" -v kind="$2" '
+        NR > 1 { p = $5; sub(/%/, "", p)
+                 if (p + 0 >= t) printf "  %s%% %s used (%s free) on %s\n", p + 0, kind, $4, $6 }'
+}
+
+# $(...) strips trailing newlines, so collect each section and re-add a newline
+# after it — otherwise the rows (and the closing line below) run together.
+offenders=""
+for section in "$(scan h space)" "$(scan ih inodes)"; do
+    [ -n "$section" ] && offenders="${offenders}${section}"$'\n'
+done
+
+if [ -z "$offenders" ]; then
+    rm -f "$STATE"        # back under threshold — reset so the next episode pings immediately
+    exit 0
+fi
+
+if [ -e "$STATE" ]; then
+    age=$(( $(date +%s) - $(stat -c %Y "$STATE") ))
+    [ "$age" -lt "$THROTTLE" ] && exit 0
+fi
+
+msg="⚠ $(hostname): disk usage has reached ${THRESHOLD}% —
+${offenders}Free space soon (e.g. 'podman image prune -a', 'journalctl --vacuum-time=7d') to avoid the stack failing."
+
+# Slack wants a JSON string: escape backslashes and quotes, join lines with \n.
+payload=$(printf '%s' "$msg" | awk 'BEGIN{ORS="\\n"} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); print}')
+curl -fsS -X POST -H 'Content-Type: application/json' \
+    --data "{\"text\": \"${payload}\"}" "$WEBHOOK_URL" >/dev/null
+
+mkdir -p "$(dirname "$STATE")"
+touch "$STATE"

--- a/infra/host/disk-notify.timer
+++ b/infra/host/disk-notify.timer
@@ -1,0 +1,14 @@
+# Checks hourly whether a filesystem has crossed its usage threshold. The script
+# (disk-notify.sh) throttles the actual Slack notifications to once per 24h, so
+# an hourly check means timely warning without a noisy channel. Disk usage
+# creeps slowly, so hourly is plenty. Persistent=true catches up a missed run
+# after the VM was off.
+[Unit]
+Description=Check hourly for a host filesystem running low
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/host/host-stats.service
+++ b/infra/host/host-stats.service
@@ -1,0 +1,11 @@
+# Posts a daily host health digest to Slack. Triggered by host-stats.timer.
+# System-level (root) so it runs regardless of who's logged in. Install: see infra/host/monitoring.md.
+[Unit]
+Description=Post a daily host health digest (CPU/memory/disk) to Slack
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/slack-notify.env
+ExecStart=/usr/local/bin/host-stats.sh

--- a/infra/host/host-stats.sh
+++ b/infra/host/host-stats.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Run daily (host-stats.timer): post a host health digest to Slack — for the
+# previous day, the average / peak / number of busy intervals for CPU and
+# memory (from sysstat/sar), plus current disk usage. disk-notify.sh is the
+# urgent threshold watchdog; this is the trend digest.
+#
+# The "N intervals above X%" spike count is the point of per-minute sampling:
+# each minute sar records is one interval, so counting the busy ones surfaces a
+# local spike that a daily average would smooth away. Set the collection cadence
+# to match (see infra/host/monitoring.md).
+#
+# sysstat names its files by day-of-month (saNN), so a stale saNN can be last
+# month's file under the same name. Two guards: we only trust a file written
+# recently (FRESH_MAX) — so a dead collector reads as "n/a", never as month-old
+# numbers dressed up as current — and after sending we prune to a few days of
+# history by file age, which needs no month-length arithmetic.
+#
+# The digest posts via STATS_WEBHOOK_URL — its own channel, separate from the
+# alerts' WEBHOOK_URL. A Slack incoming webhook is one-channel, so the two
+# channels are two webhook URLs (same app) in /etc/slack-notify.env.
+set -euo pipefail
+
+[ -n "${STATS_WEBHOOK_URL:-}" ] || { echo "STATS_WEBHOOK_URL not set in /etc/slack-notify.env" >&2; exit 0; }
+
+SPIKE=${CPU_SPIKE_PCT:-70}          # a sample busier than this counts as a "spike" minute
+KEEP_DAYS=${STATS_KEEP_DAYS:-3}     # days of sysstat history to retain after the digest
+FRESH_MAX=$(( 2 * 24 * 3600 ))      # a data file older than this is treated as stale
+
+# ISO time keeps each row's leading timestamp a single token; the row parser
+# below maps columns by header name regardless, but this keeps output stable.
+export S_TIME_FORMAT=ISO LC_ALL=C
+
+# Prefer yesterday's complete file, fall back to today's partial — but only if
+# the file was actually written recently (guards against a dead collector and
+# against last month's saNN being reused under the same name).
+f=""
+for d in "$(date -d yesterday +%d)" "$(date +%d)"; do
+    cand="/var/log/sa/sa$d"
+    [ -f "$cand" ] || continue
+    age=$(( $(date +%s) - $(stat -c %Y "$cand") ))
+    [ "$age" -le "$FRESH_MAX" ] && { f="$cand"; break; }
+done
+
+# Reduce one sar report to "avg max spikes samples" across its per-interval rows.
+# The column is located by header name, so layout differences between sysstat
+# versions don't matter; invert=1 turns %idle into busy% (100 - idle). Prints
+# nothing when there are no data rows, so the caller can fall back to "n/a".
+stats() {  # $1 = sar flag (-u|-r), $2 = column header, $3 = invert (0|1), $4 = spike threshold
+    { sar "$1" -f "$f" 2>/dev/null || true; } | awk -v want="$2" -v inv="$3" -v thr="$4" '
+        /^Average:/ || /RESTART/ { next }
+        index($0, want) && !col  { for (i = 1; i <= NF; i++) if ($i == want) col = i; next }
+        col && $col ~ /^[0-9.]+$/ {
+            v = inv ? 100 - $col : $col + 0
+            n++; sum += v
+            if (v > max)   max = v
+            if (v > thr)   spikes++
+        }
+        END { if (n) printf "%.0f %.0f %d %d", sum / n, max, spikes, n }'
+}
+
+cpu="n/a"; mem="n/a"; note=""
+if [ -z "$f" ]; then
+    note="
+⚠ no recent sysstat data — is collection running? (systemctl status sysstat-collect.timer)"
+else
+    if read -r avg max spikes n <<<"$(stats -u %idle 1 "$SPIKE")" && [ -n "${n:-}" ]; then
+        cpu="avg ${avg}% · peak ${max}% · ${spikes}/${n} min above ${SPIKE}%"
+    fi
+    if read -r avg max _ n <<<"$(stats -r %memused 0 "$SPIKE")" && [ -n "${n:-}" ]; then
+        mem="avg ${avg}% · peak ${max}%"
+    fi
+fi
+
+load=$(awk '{printf "%s / %s / %s", $1, $2, $3}' /proc/loadavg)
+cores=$(nproc 2>/dev/null || echo '?')   # load == cores is full saturation, so it's the scale for the numbers above
+disk=$(df -Ph -x tmpfs -x devtmpfs -x squashfs -x overlay -x efivarfs |
+    awk 'NR > 1 { printf "  %s on %s (%s used of %s, %s free)\n", $5, $6, $3, $2, $4 }')
+
+msg="📊 $(hostname) — daily health for $(date -d yesterday +%F)
+• CPU: ${cpu}
+• Memory: ${mem}
+• Load (1/5/15m): ${load}  (${cores} cores = full)
+• Disk:
+${disk}${note}"
+
+# Slack wants a JSON string: escape backslashes and quotes, join lines with \n.
+payload=$(printf '%s' "$msg" | awk 'BEGIN{ORS="\\n"} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); print}')
+curl -fsS -X POST -H 'Content-Type: application/json' \
+    --data "{\"text\": \"${payload}\"}" "$STATS_WEBHOOK_URL" >/dev/null
+
+# Reported — now prune old history. Age-based, so there's no day-of-month or
+# month-length math; stale files (incl. last month's under a reused name) go too.
+find /var/log/sa -maxdepth 1 -type f -name 'sa*' -mtime +"$KEEP_DAYS" -delete 2>/dev/null || true

--- a/infra/host/host-stats.timer
+++ b/infra/host/host-stats.timer
@@ -1,0 +1,13 @@
+# Posts the health digest once a day at 08:00. RandomizedDelaySec spreads the
+# send so it doesn't fire at the exact same second as other timers.
+# Persistent=true catches up a missed run after the VM was off.
+[Unit]
+Description=Send the daily host health digest to Slack
+
+[Timer]
+OnCalendar=*-*-* 08:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/host/monitoring.md
+++ b/infra/host/monitoring.md
@@ -1,0 +1,166 @@
+# Host monitoring: disk alerts and health stats
+
+Two Slack alerters for the Oracle Linux VM, plus the historical CPU/memory data
+behind them. Like the [OS-update notifier](os-updates.md), these are additive
+host ops — none of it touches the running app stack.
+
+- **`disk-notify`** — a watchdog that pings Slack when any filesystem crosses a
+  usage threshold (the early warning before the disk fills from container
+  images and podman/Caddy start failing).
+- **`host-stats`** — a daily digest posting yesterday's CPU and memory (average,
+  peak, and how many minutes ran hot), plus current disk usage.
+
+Both read `/etc/slack-notify.env`, alongside the OS-update notifier. It holds
+two webhook URLs so urgent alerts and the daily digest land in separate channels
+(a Slack incoming webhook is bound to one channel — see
+[its own channel](#posting-the-digest-to-its-own-channel)):
+
+- `WEBHOOK_URL` — alerts channel: `reboot-notify` and `disk-notify`.
+- `STATS_WEBHOOK_URL` — stats channel: the `host-stats` digest.
+
+If you haven't created the file and the first (`WEBHOOK_URL`) webhook yet, see
+[os-updates.md → Push the alert to Slack](os-updates.md#b-push-the-alert-to-slack).
+
+## Disk-space alert (`disk-notify`)
+
+Install ([`disk-notify.sh`](disk-notify.sh), [`.service`](disk-notify.service),
+[`.timer`](disk-notify.timer)):
+
+```bash
+sudo cp infra/host/disk-notify.sh /usr/local/bin/disk-notify.sh
+sudo chmod +x /usr/local/bin/disk-notify.sh
+sudo cp infra/host/disk-notify.service infra/host/disk-notify.timer /etc/systemd/system/
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now disk-notify.timer
+```
+
+The timer **checks** hourly; the script **notifies** at most once per 24h while a
+filesystem stays over threshold (default **85%**), for both block and inode
+usage. The marker (`/var/lib/disk-notify/last-notified`) is cleared once usage
+drops back under, so a fresh episode pings right away — same shape as
+[reboot-notify](os-updates.md#behavior).
+
+Force a run to confirm it's wired up (silent if everything's under threshold):
+
+```bash
+sudo systemctl start disk-notify.service && journalctl -u disk-notify.service -n 20 --no-pager
+```
+
+## Daily health digest (`host-stats`)
+
+For each of CPU and memory the digest reports **average**, **peak**, and (for
+CPU) **how many intervals ran above a threshold** (`CPU_SPIKE_PCT`, default 70%)
+over the previous day. That last number is what catches a local spike a daily
+average would smooth away — but it's only meaningful if each interval is short,
+so the collection cadence matters.
+
+`sysstat` is the standard tool for this history. Each `sar` sample stores the
+kernel's cumulative counters; the per-interval CPU% is the *average over that
+interval* (counter delta ÷ time), so nothing between samples is lost. Memory is
+an instantaneous gauge, so its samples are point-in-time.
+
+```bash
+sudo dnf install -y sysstat
+sudo systemctl enable --now sysstat-collect.timer sysstat-summary.timer
+```
+
+The default cadence is every 10 minutes; drop it to **1 minute** so the spike
+count has the resolution to mean "a busy minute". (1 min matches systemd timers'
+default `AccuracySec`; finer than that needs extra tuning for little gain.)
+
+```bash
+sudo mkdir -p /etc/systemd/system/sysstat-collect.timer.d
+sudo tee /etc/systemd/system/sysstat-collect.timer.d/override.conf >/dev/null << 'EOF'
+[Timer]
+OnCalendar=
+OnCalendar=minutely
+AccuracySec=1s
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart sysstat-collect.timer
+```
+
+> **Storage & staleness:** the digest prunes `/var/log/sa/` to the last
+> `STATS_KEEP_DAYS` (default **3**) after each run, by file age — so 1-minute
+> sampling stays at single-digit MB and never accumulates. This also closes a
+> trap: sysstat names files by day-of-month (`saNN`), so a dead collector would
+> otherwise leave last month's `saNN` in place to be misread as "today". The
+> digest only trusts a file written in the last ~2 days; a stale or missing one
+> reads as `n/a` with a "collection may have stopped" note, never as old numbers
+> dressed up as current.
+
+> Give it a few sampling intervals before the first digest has data — until a
+> recent `/var/log/sa/saNN` file exists, the CPU/memory fields read `n/a` (disk
+> usage still works, since that's read live).
+
+Then install the digest ([`host-stats.sh`](host-stats.sh),
+[`.service`](host-stats.service), [`.timer`](host-stats.timer)):
+
+```bash
+sudo cp infra/host/host-stats.sh /usr/local/bin/host-stats.sh
+sudo chmod +x /usr/local/bin/host-stats.sh
+sudo cp infra/host/host-stats.service infra/host/host-stats.timer /etc/systemd/system/
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now host-stats.timer
+```
+
+It fires daily at 08:00 and reports the **previous full calendar day** (a clean
+24h window). First add its webhook ([below](#posting-the-digest-to-its-own-channel)) —
+the digest needs `STATS_WEBHOOK_URL` — then send one now to verify:
+
+```bash
+sudo systemctl start host-stats.service
+```
+
+### Posting the digest to its own channel
+
+The digest requires its own `STATS_WEBHOOK_URL` — it does **not** fall back to
+the alerts channel, so a missing one is a clear config error rather than daily
+stats quietly flooding the alerts channel. Add a **second** Incoming Webhook to
+the *same* Slack app (a webhook is bound to one channel, so a different channel
+needs a different URL — but not a different app), then add it to the env file:
+
+```bash
+printf 'STATS_WEBHOOK_URL=%s\n' 'https://hooks.slack.com/services/AAA/BBB/CCC' | sudo tee -a /etc/slack-notify.env >/dev/null
+```
+
+`disk-notify` and `reboot-notify` use `WEBHOOK_URL`; only the digest uses
+`STATS_WEBHOOK_URL`.
+
+## Querying the stats ad-hoc
+
+`sysstat` data is also queryable directly with `sar` any time — useful when an
+alert fires and you want detail the digest doesn't carry:
+
+```bash
+sar -u                       # CPU, every sample today (last line is the average)
+sar -r                       # memory
+sar -u -f /var/log/sa/sa15   # a specific day-of-month (here, the 15th)
+sar -d -p                    # per-disk I/O
+sar -q                       # load average + run queue
+```
+
+The digest prunes history to the last few days (`STATS_KEEP_DAYS`, see Tuning),
+so `sar -f` lookback only reaches back that far. sysstat's own `HISTORY`
+(`/etc/sysconfig/sysstat`) is moot once our prune runs tighter than it.
+
+## Tuning
+
+- **Disk threshold** — set `DISK_THRESHOLD=` (percent) in `/etc/slack-notify.env`;
+  `disk-notify.service` already sources that file.
+- **Check / re-nag cadence** — `OnCalendar=` in [`disk-notify.timer`](disk-notify.timer)
+  and `THROTTLE` in [`disk-notify.sh`](disk-notify.sh).
+- **Digest time** — `OnCalendar=` in [`host-stats.timer`](host-stats.timer).
+- **CPU spike threshold** — set `CPU_SPIKE_PCT=` (percent) in `/etc/slack-notify.env`;
+  the digest counts intervals busier than this.
+- **Sampling resolution** — `OnCalendar=` in the `sysstat-collect.timer` drop-in
+  above; finer samples sharpen the spike count at the cost of more stored data.
+- **History retention** — set `STATS_KEEP_DAYS=` in `/etc/slack-notify.env`; the
+  digest prunes `/var/log/sa/` to that many days (by file age) after each run.
+- **Digest channel** — `STATS_WEBHOOK_URL=` in `/etc/slack-notify.env` is the
+  digest's own channel (separate from the alerts' `WEBHOOK_URL`; see above).
+
+After editing a unit or script, re-copy it and
+`sudo systemctl daemon-reload && sudo systemctl restart <name>.timer`.

--- a/infra/host/os-updates.md
+++ b/infra/host/os-updates.md
@@ -93,7 +93,17 @@ First, create the webhook (one-time, in the Slack UI):
 2. **Incoming Webhooks** → toggle **On** → **Add New Webhook to Workspace** → pick the channel.
 3. Copy the **Webhook URL** (`https://hooks.slack.com/services/…`).
 
-Then install ([`reboot-notify.sh`](reboot-notify.sh),
+The URL goes in `/etc/slack-notify.env`, the shared secrets file for all the
+host alerters — `reboot-notify` and `disk-notify` use this `WEBHOOK_URL`; the
+[daily stats digest](monitoring.md) adds its own `STATS_WEBHOOK_URL` for a
+separate channel. Create the file with the URL from step 3:
+
+```bash
+printf 'WEBHOOK_URL=%s\n' 'https://hooks.slack.com/services/XXX/YYY/ZZZ' | sudo tee /etc/slack-notify.env >/dev/null
+sudo chmod 600 /etc/slack-notify.env
+```
+
+Then install the units ([`reboot-notify.sh`](reboot-notify.sh),
 [`.service`](reboot-notify.service), [`.timer`](reboot-notify.timer) — copy from
 a checkout, or paste their contents):
 
@@ -101,10 +111,6 @@ a checkout, or paste their contents):
 sudo cp infra/host/reboot-notify.sh /usr/local/bin/reboot-notify.sh
 sudo chmod +x /usr/local/bin/reboot-notify.sh
 sudo cp infra/host/reboot-notify.service infra/host/reboot-notify.timer /etc/systemd/system/
-
-# Paste the webhook URL from step 3 above
-printf 'WEBHOOK_URL=%s\n' 'https://hooks.slack.com/services/XXX/YYY/ZZZ' | sudo tee /etc/reboot-notify.env >/dev/null
-sudo chmod 600 /etc/reboot-notify.env
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now reboot-notify.timer
@@ -114,7 +120,7 @@ These are **system** units (under `/etc/systemd/system/`, run by PID 1), so they
 need no linger — just `enable` to start on boot. Verify the webhook end-to-end:
 
 ```bash
-sudo bash -c 'source /etc/reboot-notify.env && curl -fsS -X POST -H "Content-Type: application/json" \
+sudo bash -c 'source /etc/slack-notify.env && curl -fsS -X POST -H "Content-Type: application/json" \
   --data "{\"text\":\"✅ reboot-notify test from $(hostname)\"}" "$WEBHOOK_URL"'
 ```
 

--- a/infra/host/reboot-notify.service
+++ b/infra/host/reboot-notify.service
@@ -7,5 +7,5 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/reboot-notify.env
+EnvironmentFile=/etc/slack-notify.env
 ExecStart=/usr/local/bin/reboot-notify.sh

--- a/infra/host/reboot-notify.sh
+++ b/infra/host/reboot-notify.sh
@@ -3,9 +3,10 @@
 # applying updates, post to a Slack incoming webhook. dnf-automatic installs
 # patches but never reboots, so this is how a pending reboot gets noticed.
 #
-# The webhook URL comes from /etc/reboot-notify.env (WEBHOOK_URL=...), kept out
-# of this script so the secret isn't committed. For Discord, change the JSON
-# key from "text" to "content"; for ntfy, send "$msg" as a plain-text body.
+# The webhook URL comes from /etc/slack-notify.env (WEBHOOK_URL=...), shared
+# with the other host alerters (disk-notify, host-stats) so there's one secret
+# to manage. For Discord, change the JSON key from "text" to "content"; for
+# ntfy, send "$msg" as a plain-text body.
 #
 # The timer checks often; this script throttles the *notifications* to one per
 # THROTTLE window so a lingering pending-reboot doesn't spam the channel. The
@@ -13,7 +14,7 @@
 # so the next episode pings immediately.
 set -euo pipefail
 
-[ -n "${WEBHOOK_URL:-}" ] || { echo "WEBHOOK_URL not set in /etc/reboot-notify.env" >&2; exit 0; }
+[ -n "${WEBHOOK_URL:-}" ] || { echo "WEBHOOK_URL not set in /etc/slack-notify.env" >&2; exit 0; }
 
 STATE=/var/lib/reboot-notify/last-notified
 THROTTLE=$((24 * 3600))   # seconds between repeat pings while a reboot stays pending


### PR DESCRIPTION
## What

Two new host-level systemd alerters for the Oracle Linux VM, reusing the same Slack-webhook pattern as the existing `reboot-notify`, plus the historical metrics behind them.

- **`disk-notify`** — hourly watchdog that pings Slack when any local filesystem crosses a usage threshold (blocks **and** inodes; default 85%, `DISK_THRESHOLD`). Throttled to one ping per 24h via the same state-marker pattern as `reboot-notify`; the marker resets when usage drops back under. This is the early warning before container-image pulls fill the disk.
- **`host-stats`** — daily digest (08:00) of the **previous full day** from `sysstat`/`sar`:
  - **CPU & memory**: average, peak, and — for CPU — how many minute-intervals ran above a spike threshold (`CPU_SPIKE_PCT`, default 70%). The spike count is the point of per-minute sampling: it surfaces a local burst a daily average would smooth away.
  - **Load** (instantaneous 1/5/15m) with **core count** so the numbers have a saturation scale.
  - **Disk** usage, live.

## Webhooks / channels

All alerters read `/etc/slack-notify.env` (unified from the old per-script env file). Alerts and the digest go to **separate channels** via two webhooks on the same Slack app:

- `WEBHOOK_URL` — alerts: `reboot-notify`, `disk-notify`
- `STATS_WEBHOOK_URL` — the `host-stats` digest (required; no fallback, so a misconfig surfaces instead of flooding the alerts channel)

## Correctness guards

- **Staleness:** `sysstat` names files by day-of-month (`saNN`), so a dead collector could leave last month's file to be misread as "today". The digest only trusts a file written in the last ~2 days; otherwise it reports `n/a` with a "collection may have stopped" note — turning the failure into a signal.
- **Retention:** after sending, the digest prunes `/var/log/sa` to `STATS_KEEP_DAYS` (default 3) **by file age** (`find -mtime`), so there's no month-length arithmetic and the footprint stays at single-digit MB.

## Testing

These are host-infra shell scripts + docs, outside the app build/test surface (`npm test` covers backend/frontend/E2E and doesn't touch `infra/host`). Validated directly instead: `bash -n` on all scripts, plus functional runs with stubbed `curl`/`sar`/`df` covering fresh data, stale-file fallback, the age-based prune (keeps recent, drops old, leaves non-`sa*` files), JSON payload validity, and webhook selection.

## Docs

New [`infra/host/monitoring.md`](infra/host/monitoring.md) (install, 1-minute sysstat cadence, retention, second-channel setup); `os-updates.md` and `SETUP.md` updated for the shared env file and the new alerters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)