### PR TITLE
feat(infra): roll host health digest to a trailing 24h window

### DIFF
--- a/infra/host/host-stats.sh
+++ b/infra/host/host-stats.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # Run daily (host-stats.timer): post a host health digest to Slack — for the
-# previous day, the average / peak / number of busy intervals for CPU and
-# memory (from sysstat/sar), plus current disk usage. disk-notify.sh is the
-# urgent threshold watchdog; this is the trend digest.
+# trailing 24h ending at run time, the average / peak / number of busy intervals
+# for CPU and memory (from sysstat/sar), plus current disk usage. disk-notify.sh
+# is the urgent threshold watchdog; this is the trend digest.
+#
+# A rolling window (not the previous calendar day) so the digest is current at
+# send time rather than hours stale. The window crosses midnight, so it spans
+# two day-of-month files: yesterday's saNN from the boundary to end-of-day, plus
+# today's from start-of-day to the boundary. The host runs on UTC, so the wall
+# clock is continuous (no DST jumps) and that split is always a clean 24h.
 #
 # The "N intervals above X%" spike count is the point of per-minute sampling:
 # each minute sar records is one interval, so counting the busy ones surfaces a
@@ -30,23 +36,30 @@ FRESH_MAX=$(( 2 * 24 * 3600 ))      # a data file older than this is treated as 
 # below maps columns by header name regardless, but this keeps output stable.
 export S_TIME_FORMAT=ISO LC_ALL=C
 
-# Prefer yesterday's complete file, fall back to today's partial — but only if
-# the file was actually written recently (guards against a dead collector and
-# against last month's saNN being reused under the same name).
-f=""
-for d in "$(date -d yesterday +%d)" "$(date +%d)"; do
-    cand="/var/log/sa/sa$d"
-    [ -f "$cand" ] || continue
-    age=$(( $(date +%s) - $(stat -c %Y "$cand") ))
-    [ "$age" -le "$FRESH_MAX" ] && { f="$cand"; break; }
-done
+BOUNDARY=$(date +%H:%M:00)            # window edge: now, split point between the two days
+YDAY=/var/log/sa/sa$(date -d yesterday +%d)
+TODAY=/var/log/sa/sa$(date +%d)
 
