### PR TITLE
ci: drop path-based deploy gating, deploy both apps on every main push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,26 +26,6 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  changes:
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
-        id: filter
-        with:
-          filters: |
-            backend:
-              - 'backend/**'
-              - '.github/workflows/**'
-              - 'infra/**'
-            frontend:
-              - 'frontend/**'
-              - '.github/workflows/**'
-
   e2e:
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -276,13 +256,12 @@ jobs:
         working-directory: frontend
 
   backend-deploy:
-    needs: [changes, e2e, backend-test, frontend-format, frontend-test]
+    needs: [e2e, backend-test, frontend-format, frontend-test]
     if: |
       always() &&
       (
         (
           github.event_name == 'push' &&
-          needs.changes.outputs.backend == 'true' &&
           needs.e2e.result == 'success' &&
           needs.backend-test.result == 'success' &&
           needs.frontend-format.result == 'success' &&
@@ -530,19 +509,18 @@ jobs:
           expected-content: ${{ github.sha }}
 
   frontend-deploy:
-    needs: [changes, e2e, backend-test, frontend-format, frontend-test, backend-deploy]
+    needs: [e2e, backend-test, frontend-format, frontend-test, backend-deploy]
     if: |
       always() &&
       (
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'push' &&
-          needs.changes.outputs.frontend == 'true' &&
           needs.e2e.result == 'success' &&
           needs.backend-test.result == 'success' &&
           needs.frontend-format.result == 'success' &&
           needs.frontend-test.result == 'success' &&
-          (needs.backend-deploy.result == 'success' || needs.backend-deploy.result == 'skipped')
+          needs.backend-deploy.result == 'success'
         )
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Removes the `changes` job (`dorny/paths-filter`) from `ci-cd.yml` and the `needs.changes.outputs.*` conditions it fed. Every push to `main` that passes all four test jobs (`e2e`, `backend-test`, `frontend-format`, `frontend-test`) now runs `backend-deploy` followed by `frontend-deploy`, regardless of which paths the merge touched.

## Why

The skip saved little (the test jobs — the expensive part — always ran anyway) and could misfire when merging multiple PRs in quick succession, leaving a needed deploy skipped. Always deploying is simpler and idempotent — the blue/green deploy just rolls the same image forward.

## Details

- `frontend-deploy` also loses the `needs.backend-deploy.result == 'skipped'` alternative: it existed only for "frontend changed, backend didn't" pushes, and with the gating gone `backend-deploy` can no longer be skipped on a push where all tests passed. The backend-first ordering is unchanged.
- The `workflow_dispatch` escape hatch (`skip_backend_deploy`) and PR-vs-push behavior are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)