### PR TITLE
feat(frontend): three-state theme switcher (light/system/dark)

### DIFF
--- a/frontend/src/components/Navbar.astro
+++ b/frontend/src/components/Navbar.astro
@@ -3,6 +3,7 @@ import { Icon } from "astro-icon/components";
 import type { Locale } from "../i18n/utils";
 import { localePath } from "../i18n/utils";
 import LanguagePicker from "./LanguagePicker.astro";
+import ThemePicker from "./ThemePicker.astro";
 
 type ActivePage =
   | "home"
@@ -37,13 +38,12 @@ interface Props {
     a11y: {
       mainNavigation: string;
       skipToContent: string;
-      toggleDarkMode: string;
       language: string;
       switchToEnglish: string;
       switchToCzech: string;
       openProjectsMenu: string;
     };
-    theme: { switchToDark: string };
+    theme: { label: string; light: string; system: string; dark: string };
   };
 }
 
@@ -98,18 +98,9 @@ const navItems: NavItem[] = [
   <div class="flex justify-between items-center px-8 py-4 max-w-7xl mx-auto">
     <a href={localePath(lang, "home")} class="text-xl font-bold tracking-tighter text-on-surface font-headline">kalandra.tech</a>
 
-    <!-- Theme toggle + Language picker + Auth (mobile) -->
+    <!-- Theme picker + Language picker + Auth (mobile) -->
     <div class="flex md:hidden items-center gap-2">
-      <button
-        id="theme-toggle-mobile"
-        type="button"
-        class="p-1 text-on-surface-variant"
-        aria-label={t.a11y.toggleDarkMode}
-        title={t.theme.switchToDark}
-      >
-        <Icon name="material-symbols:dark-mode" class="size-[18px] dark-hidden" aria-hidden="true" />
-        <Icon name="material-symbols:light-mode" class="size-[18px] hidden dark-visible" aria-hidden="true" />
-      </button>
+      <ThemePicker labels={{ label: t.theme.label, light: t.theme.light, system: t.theme.system, dark: t.theme.dark }} />
       <!-- Language picker (mobile) -->
       <LanguagePicker
         lang={lang}
@@ -193,19 +184,9 @@ const navItems: NavItem[] = [
       }
     </div>
 
-    <!-- Theme toggle + Language picker + Auth (desktop) -->
+    <!-- Theme picker + Language picker + Auth (desktop) -->
     <div class="hidden md:flex items-center gap-2">
-      <!-- Dark mode toggle -->
-      <button
-        id="theme-toggle"
-        type="button"
-        class="p-1.5 grid place-items-center text-on-surface-variant hover:text-primary transition-colors rounded-lg hover:bg-surface-container-high"
-        aria-label={t.a11y.toggleDarkMode}
-        title={t.theme.switchToDark}
-      >
-        <Icon name="material-symbols:dark-mode" class="size-5 dark-hidden" aria-hidden="true" />
-        <Icon name="material-symbols:light-mode" class="size-5 hidden dark-visible" aria-hidden="true" />
-      </button>
+      <ThemePicker labels={{ label: t.theme.label, light: t.theme.light, system: t.theme.system, dark: t.theme.dark }} />
       <!-- Language picker (desktop) -->
       <LanguagePicker
         lang={lang}

--- a/frontend/src/components/ThemePicker.astro
+++ b/frontend/src/components/ThemePicker.astro
@@ -1,0 +1,61 @@
+---
+import { Icon } from "astro-icon/components";
+
+interface Props {
+  labels: {
+    label: string;
+    light: string;
+    system: string;
+    dark: string;
+  };
+}
+
+const { labels } = Astro.props;
+
+// Three-state toggle: explicit light/dark plus a "system" middle that follows
+// the OS preference (the default when the visitor has never picked one). The
+// active segment is highlighted purely from the `data-theme-pref` attribute the
+// pre-paint script sets on <html>, so the right one paints with no flash.
+const options: { value: "light" | "system" | "dark"; label: string; icon: string }[] = [
+  { value: "light", label: labels.light, icon: "light-mode" },
+  { value: "system", label: labels.system, icon: "computer" },
+  { value: "dark", label: labels.dark, icon: "dark-mode" },
+];
+---
+
+<div class="inline-flex items-center gap-0.5 rounded-full border border-on-surface/30 p-0.5" role="group" aria-label={labels.label}>
+  {
+    options.map((opt) => (
+      <button
+        type="button"
+        data-theme-option={opt.value}
+        title={opt.label}
+        aria-label={opt.label}
+        aria-pressed="false"
+        class="theme-opt grid place-items-center rounded-full p-1.5 text-on-surface-variant transition cursor-pointer"
+      >
+        <Icon name={`material-symbols:${opt.icon}`} class="size-[18px]" aria-hidden="true" />
+      </button>
+    ))
+  }
+</div>
+
+<style>
+  /* Inactive segments are dimmed; the one matching the stored preference is
+     lit. Driven by the html[data-theme-pref] attribute so the active state is
+     correct on first paint — no JS-driven flash. */
+  .theme-opt {
+    opacity: 0.5;
+  }
+  .theme-opt:hover {
+    opacity: 1;
+    color: var(--color-on-surface);
+  }
+  :global(html[data-theme-pref="light"]) .theme-opt[data-theme-option="light"],
+  :global(html[data-theme-pref="system"]) .theme-opt[data-theme-option="system"],
+  :global(html[data-theme-pref="dark"]) .theme-opt[data-theme-option="dark"] {
+    opacity: 1;
+    color: var(--color-on-surface);
+    background-color: var(--color-surface-container-high);
+  }
+</style>

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -34,13 +34,14 @@
     "callbackError": "Přihlášení se nepodařilo dokončit. Zkuste to prosím znovu."
   },
   "theme": {
-    "switchToDark": "Přepnout na tmavý režim",
-    "switchToLight": "Přepnout na světlý režim"
+    "label": "Motiv",
+    "light": "Světlý režim",
+    "system": "Podle systému",
+    "dark": "Tmavý režim"
   },
   "a11y": {
     "skipToContent": "Přeskočit na obsah",
     "mainNavigation": "Hlavní navigace",
-    "toggleDarkMode": "Přepnout tmavý režim",
     "language": "Jazyk",
     "switchToEnglish": "Přepnout do angličtiny",
     "switchToCzech": "Přepnout do češtiny",

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -34,13 +34,14 @@
     "callbackError": "Sign-in could not be completed. Please try again."
   },
   "theme": {
-    "switchToDark": "Switch to dark mode",
-    "switchToLight": "Switch to light mode"
+    "label": "Theme",
+    "light": "Light mode",
+    "system": "System theme",
+    "dark": "Dark mode"
   },
   "a11y": {
     "skipToContent": "Skip to content",
     "mainNavigation": "Main navigation",
-    "toggleDarkMode": "Toggle dark mode",
     "language": "Language",
     "switchToEnglish": "Switch to English",
     "switchToCzech": "Switch to Czech",

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -119,8 +119,13 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
 
     <script is:inline>
       (function () {
-        var theme = localStorage.getItem("theme");
-        if (theme === "dark" || (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+        // Stored preference is "light" | "dark", or absent meaning "follow the
+        // OS" (the system default). Expose it as data-theme-pref so the theme
+        // picker can highlight the active segment on first paint.
+        var pref = localStorage.getItem("theme");
+        if (pref !== "light" && pref !== "dark") pref = "system";
+        document.documentElement.dataset.themePref = pref;
+        if (pref === "dark" || (pref === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
           document.documentElement.classList.add("dark");
           // Pre-paint swap of theme-aware images. As the body parses, swap
           // any `[data-src-dark]` <img> to its dark variant before the
@@ -212,19 +217,6 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
       }
       html.auth-known-in .signed-in-only {
         display: block !important;
-      }
-
-      /* Theme toggle icons: pure-CSS swap so the correct icon paints immediately based on the
-       `dark` class set by the inline pre-paint script. Avoids the JS-driven flash that
-       happened while the end-of-body updateToggleIcons() script had not yet run. */
-      html:not(.dark) .dark-visible {
-        display: none !important;
-      }
-      html.dark .dark-hidden {
-        display: none !important;
-      }
-      html.dark .dark-visible {
-        display: inline-block !important;
       }
     </style>
   </head>

--- a/frontend/src/lib/theme-toggle.ts
+++ b/frontend/src/lib/theme-toggle.ts
@@ -1,12 +1,17 @@
-function updateToggleIcons() {
-  const isDark = document.documentElement.classList.contains("dark");
-  const lightTip = document.documentElement.lang === "cs" ? "Přepnout na světlý režim" : "Switch to light mode";
-  const darkTip = document.documentElement.lang === "cs" ? "Přepnout na tmavý režim" : "Switch to dark mode";
-  const tip = isDark ? lightTip : darkTip;
-  const btn = document.getElementById("theme-toggle");
-  const btnM = document.getElementById("theme-toggle-mobile");
-  if (btn) btn.title = tip;
-  if (btnM) btnM.title = tip;
+type ThemePref = "light" | "system" | "dark";
+
+const STORAGE_KEY = "theme";
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+// "system" is represented by the absence of a stored value, matching the
+// pre-paint script in Layout.astro — an unset preference follows the OS.
+function getPref(): ThemePref {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "light" || stored === "dark" ? stored : "system";
+}
+
+function resolveDark(pref: ThemePref): boolean {
+  return pref === "dark" || (pref === "system" && prefersDark.matches);
 }
 
 // Swap any image marked with data-src-dark to its theme-appropriate src.
@@ -24,33 +29,51 @@ function swapThemedImages(willBeDark: boolean) {
   });
 }
 
-function applyThemeFlip() {
-  const willBeDark = !document.documentElement.classList.contains("dark");
+// Reflect the active preference on the picker: the data-theme-pref attribute
+// drives the CSS highlight, and aria-pressed announces the choice.
+function syncPickerState(pref: ThemePref) {
+  document.documentElement.dataset.themePref = pref;
+  document.querySelectorAll<HTMLButtonElement>("[data-theme-option]").forEach((btn) => {
+    btn.setAttribute("aria-pressed", btn.dataset.themeOption === pref ? "true" : "false");
+  });
+}
+
+function applyTheme(pref: ThemePref) {
+  const willBeDark = resolveDark(pref);
   swapThemedImages(willBeDark);
   document.documentElement.classList.toggle("dark", willBeDark);
-  localStorage.setItem("theme", willBeDark ? "dark" : "light");
-  updateToggleIcons();
+  if (pref === "system") localStorage.removeItem(STORAGE_KEY);
+  else localStorage.setItem(STORAGE_KEY, pref);
+  syncPickerState(pref);
 }
 
 // Entry point: prefer the View Transitions API for a smooth full-page
-// crossfade; fall back to the original instant flip on older browsers.
-// The legacy `no-transitions` snap is only kept as the fallback path —
-// when view transitions run, we let the browser's snapshot/crossfade
-// handle the whole page so individual element transitions are redundant.
-function toggleTheme() {
+// crossfade; fall back to the instant flip on older browsers.
+function setTheme(pref: ThemePref) {
   type DocWithVT = Document & { startViewTransition?: (cb: () => void) => unknown };
   const doc = document as DocWithVT;
   if (typeof doc.startViewTransition === "function") {
-    doc.startViewTransition(applyThemeFlip);
+    doc.startViewTransition(() => applyTheme(pref));
     return;
   }
   document.documentElement.classList.add("no-transitions");
-  applyThemeFlip();
+  applyTheme(pref);
   // Force reflow so the no-transitions class takes effect before we remove it
   document.documentElement.offsetHeight;
   document.documentElement.classList.remove("no-transitions");
 }
 
-document.getElementById("theme-toggle")?.addEventListener("click", toggleTheme);
-document.getElementById("theme-toggle-mobile")?.addEventListener("click", toggleTheme);
-updateToggleIcons();
+document.querySelectorAll<HTMLButtonElement>("[data-theme-option]").forEach((btn) => {
+  btn.addEventListener("click", () => setTheme(btn.dataset.themeOption as ThemePref));
+});
+
+// While following the system, track live OS changes (e.g. the nightly
+// light→dark switch) without a stored override taking precedence.
+prefersDark.addEventListener("change", () => {
+  if (getPref() !== "system") return;
+  const willBeDark = prefersDark.matches;
+  swapThemedImages(willBeDark);
+  document.documentElement.classList.toggle("dark", willBeDark);
+});
+
+syncPickerState(getPref());

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -90,11 +90,18 @@ test.describe("Navigation", () => {
   });
 });
 
-test.describe("Dark mode", () => {
-  test("toggle switches to dark mode and re-styles the page", async ({ page }) => {
+test.describe("Theme picker", () => {
+  test("light/system/dark segments re-style the page and persist the choice", async ({ page }) => {
     await page.goto("/");
     const html = page.locator("html");
+
+    // Default (no stored preference) follows the OS, which Playwright runs as
+    // light unless told otherwise.
     await expect(html).not.toHaveClass(/dark/);
+    await expect(html).toHaveAttribute("data-theme-pref", "system");
+
+    // Only the desktop picker is visible at the default viewport width.
+    const opt = (value: string) => page.locator(`[data-theme-option="${value}"]:visible`);
 
     // Capture a few token-driven colors in light mode so we can confirm they
     // actually change — the .dark class flipping is a precondition, not proof.
@@ -107,19 +114,32 @@ test.describe("Dark mode", () => {
 
     const lightColors = await readColors();
 
-    await page.locator("#theme-toggle").click();
+    await opt("dark").click();
     await expect(html).toHaveClass(/dark/);
+    await expect(html).toHaveAttribute("data-theme-pref", "dark");
+    await expect(opt("dark")).toHaveAttribute("aria-pressed", "true");
 
     const darkColors = await readColors();
     expect(darkColors.body).not.toBe(lightColors.body);
     expect(darkColors.nav).not.toBe(lightColors.nav);
     expect(darkColors.footer).not.toBe(lightColors.footer);
 
-    await page.locator("#theme-toggle").click();
+    await opt("light").click();
     await expect(html).not.toHaveClass(/dark/);
+    await expect(html).toHaveAttribute("data-theme-pref", "light");
 
-    // Toggling back restores the original light-mode colors.
+    // Switching back to light restores the original colors.
     const restoredColors = await readColors();
     expect(restoredColors).toEqual(lightColors);
+
+    // The chosen preference survives a reload.
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme-pref", "light");
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+    // The system segment clears the override (no stored value).
+    await opt("system").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme-pref", "system");
+    expect(await page.evaluate(() => localStorage.getItem("theme"))).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Replaces the binary dark-mode toggle button with a three-state segmented **theme picker**, styled to match the existing language selector — inspired by the Zitadel switcher.

- ☀️ **Light** · 🖥️ **System** · 🌙 **Dark**
- The middle **System** segment follows the OS `prefers-color-scheme` and is the **default** when the visitor has never picked one. While on System, the page tracks live OS theme changes (e.g. the nightly light→dark flip).
- Explicit Light/Dark are stored in `localStorage`; choosing System clears the override (no stored key), matching the existing "absent means follow OS" convention.

## How

- New `ThemePicker.astro` component (mirrors `LanguagePicker.astro`): a bordered pill with dimmed inactive segments and a highlighted active one. The active segment is driven purely by the `data-theme-pref` attribute the pre-paint script sets on `<html>`, so it paints correctly with **no flash**.
- `theme-toggle.ts` rewritten for three states; keeps the View Transitions crossfade and themed-image swapping.
- `Layout.astro` pre-paint script now resolves dark across all three states and exposes `data-theme-pref`; removed the now-dead `.dark-hidden`/`.dark-visible` icon-swap CSS.
- Both mobile and desktop navbar slots use the new picker.
- Translations updated (`theme.{label,light,system,dark}`) in EN + CS; removed obsolete `switchToDark`/`switchToLight`/`toggleDarkMode`.
- E2E test updated to drive the three segments and assert state, persistence across reload, and that System clears the override.

## Testing

Full `npm test` passes — backend, frontend unit, and E2E (12 passed, including the updated theme-picker spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)