-# Reduce one sar report to "avg max spikes samples" across its per-interval rows.
-# The column is located by header name, so layout differences between sysstat
-# versions don't matter; invert=1 turns %idle into busy% (100 - idle). Prints
-# nothing when there are no data rows, so the caller can fall back to "n/a".
+# True if the file exists and was written within FRESH_MAX — guards a dead
+# collector and last month's saNN reused under the same name.
+fresh() { [ -f "$1" ] && [ $(( $(date +%s) - $(stat -c %Y "$1") )) -le "$FRESH_MAX" ]; }
+
+# Emit one sar report's per-interval rows across the trailing 24h: yesterday from
+# the boundary to end-of-day, then today up to the boundary. Both -s and -e are
+# pinned because sar otherwise defaults -e to 18:00, which would drop the evening.
+# A missing or stale segment just contributes no rows.
+sar_window() {  # $1 = sar flag (-u|-r)
+    if fresh "$YDAY";  then sar "$1" -s "$BOUNDARY" -e 23:59:59 -f "$YDAY"  2>/dev/null || true; fi
+    if fresh "$TODAY"; then sar "$1" -s 00:00:00 -e "$BOUNDARY" -f "$TODAY" 2>/dev/null || true; fi
+}
+
+# Reduce the windowed sar rows to "avg max spikes samples". The column is located
+# by header name, so layout differences between sysstat versions don't matter (and
+# the second segment's repeated header is harmlessly ignored once the column is
+# found); invert=1 turns %idle into busy% (100 - idle). Prints nothing when there
+# are no data rows, so the caller can fall back to "n/a".
 stats() {  # $1 = sar flag (-u|-r), $2 = column header, $3 = invert (0|1), $4 = spike threshold
-    { sar "$1" -f "$f" 2>/dev/null || true; } | awk -v want="$2" -v inv="$3" -v thr="$4" '
+    sar_window "$1" | awk -v want="$2" -v inv="$3" -v thr="$4" '
         /^Average:/ || /RESTART/ { next }
         index($0, want) && !col  { for (i = 1; i <= NF; i++) if ($i == want) col = i; next }
         col && $col ~ /^[0-9.]+$/ {
@@ -59,16 +72,14 @@ stats() {  # $1 = sar flag (-u|-r), $2 = column header, $3 = invert (0|1), $4 = 
 }
 
 cpu="n/a"; mem="n/a"; note=""
-if [ -z "$f" ]; then
+if read -r avg max spikes n <<<"$(stats -u %idle 1 "$SPIKE")" && [ -n "${n:-}" ]; then
+    cpu="avg ${avg}% · peak ${max}% · ${spikes}/${n} min above ${SPIKE}%"
+else
     note="
 ⚠ no recent sysstat data — is collection running? (systemctl status sysstat-collect.timer)"
-else
-    if read -r avg max spikes n <<<"$(stats -u %idle 1 "$SPIKE")" && [ -n "${n:-}" ]; then
-        cpu="avg ${avg}% · peak ${max}% · ${spikes}/${n} min above ${SPIKE}%"
-    fi
-    if read -r avg max _ n <<<"$(stats -r %memused 0 "$SPIKE")" && [ -n "${n:-}" ]; then
-        mem="avg ${avg}% · peak ${max}%"
-    fi
+fi
+if read -r avg max _ n <<<"$(stats -r %memused 0 "$SPIKE")" && [ -n "${n:-}" ]; then
+    mem="avg ${avg}% · peak ${max}%"
 fi
 
 load=$(awk '{printf "%s / %s / %s", $1, $2, $3}' /proc/loadavg)
@@ -76,7 +87,8 @@ cores=$(nproc 2>/dev/null || echo '?')   # load == cores is full saturation, so 
 disk=$(df -Ph -x tmpfs -x devtmpfs -x squashfs -x overlay -x efivarfs |
     awk 'NR > 1 { printf "  %s on %s (%s used of %s, %s free)\n", $5, $6, $3, $2, $4 }')
 
-msg="📊 $(hostname) — daily health for $(date -d yesterday +%F)
+hm=${BOUNDARY%:*}   # HH:MM for the header — the window runs hm yesterday → hm today
+msg="📊 $(hostname) — health, $(date -d yesterday +%F) ${hm} → $(date +%F) ${hm} $(date +%Z) (last 24h)
 • CPU: ${cpu}
 • Memory: ${mem}
 • Load (1/5/15m): ${load}  (${cores} cores = full)

--- a/infra/host/host-stats.timer
+++ b/infra/host/host-stats.timer
@@ -1,11 +1,11 @@
-# Posts the health digest once a day at 08:00. RandomizedDelaySec spreads the
+# Posts the health digest once a day at 09:00. RandomizedDelaySec spreads the
 # send so it doesn't fire at the exact same second as other timers.
 # Persistent=true catches up a missed run after the VM was off.
 [Unit]
 Description=Send the daily host health digest to Slack
 
 [Timer]
-OnCalendar=*-*-* 08:00
+OnCalendar=*-*-* 09:00
 RandomizedDelaySec=300
 Persistent=true
 

--- a/infra/host/monitoring.md
+++ b/infra/host/monitoring.md
@@ -7,8 +7,8 @@ host ops — none of it touches the running app stack.
 - **`disk-notify`** — a watchdog that pings Slack when any filesystem crosses a
   usage threshold (the early warning before the disk fills from container
   images and podman/Caddy start failing).
-- **`host-stats`** — a daily digest posting yesterday's CPU and memory (average,
-  peak, and how many minutes ran hot), plus current disk usage.
+- **`host-stats`** — a daily digest posting the last 24h of CPU and memory
+  (average, peak, and how many minutes ran hot), plus current disk usage.
 
 Both read `/etc/slack-notify.env`, alongside the OS-update notifier. It holds
 two webhook URLs so urgent alerts and the daily digest land in separate channels
@@ -20,6 +20,19 @@ two webhook URLs so urgent alerts and the daily digest land in separate channels
 
 If you haven't created the file and the first (`WEBHOOK_URL`) webhook yet, see
 [os-updates.md → Push the alert to Slack](os-updates.md#b-push-the-alert-to-slack).
+
+> **Updating a host with no repo checkout.** The `cp` steps below assume you're
+> in a checkout, as at first install — CI never ships these host scripts (it
+> deploys only the app slot units). To update one in place on the VM, copy it up
+> and install it with `sudo`:
+>
+> ```bash
+> scp infra/host/host-stats.sh opc@<public-ip>:/tmp/
+> ssh opc@<public-ip> 'sed -i "s/\r$//" /tmp/host-stats.sh && sudo install -m 755 /tmp/host-stats.sh /usr/local/bin/host-stats.sh'
+> ```
+>
+> The `sed` strips CR in case the file was checked out on Windows (a CRLF shebang
+> breaks the script). Then `daemon-reload`/restart as the section below shows.
 
 ## Disk-space alert (`disk-notify`)
 
@@ -80,7 +93,8 @@ in the console first if you want a safety net. If `growpart` is missing:
 
 For each of CPU and memory the digest reports **average**, **peak**, and (for
 CPU) **how many intervals ran above a threshold** (`CPU_SPIKE_PCT`, default 70%)
-over the previous day. That last number is what catches a local spike a daily
+over the **trailing 24h** ending when it runs (so the digest is current at send
+time, not hours stale). That spike count is what catches a local spike a daily
 average would smooth away — but it's only meaningful if each interval is short,
 so the collection cadence matters.
 
@@ -135,9 +149,11 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now host-stats.timer
 ```
 
-It fires daily at 08:00 and reports the **previous full calendar day** (a clean
-24h window). First add its webhook ([below](#posting-the-digest-to-its-own-channel)) —
-the digest needs `STATS_WEBHOOK_URL` — then send one now to verify:
+It fires daily at 09:00 and reports the **trailing 24h** ending at that time
+(09:00 yesterday → 09:00 today). The host runs on UTC, so that window is a clean,
+continuous 24h with no DST seam. First add its webhook
+([below](#posting-the-digest-to-its-own-channel)) — the digest needs
+`STATS_WEBHOOK_URL` — then send one now to verify:
 
 ```bash
 sudo systemctl start host-stats.service
@@ -191,5 +207,6 @@ so `sar -f` lookback only reaches back that far. sysstat's own `HISTORY`
 - **Digest channel** — `STATS_WEBHOOK_URL=` in `/etc/slack-notify.env` is the
   digest's own channel (separate from the alerts' `WEBHOOK_URL`; see above).
 
-After editing a unit or script, re-copy it and
-`sudo systemctl daemon-reload && sudo systemctl restart <name>.timer`.
+After editing a unit or script, re-copy it (or stream it up if the VM has no
+checkout — see the note under [Disk-space alert](#disk-space-alert-disk-notify))
+and `sudo systemctl daemon-reload && sudo systemctl restart <name>.timer`.


### PR DESCRIPTION
## What

The daily host health digest (`host-stats`) reported the **previous full calendar day**, so a run at 08:00 carried numbers up to ~8h stale and the sample count fell short of a full day (e.g. `989/1440` on a day collection started mid-morning).

This switches it to a **trailing 24h window ending at run time**, and moves the digest 08:00 → 09:00.

## Changes

- **`host-stats.sh`** — compute the window edge from the run time and read **two** day-of-month `sar` files: yesterday from the boundary to end-of-day, today from start-of-day to the boundary. Both `-s` and `-e` are pinned explicitly because `sar` otherwise defaults `-e` to 18:00 and would silently drop the evening. The dead-collector / reused-`saNN` freshness guards now apply per file (`fresh()`), so a missing or stale segment just contributes no rows. Header now reads e.g. `health, 2026-06-25 09:00 → 2026-06-26 09:00 UTC (last 24h)`.
- **`host-stats.timer`** — `OnCalendar` 08:00 → 09:00.
- **`monitoring.md`** — document the trailing-24h window + new time, and add a note on updating a host that has **no repo checkout** (CI never ships these host scripts), with the `scp` + `sed`-strip-CR install pattern.

## Verification

Deployed to the VM and fired one digest. The CPU line came back `avg 1% · peak 26% · 0/1439 min above 70%` — a near-complete 1440-minute day, confirming the rolling window captures a full 24h of per-minute samples (vs. the prior `989`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)