### PR TITLE
fix(job-offers): client-supplied ids for retry dedup; mark Temporal shipped in pages and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Personal showcase website at [www.kalandra.tech](https://www.kalandra.tech). Ser
 - **Backend**: ASP.NET Core (.NET 10) with Marten (event sourcing), deployed to Oracle Cloud
 - **Auth**: Supabase Auth (email/password + Google OAuth)
 - **Database**: PostgreSQL (Supabase in production, Docker locally)
-- **Background workflows**: [Temporal](https://temporal.io) — durable store-and-notify for blog comments (self-hosted)
+- **Background workflows**: [Temporal](https://temporal.io) — durable store-and-notify email notifications for blog comments and job offers (self-hosted)
 - **Observability**: [Sentry](https://sentry.io) for errors, traces, and logs (backend via the OpenTelemetry bridge; frontend via the CDN loader script behind a provider-agnostic abstraction)
 - **CI/CD**: GitHub Actions
 

--- a/backend/src/Kalandra.Api/Features/JobOffers/Contracts/AddCommentRequest.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/Contracts/AddCommentRequest.cs
@@ -2,4 +2,4 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Kalandra.Api.Features.JobOffers.Contracts;
 
-public record AddCommentRequest([MaxLength(5000)] NonEmptyString Content);
+public record AddCommentRequest([MaxLength(5000)] NonEmptyString Content, Guid? CommentId);

--- a/backend/src/Kalandra.Api/Features/JobOffers/Contracts/CreateJobOfferRequest.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/Contracts/CreateJobOfferRequest.cs
@@ -12,4 +12,5 @@ public record CreateJobOfferRequest(
     [MaxLength(100)] string? SalaryRange,
     [MaxLength(200)] string? Location,
     bool IsRemote,
-    [MaxLength(2000)] string? AdditionalNotes);
+    [MaxLength(2000)] string? AdditionalNotes,
+    Guid? Id);

--- a/backend/src/Kalandra.Api/Features/JobOffers/Contracts/CreateOfferError.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/Contracts/CreateOfferError.cs
@@ -1,3 +1,3 @@
 namespace Kalandra.Api.Features.JobOffers.Contracts;
 
-public enum CreateOfferError { CaptchaFailed, TooManyAttachments, TotalSizeTooLarge, DisallowedContentType }
+public enum CreateOfferError { CaptchaFailed, TooManyAttachments, TotalSizeTooLarge, DisallowedContentType, IdAlreadyUsed }

--- a/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
@@ -78,7 +78,12 @@ public class JobOffersController(
         if (!ModelState.IsValid)
             return ValidationProblem();
 
+        // Client-supplied so an accidental resend reuses it and the workflow dedupes to one
+        // offer; we mint one only when a caller omits it.
+        var offerId = request.Id is { } requestedId && requestedId != Guid.Empty ? requestedId : Guid.NewGuid();
+
         var command = new CreateJobOfferCommand(
+            Id: offerId,
             User: AppUser,
             CompanyName: request.CompanyName,
             ContactName: request.ContactName,
@@ -108,8 +113,14 @@ public class JobOffersController(
 
         var query = new GetJobOfferDetailQuery(Id: streamId, User: AppUser);
         var offer = await getDetailHandler.Get(query, ct);
+
+        // Null means the client-supplied id already belongs to someone else's offer: the
+        // store was an idempotent no-op and the detail query hides foreign offers.
+        if (offer == null)
+            return this.ValidationError("Id", CreateOfferError.IdAlreadyUsed);
+
         return CreatedAtAction(nameof(GetDetail), new { id = streamId },
-            GetJobOfferDetailResponse.Serialize(offer!));
+            GetJobOfferDetailResponse.Serialize(offer));
     }
 
     // ───── Edit ─────
@@ -249,8 +260,13 @@ public class JobOffersController(
         [FromBody] AddCommentRequest request,
         CancellationToken ct)
     {
+        // Client-supplied so an accidental resend reuses it and the workflow dedupes to one
+        // comment; we mint one only when a caller omits it.
+        var commentId = request.CommentId is { } requestedId && requestedId != Guid.Empty ? requestedId : Guid.NewGuid();
+
         var command = new AddCommentCommand(
             JobOfferId: id,
+            CommentId: commentId,
             User: AppUser,
             Content: request.Content,
             Timestamp: timeProvider.GetUtcNow());

--- a/backend/src/Kalandra.Blog/Workflows/BlogCommentWorkflow.cs
+++ b/backend/src/Kalandra.Blog/Workflows/BlogCommentWorkflow.cs
@@ -32,20 +32,23 @@ public class BlogCommentWorkflow
     {
         await Workflow.WaitConditionAsync(() => storeOutcome != null);
 
-        if (storeOutcome!.Posted == null)
-            return; // rejected by domain validation — nothing to notify
+        if (storeOutcome!.Posted != null)
+        {
+            var notifications = await Workflow.ExecuteActivityAsync(
+                (BlogCommentActivities activities) => activities.PlanCommentNotificationsAsync(input),
+                Options);
 
-        var notifications = await Workflow.ExecuteActivityAsync(
-            (BlogCommentActivities activities) => activities.PlanCommentNotificationsAsync(input),
-            Options);
+            // One activity per email so a failed send retries on its own instead of re-delivering the rest.
+            var sends = notifications
+                .Select(notification => Workflow.ExecuteActivityAsync(
+                    (BlogCommentActivities activities) => activities.SendCommentNotificationAsync(notification, input),
+                    Options))
+                .ToList();
+            await Task.WhenAll(sends);
+        }
 
-        // One activity per email so a failed send retries on its own instead of re-delivering the rest.
-        var sends = notifications
-            .Select(notification => Workflow.ExecuteActivityAsync(
-                (BlogCommentActivities activities) => activities.SendCommentNotificationAsync(notification, input),
-                Options))
-            .ToList();
-        await Task.WhenAll(sends);
+        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 
     [WorkflowUpdate]

--- a/backend/src/Kalandra.JobOffers/Commands/AddComment.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/AddComment.cs
@@ -10,6 +10,7 @@ namespace Kalandra.JobOffers.Commands;
 
 public record AddCommentCommand(
     Guid JobOfferId,
+    Guid CommentId,
     CurrentUser User,
     NonEmptyString Content,
     DateTimeOffset Timestamp);
@@ -24,7 +25,7 @@ public class AddCommentHandler(ITemporalClient temporalClient)
         AddCommentCommand command, CancellationToken ct)
     {
         var comment = new JobOfferCommentAdded(
-            CommentId: Guid.NewGuid(),
+            CommentId: command.CommentId,
             UserId: command.User.Id,
             UserEmail: command.User.Email,
             UserName: command.User.FullName,
@@ -37,7 +38,7 @@ public class AddCommentHandler(ITemporalClient temporalClient)
             (JobOfferCommentWorkflow workflow) => workflow.RunAsync(input),
             new(id: JobOfferCommentWorkflow.IdFor(comment.CommentId), taskQueue: JobOffersTaskQueue.Name)
             {
-                // An internal RPC retry reattaches instead of failing.
+                // A client retry of the same request reattaches instead of failing.
                 IdConflictPolicy = WorkflowIdConflictPolicy.UseExisting,
             });
 

--- a/backend/src/Kalandra.JobOffers/Commands/CreateJobOffer.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/CreateJobOffer.cs
@@ -19,6 +19,7 @@ public record CreateJobOfferFile(
     Stream Content);
 
 public record CreateJobOfferCommand(
+    Guid Id,
     CurrentUser User,
     NonEmptyString CompanyName,
     NonEmptyString ContactName,
@@ -68,7 +69,7 @@ public class CreateJobOfferHandler(ITemporalClient temporalClient, IStorageServi
             return CreateJobOfferError.DisallowedContentType;
 
         // Upload attachments
-        var streamId = Guid.NewGuid();
+        var streamId = command.Id;
         var uploadedAttachments = new List<AttachmentInfo>();
 
         if (command.Files.Count > 0)
@@ -110,7 +111,7 @@ public class CreateJobOfferHandler(ITemporalClient temporalClient, IStorageServi
             (JobOfferSubmittedWorkflow workflow) => workflow.RunAsync(input),
             new(id: JobOfferSubmittedWorkflow.IdFor(streamId), taskQueue: JobOffersTaskQueue.Name)
             {
-                // An internal RPC retry reattaches instead of failing.
+                // A client retry of the same request reattaches instead of failing.
                 IdConflictPolicy = WorkflowIdConflictPolicy.UseExisting,
             });
 

--- a/backend/src/Kalandra.JobOffers/Workflows/JobOfferCommentWorkflow.cs
+++ b/backend/src/Kalandra.JobOffers/Workflows/JobOfferCommentWorkflow.cs
@@ -33,20 +33,23 @@ public class JobOfferCommentWorkflow
     {
         await Workflow.WaitConditionAsync(() => storeOutcome != null);
 
-        if (storeOutcome!.Stored is not { } stored)
-            return; // rejected by domain validation — nothing to notify
+        if (storeOutcome!.Stored is { } stored)
+        {
+            var notifications = await Workflow.ExecuteActivityAsync(
+                (JobOfferActivities activities) => activities.PlanCommentNotifications(stored),
+                Options);
 
-        var notifications = await Workflow.ExecuteActivityAsync(
-            (JobOfferActivities activities) => activities.PlanCommentNotifications(stored),
-            Options);
+            // One activity per email so a failed send retries on its own instead of re-delivering the rest.
+            var sends = notifications
+                .Select(notification => Workflow.ExecuteActivityAsync(
+                    (JobOfferActivities activities) => activities.SendCommentNotificationAsync(notification, stored),
+                    Options))
+                .ToList();
+            await Task.WhenAll(sends);
+        }
 
-        // One activity per email so a failed send retries on its own instead of re-delivering the rest.
-        var sends = notifications
-            .Select(notification => Workflow.ExecuteActivityAsync(
-                (JobOfferActivities activities) => activities.SendCommentNotificationAsync(notification, stored),
-                Options))
-            .ToList();
-        await Task.WhenAll(sends);
+        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 
     [WorkflowUpdate]

--- a/backend/src/Kalandra.JobOffers/Workflows/JobOfferSubmittedWorkflow.cs
+++ b/backend/src/Kalandra.JobOffers/Workflows/JobOfferSubmittedWorkflow.cs
@@ -39,6 +39,9 @@ public class JobOfferSubmittedWorkflow
                 Options))
             .ToList();
         await Task.WhenAll(sends);
+
+        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 
     [WorkflowUpdate]

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
@@ -107,6 +107,41 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
     }
 
     [Fact]
+    public async Task Create_ResentWithTheSameClientId_IsStoredOnce()
+    {
+        Authenticate(email: "create-dedupe@test.com");
+        var offerId = Guid.NewGuid();
+
+        // An accidental resend (double-submit, retry) carries the same client-generated id.
+        var first = await client.PostAsync("/api/job-offers",
+            CreateValidFormContent(overrides: new() { ["Id"] = offerId.ToString() }), Ct);
+        var second = await client.PostAsync("/api/job-offers",
+            CreateValidFormContent(overrides: new() { ["Id"] = offerId.ToString() }), Ct);
+
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+        Assert.Equal(offerId.ToString(), (await ParseJsonAsync(first)).GetProperty("id").GetString());
+        Assert.Equal(offerId.ToString(), (await ParseJsonAsync(second)).GetProperty("id").GetString());
+
+        var mine = await ParseJsonAsync(await client.GetAsync("/api/job-offers/mine", Ct));
+        Assert.Equal(1, mine.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Create_WithAnotherUsersOfferId_Returns400_WithoutLeakingTheOffer()
+    {
+        var (id, _) = await CreateOfferAs("id-owner@test.com");
+
+        Authenticate(email: "id-thief@test.com");
+        var response = await client.PostAsync("/api/job-offers",
+            CreateValidFormContent(overrides: new() { ["Id"] = id }), Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await ParseJsonAsync(response);
+        Assert.Equal("IdAlreadyUsed", problem.GetProperty("errors").GetProperty("Id")[0].GetString());
+    }
+
+    [Fact]
     public async Task Edit_WithFieldOverMaxLength_Returns400_WithFieldError()
     {
         var (id, _) = await CreateOfferAs("editmax@test.com");
@@ -161,6 +196,25 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
             Ct);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddComment_ResentWithTheSameClientId_IsStoredOnce()
+    {
+        var (id, _) = await CreateOfferAs("comment-dedupe@test.com");
+        var commentId = Guid.NewGuid();
+
+        // An accidental resend (double-submit, retry) carries the same client-generated id.
+        var first = await client.PostAsJsonAsync($"/api/job-offers/{id}/comments", new { commentId, content = "Only once" }, Ct);
+        var second = await client.PostAsJsonAsync($"/api/job-offers/{id}/comments", new { commentId, content = "Only once" }, Ct);
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal(commentId.ToString(), (await ParseJsonAsync(first)).GetProperty("id").GetString());
+        Assert.Equal(commentId.ToString(), (await ParseJsonAsync(second)).GetProperty("id").GetString());
+
+        var comments = (await ParseJsonAsync(await client.GetAsync($"/api/job-offers/{id}/comments", Ct))).GetProperty("comments");
+        Assert.Equal(1, comments.GetArrayLength());
     }
 
     [Fact]

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -607,7 +607,7 @@ Add these secrets in **Settings → Secrets and Variables → Actions**:
 | `TURNSTILE_SITE_KEY` | Cloudflare Turnstile site key (public, mapped to `PUBLIC_TURNSTILE_SITE_KEY` at frontend build time) |
 | `BACKEND_SENTRY_DSN` | DSN from the Sentry **backend (.NET)** project — written to `Sentry__Dsn` at deploy time. **Required in production**; the API throws on startup if it's missing. |
 | `SENTRY_CI_TOKEN` | Sentry **organization auth token** (scope `org:ci`) used by `@sentry/vite-plugin` to upload frontend source maps during `frontend-deploy`. Create at **Settings → Auth Tokens** (org level). Mapped to `SENTRY_AUTH_TOKEN` at build time. Omitting it silently skips the upload — the deploy still succeeds, just without resolved stack traces. |
-| `SMTP_USERNAME` | Login for the SMTP relay that sends blog comment notifications |
+| `SMTP_USERNAME` | Login for the SMTP relay that sends notification emails (blog comments, job offers) |
 | `SMTP_PASSWORD` | Password for the SMTP relay |
 | `TEMPORAL_DB_USER` | Postgres role for Temporal's persistence — must be able to create databases on the first `deploy-temporal` run (`postgres` works) |
 | `TEMPORAL_DB_PASSWORD` | Password for that role |
@@ -621,7 +621,8 @@ Plus these repository **variables** (Settings → Variables → Actions):
 | `SMTP_HOST` | SMTP relay hostname — production refuses to start while this is `localhost` |
 | `SMTP_PORT` | SMTP relay port (typically `587`) |
 | `SMTP_FROM_EMAIL` | From address on notification mail (e.g. `blog@kalandra.tech`) |
-| `BLOG_AUTHOR_NOTIFICATION_EMAIL` | Mailbox that receives new-comment notifications — a real address, not `.local` |
+| `BLOG_AUTHOR_NOTIFICATION_EMAIL` | Mailbox that receives blog new-comment notifications — a real address, not `.local` |
+| `JOB_OFFERS_OWNER_NOTIFICATION_EMAIL` | Mailbox that receives job-offer notifications (new offers and comments) — a real address, not `.local` |
 | `TEMPORAL_DB_HOST` | The `Host=` from `DB_CONNECTION_STRING` (`db.<project-ref>.supabase.co`) — the direct/session host, **not** the transaction pooler |
 | `TEMPORAL_DB_PORT` | `5432` |
 

--- a/docs/backend-db.md
+++ b/docs/backend-db.md
@@ -8,11 +8,12 @@ Marten lives in domain projects (e.g. `Kalandra.JobOffers`), Supabase clients li
 |-----------------------|------------------|----------------------------------------------------------|
 | Event store           | Marten           | PostgreSQL — Supabase in prod, Docker compose locally    |
 | Read models           | Marten snapshots | Same PostgreSQL instance, inline-projected               |
+| Workflow persistence  | Temporal         | Same PostgreSQL instance — `temporal` + `temporal_visibility` databases |
 | Identity              | Supabase Auth    | JWT validated by API via JWKS                            |
 | User admin operations | Supabase Auth    | `SupabaseAdminService` (HTTP, service-key)               |
 | File attachments      | Supabase Storage | `SupabaseStorageService` (SDK, service-key)              |
 
-PostgreSQL is the only database. Supabase is used as managed Postgres + auth + object storage.
+PostgreSQL is the only database — even Temporal persists into it. Supabase is used as managed Postgres + auth + object storage.
 
 ## Marten conventions
 

--- a/docs/backend-domain.md
+++ b/docs/backend-domain.md
@@ -1,6 +1,6 @@
 # Domain Layer
 
-The domain layer owns the business. It lives in `backend/src/Kalandra.JobOffers/` and is the only place where business rules, invariants, and event shapes are defined. It has no reference to ASP.NET Core and does not know what HTTP is. Its dependencies are `Marten` (event store) and `Kalandra.Infrastructure` (cross-cutting types like `CurrentUser`, `IStorageService`).
+The domain layer owns the business. It lives in the domain projects (`backend/src/Kalandra.JobOffers/`, `backend/src/Kalandra.Blog/`) and is the only place where business rules, invariants, and event shapes are defined. It has no reference to ASP.NET Core and does not know what HTTP is. Its dependencies are `Marten` (event store), `Temporalio` (durable workflows, see `docs/backend-architecture.md` → "Background workflows"), and `Kalandra.Infrastructure` (cross-cutting types like `CurrentUser`, `IStorageService`). This doc uses `Kalandra.JobOffers` as the running example.
 
 ## Table of contents
 
@@ -31,7 +31,7 @@ A handler's validation is the **last line of defence**. The API layer may reject
 
 ## Commands, queries, handlers
 
-- **Commands** mutate state. Their return type is `Result<TSuccess, TError>` where `TSuccess` is either the new stream ID (on create) or the updated aggregate (on edit/cancel/change-status). They take an `IDocumentSession` (read-write).
+- **Commands** mutate state. Their return type is `Result<TSuccess, TError>` where `TSuccess` is either the new stream ID (on create) or the updated aggregate (on edit/cancel/change-status). They take an `IDocumentSession` (read-write). Commands that also notify (create offer, add comment, post blog comment) instead take an `ITemporalClient` and drive a durable workflow whose store activity owns the write.
 - **Queries** read state. They return `T?` (null for not-found or not-authorized) or a result record. They take an `IQuerySession` (read-only).
 - Both are registered as `Scoped` in `ServiceRegistration.AddJobOffersDomain()`.
 - The command / query / handler live in the **same file** with matching names: `CreateJobOffer.cs` holds `CreateJobOfferCommand`, `CreateJobOfferError`, and `CreateJobOfferHandler`.

--- a/docs/backend-testing.md
+++ b/docs/backend-testing.md
@@ -11,8 +11,8 @@ xUnit v3 with Microsoft.Testing.Platform.
 
 ## Test project naming
 
-- **`{Project}.Tests`** — unit tests for that project. No external dependencies (no Testcontainers, no `WebApplicationFactory`). Example: `Kalandra.JobOffers.Tests` for aggregate decide/apply tests.
-- **`{Project}.IntegrationTests`** — integration tests that need real infrastructure. Example: `Kalandra.Api.IntegrationTests` uses Testcontainers PostgreSQL + `TestWebApplicationFactory` for full HTTP round-trip tests.
+- **`{Project}.Tests`** — unit tests for that project. No external dependencies (no Testcontainers, no `WebApplicationFactory`). Examples: `Kalandra.JobOffers.Tests` and `Kalandra.Blog.Tests` for aggregate decide/apply and notification-planning tests.
+- **`{Project}.IntegrationTests`** — integration tests that need real infrastructure. Example: `Kalandra.Api.IntegrationTests` uses Testcontainers (PostgreSQL + Temporal dev server) + `TestWebApplicationFactory` for full HTTP round-trip tests.
 
 Each test project lives in `backend/tests/` and references only the project it's testing (plus `Kalandra.Infrastructure` if needed for shared types like `CurrentUser`).
 
@@ -20,8 +20,8 @@ Each test project lives in `backend/tests/` and references only the project it's
 
 `TestWebApplicationFactory` is the single test host. It:
 
-- Spins up a disposable PostgreSQL container via Testcontainers (real database, not mocks).
-- Replaces external HTTP dependencies with in-memory fakes: `InMemoryStorageService`, `AlwaysPassTurnstileValidator`, `FakeSupabaseAdminService`, `NoOpUserInfoService`.
+- Spins up disposable PostgreSQL and Temporal dev-server containers via Testcontainers — the database is real and the durable notification workflows execute for real.
+- Replaces external HTTP dependencies with in-memory fakes: `InMemoryStorageService`, `AlwaysPassTurnstileValidator`, `FakeSupabaseAdminService`, `FakeUserInfoService`, `TestBlogPostCatalog`, and `TestEmailSender` — outbound notification emails are captured there, so tests assert actual deliveries (`factory.EmailSender.Sent`).
 - Configures JWT validation against `FakeJwksHandler` so tests can mint their own tokens via `JwtTestHelper.GenerateToken(userId, email, isAdmin)`.
 - Bypasses the rate limiter via the `X-Interactive-Captcha` header.
 
@@ -107,7 +107,7 @@ The rule is about the **HTTP boundary** — what goes over the wire as JSON must
 - Happy paths with full response shape assertion.
 - Validation failures (400 with expected error codes).
 - Authorization boundaries (owner vs. other user vs. admin).
-- Side effects (history entries, comments visible to both parties).
+- Side effects (history entries, comments visible to both parties, notification emails delivered through the real Temporal workflow — poll `factory.EmailSender.Sent` since delivery is asynchronous).
 
 **Domain aggregate tests** — pure unit tests that exercise decide/apply directly. No HTTP, no database. Use domain types directly (no wire-contract risk). Test every state-machine transition: which succeed, which fail, and which error variant is returned.
 

--- a/frontend/src/components/ArchitectureDiagram.astro
+++ b/frontend/src/components/ArchitectureDiagram.astro
@@ -219,44 +219,28 @@ const { t, class: className, ...rest } = Astro.props;
           </text>
         </g>
 
-        <!-- Internal arrow: API → Temporal (planned, dashed) -->
-        <line
-          x1="460"
-          y1="203"
-          x2="460"
-          y2="220"
-          stroke="var(--color-outline-variant)"
-          stroke-width="1"
-          stroke-dasharray="3,2"
-          marker-end="url(#arrow-muted)"></line>
+        <!-- Internal arrow: API → Temporal -->
+        <line x1="530" y1="203" x2="530" y2="220" stroke="var(--color-outline)" stroke-width="1" marker-end="url(#arrow)"></line>
 
-        <!-- Temporal (planned — same size as API) -->
-        <g opacity="0.4">
+        <!-- Temporal (offset right and narrower than the API so no arrow crosses it) -->
+        <g>
           <rect
-            x="358"
+            x="420"
             y="228"
-            width="220"
+            width="180"
             height="60"
             rx="8"
             fill="var(--color-surface-container-high)"
             stroke="var(--color-outline-variant)"
-            stroke-width="1"
-            stroke-dasharray="4,3"></rect>
-          <rect x="358" y="228" width="4" height="60" rx="2" fill="var(--color-tertiary)"></rect>
-          <circle cx="376" cy="248" r="3.5" fill="var(--color-tertiary)" opacity="0.6"></circle>
-          <text x="386" y="252" fill="var(--color-on-surface)" font-family="var(--font-body)" font-size="13" font-weight="600">
+            stroke-width="0.5"></rect>
+          <rect x="420" y="228" width="4" height="60" rx="2" fill="var(--color-tertiary)"></rect>
+          <circle cx="438" cy="248" r="3.5" fill="var(--color-tertiary)" opacity="0.6"></circle>
+          <text x="448" y="252" fill="var(--color-on-surface)" font-family="var(--font-body)" font-size="13" font-weight="600">
             Temporal
           </text>
-          <text x="374" y="268" fill="var(--color-on-surface-variant)" font-family="var(--font-body)" font-size="11">
+          <text x="436" y="268" fill="var(--color-on-surface-variant)" font-family="var(--font-body)" font-size="11">
             {t.backgroundJobs}
           </text>
-          <!-- Animated loading spinner -->
-          <g transform="translate(556, 252)">
-            <g class="planned-spinner">
-              <circle cx="0" cy="0" r="6" fill="none" stroke="var(--color-outline-variant)" stroke-width="1.5"></circle>
-              <path d="M0,-6 A6,6 0 0,1 6,0" fill="none" stroke="var(--color-tertiary)" stroke-width="1.5" stroke-linecap="round"></path>
-            </g>
-          </g>
         </g>
       </g>
 
@@ -358,12 +342,16 @@ const { t, class: className, ...rest } = Astro.props;
       ></path>
 
       <!-- Backend API → PostgreSQL (API bottom → DB top) -->
-      <path d="M468,203 C468,340 400,400 380,438" fill="none" stroke="var(--color-outline)" stroke-width="1.5" marker-end="url(#arrow)"
+      <path d="M390,203 C390,330 385,400 375,438" fill="none" stroke="var(--color-outline)" stroke-width="1.5" marker-end="url(#arrow)"
+      ></path>
+
+      <!-- Temporal → PostgreSQL (workflow persistence) -->
+      <path d="M490,288 C490,360 460,400 445,438" fill="none" stroke="var(--color-outline)" stroke-width="1.5" marker-end="url(#arrow)"
       ></path>
 
       <!-- Backend API → Supabase Auth (JWT validation, dashed) -->
       <path
-        d="M440,196 C420,320 340,400 330,503"
+        d="M370,196 C355,320 340,400 330,503"
         fill="none"
         stroke="var(--color-outline)"
         stroke-width="1"
@@ -372,7 +360,7 @@ const { t, class: className, ...rest } = Astro.props;
 
       <!-- Backend API → Supabase Storage (file uploads) -->
       <path
-        d="M490,203 C500,400 460,530 440,568"
+        d="M405,203 C415,400 440,530 440,568"
         fill="none"
         stroke="var(--color-outline)"
         stroke-width="1"

--- a/frontend/src/i18n/cs/project.json
+++ b/frontend/src/i18n/cs/project.json
@@ -14,7 +14,7 @@
     "statusLabel": "Stav",
     "statusValue": "Použitelné MVP",
     "versionLabel": "Aktuální verze",
-    "versionValue": "v2.0",
+    "versionValue": "v4.0",
     "timeLabel": "Čas nasazení",
     "timeValue": "32 hodin",
     "timeNote": "Viz roadmap pro rozpis.",
@@ -34,8 +34,7 @@
     "architecture": "Architektura",
     "decisions": "Architektonická rozhodnutí",
     "roadmap": "Plán vývoje",
-    "lessonsLearned": "Poučení z projektu",
-    "openQuestions": "Otevřené otázky"
+    "lessonsLearned": "Poučení z projektu"
   },
   "techStack": {
     "title": "Postaveno na",
@@ -280,10 +279,10 @@
         "context": "Potřebujeme testovací přístup, který poskytuje vysokou jistotu s minimem mockování a pokrývá celý stack od API endpointů po databázi.",
         "decision": "Tři vrstvy testování, všechny běží paralelně v CI/CD. Každá blokuje deployment při selhání.",
         "why": [
-          "Backend integrační testy (hlavní zaměření): xUnit + Testcontainers — reálný PostgreSQL, celé API přes WebApplicationFactory. Mockovat co nejméně (auth je mockovaný, externí služby jako Slack/email budou mockované), ale databáze je reálná, takže většinu funkcionality lze snadno ověřit",
+          "Backend integrační testy (hlavní zaměření): xUnit + Testcontainers — reálný PostgreSQL a reálný Temporal dev server, celé API přes WebApplicationFactory. Mockovat co nejméně (auth je mockovaný, odchozí emaily zachytává in-memory fake a testy je ověřují), ale databáze je reálná, takže většinu funkcionality lze snadno ověřit",
           "Backend unit testy: pro doménovou logiku a čisté funkce, kde by integrační testy byly zbytečně složité",
           "Frontend page testy: Playwright — builduje statický web, ověřuje renderování, navigaci, i18n a dark mode",
-          "E2E testy: Playwright proti celé běžící aplikaci — fungující auth, fungující DB, vše reálné. Pouze externí systémy jako Slack a email nelze ověřit",
+          "E2E testy: Playwright proti celé běžící aplikaci — fungující auth, fungující DB, vše reálné. Pouze skutečně externí efekty jako reálné doručení emailu nelze ověřit",
           "CI/CD: Všechny tři testovací sady běží paralelně, všechny blokují deployment při selhání"
         ]
       }
@@ -300,6 +299,7 @@
         "verdict": "Asi bych to udělal znovu pro jednoduchost nastavení u osobních projektů. Ne u komerčních projektů se skutečným rozpočtem.",
         "observations": [
           "PostgreSQL zdarma je super a samo o sobě stojí za to",
+          "Persistence Temporalu se vešla do stejné Supabase PostgreSQL (databáze temporal a temporal_visibility) — žádná další databáze navíc",
           {
             "text": "Auth má některé hrubé hrany — např. problémy s email providerem",
             "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605",
@@ -330,20 +330,6 @@
         "observations": [
           "Už teď byly místa, kde by pomohl router — např. sdílený header, footer a auth status napříč stránkami",
           "SSG je jednodušší pro nastavení deploye, ale v reálných podmínkách prostě zaplatíte za infrastrukturu a neřešíte to"
-        ]
-      }
-    ]
-  },
-  "openQuestions": {
-    "title": "Otevřené otázky",
-    "items": [
-      {
-        "title": "Temporal + Supabase databáze",
-        "description": "Temporal vyžaduje vlastní databázi. Napojení na Supabase PostgreSQL by mohlo vyčerpat limity free tieru pro připojení, úložiště a egress.",
-        "options": [
-          "Použít Supabase PostgreSQL pro Temporal — monitorovat využití kvóty",
-          "Spustit samostatnou SQLite nebo PostgreSQL instanci na VPS pro Temporal",
-          "Přejít na Azure Queue Storage, pokud je režie Temporalu příliš vysoká"
         ]
       }
     ]
@@ -439,17 +425,36 @@
         "number": 3,
         "title": "Emaily, Slack a observabilita",
         "done": false,
-        "faded": true,
-        "description": "Emailová potvrzení a Slack notifikace při podání pracovních nabídek a změnách stavu. Kompletní observability stack: Sentry pro chyby, traces a logy, PostHog pro produktovou analytiku.",
+        "description": "Částečně hotovo: emailové notifikace běží (přes Temporal, viz v4) a Sentry pokrývá chyby, traces a logy. Zbývá: Slack notifikace, emaily při změnách stavu a PostHog produktová analytika.",
         "side": "left"
       },
       {
         "number": 4,
         "title": "Úlohy na pozadí",
-        "done": false,
-        "faded": true,
-        "description": "Přesun emailů a notifikací do zpracování na pozadí. Self-hosted Temporal na backend VPS s retry sémantikou. Záloha: Azure Queue Storage.",
-        "side": "right"
+        "done": true,
+        "dates": "7. 7. 2026",
+        "description": "Emaily a notifikace běží jako durable workflow na pozadí: self-hosted Temporal na backend VPS s retry sémantikou, persistence v Supabase PostgreSQL. Uložení komentáře či pracovní nabídky a rozeslání notifikací sdílí jeden workflow — jedno se nestane bez druhého.",
+        "side": "right",
+        "detailsLabel": "Co se udělalo",
+        "details": [
+          {
+            "author": "claude",
+            "text": "Self-hosted Temporal server na VPS, persistence v Supabase PostgreSQL"
+          },
+          {
+            "author": "claude",
+            "text": "Durable store-and-notify workflow s retry: komentáře na blogu, podání pracovních nabídek i komentáře k nabídkám notifikují správné lidi emailem"
+          },
+          {
+            "author": "claude",
+            "text": "Temporal Web UI na temporal.kalandra.tech za Cloudflare Access"
+          },
+          { "author": "pavel", "text": "Brevo SMTP relay a nastavení Cloudflare Access" },
+          {
+            "author": "claude",
+            "text": "Aspire spouští lokální Temporal dev server; integrační testy ověřují doručené emaily proti skutečnému přes Testcontainers"
+          }
+        ]
       },
       {
         "number": 5,

--- a/frontend/src/i18n/en/project.json
+++ b/frontend/src/i18n/en/project.json
@@ -14,7 +14,7 @@
     "statusLabel": "Status",
     "statusValue": "Usable MVP",
     "versionLabel": "Current Version",
-    "versionValue": "v2.0",
+    "versionValue": "v4.0",
     "timeLabel": "Rollout Time",
     "timeValue": "32 hours",
     "timeNote": "See roadmap for breakdown.",
@@ -34,8 +34,7 @@
     "architecture": "Architecture",
     "decisions": "Architecture Decisions",
     "roadmap": "Roadmap",
-    "lessonsLearned": "Lessons Learned",
-    "openQuestions": "Open Questions"
+    "lessonsLearned": "Lessons Learned"
   },
   "techStack": {
     "title": "Engineered With",
@@ -280,10 +279,10 @@
         "context": "Need a testing approach that provides high confidence with minimal mocking, covering the full stack from API endpoints to database.",
         "decision": "Three layers of testing, all running in parallel in CI/CD. Each blocks deployment on failure.",
         "why": [
-          "Backend integration tests (main focus): xUnit + Testcontainers — real PostgreSQL, full API via WebApplicationFactory. Mock as little as possible (auth is mocked, external services like Slack/email will be mocked), but the database is real so most functionality is easy to assert",
+          "Backend integration tests (main focus): xUnit + Testcontainers — real PostgreSQL and a real Temporal dev server, full API via WebApplicationFactory. Mock as little as possible (auth is mocked, outbound email is captured by an in-memory fake and asserted), but the database is real so most functionality is easy to assert",
           "Backend unit tests: for domain logic and pure functions where integration tests would be overkill",
           "Frontend page tests: Playwright — builds the static site, verifies rendering, navigation, i18n, and dark mode",
-          "E2E tests: Playwright against the full running application — working auth, working DB, everything real. Only external systems like Slack and email can't be asserted",
+          "E2E tests: Playwright against the full running application — working auth, working DB, everything real. Only truly external side effects like actual email delivery can't be asserted",
           "CI/CD: All three test suites run in parallel, all block deployment on failure"
         ]
       }
@@ -300,6 +299,7 @@
         "verdict": "Would probably do it again just for the setup simplicity on personal projects. Not on commercial projects with real budgets.",
         "observations": [
           "Free PostgreSQL is cool and worth it on its own",
+          "Temporal's persistence fits into the same Supabase PostgreSQL (temporal + temporal_visibility databases) — no extra database to run",
           {
             "text": "Auth has some rough edges — e.g. email provider issues",
             "link": "https://github.com/orgs/supabase/discussions/37737#discussioncomment-14990605",
@@ -330,20 +330,6 @@
         "observations": [
           "Already had places where a router would help — e.g. shared header, footer, and auth status across pages",
           "SSG is simpler for deploy setup, but in real circumstances you just pay for the infrastructure and don't worry about it"
-        ]
-      }
-    ]
-  },
-  "openQuestions": {
-    "title": "Open Questions",
-    "items": [
-      {
-        "title": "Temporal + Supabase Database",
-        "description": "Temporal requires its own database. Pointing it at the Supabase PostgreSQL might eat into the free tier's connection, storage, and egress limits.",
-        "options": [
-          "Use Supabase PostgreSQL for Temporal — monitor quota usage",
-          "Run a separate SQLite or PostgreSQL instance on the VPS for Temporal",
-          "Fall back to Azure Queue Storage if Temporal overhead is too high"
         ]
       }
     ]
@@ -439,17 +425,36 @@
         "number": 3,
         "title": "Emails, Slack & Observability",
         "done": false,
-        "faded": true,
-        "description": "Email confirmations and Slack notifications on job offer submissions and status changes. Full observability stack: Sentry for errors, traces, and logs, PostHog for product analytics.",
+        "description": "Partially shipped: email notifications are live (Temporal-backed, see v4) and Sentry covers errors, traces, and logs. Remaining: Slack notifications, emails on status changes, and PostHog product analytics.",
         "side": "left"
       },
       {
         "number": 4,
         "title": "Background Tasks",
-        "done": false,
-        "faded": true,
-        "description": "Move emails and notifications into background processing. Self-hosted Temporal on the backend VPS with retry semantics. Fallback: Azure Queue Storage.",
-        "side": "right"
+        "done": true,
+        "dates": "Jul 7, 2026",
+        "description": "Emails and notifications run as durable background workflows: self-hosted Temporal on the backend VPS with retry semantics, persisting into the Supabase PostgreSQL. Storing a comment or job offer and sending its notifications share one workflow — neither happens without the other.",
+        "side": "right",
+        "detailsLabel": "What was done",
+        "details": [
+          {
+            "author": "claude",
+            "text": "Self-hosted Temporal server on the VPS, persisting into the Supabase PostgreSQL"
+          },
+          {
+            "author": "claude",
+            "text": "Durable store-and-notify workflows with retries: blog comments, job offer submissions, and job offer comments all notify the right people by email"
+          },
+          {
+            "author": "claude",
+            "text": "Temporal Web UI at temporal.kalandra.tech behind Cloudflare Access"
+          },
+          { "author": "pavel", "text": "Brevo SMTP relay and Cloudflare Access setup" },
+          {
+            "author": "claude",
+            "text": "Aspire runs a local Temporal dev server; integration tests assert the delivered emails against a real one via Testcontainers"
+          }
+        ]
       },
       {
         "number": 5,

--- a/frontend/src/pages/[...lang]/admin/job-offers.astro
+++ b/frontend/src/pages/[...lang]/admin/job-offers.astro
@@ -443,6 +443,8 @@ const c = commonTranslations[lang];
 
     async function showDetail(id, skipHashUpdate) {
       currentOfferId = id;
+      // The retry-dedup comment id must not leak onto a different offer's draft.
+      pendingCommentId = null;
       if (!skipHashUpdate) history.pushState(null, "", "#" + id);
       document.getElementById("offers-list-section")?.classList.add("hidden");
       document.getElementById("offer-detail-section")?.classList.remove("hidden");
@@ -802,12 +804,16 @@ const c = commonTranslations[lang];
       await showDetail(currentOfferId);
     });
 
+    // Reused across retries of the current draft so a resend dedupes into one comment server-side.
+    var pendingCommentId = null;
+
     // Send comment
     async function sendComment() {
       var input = document.getElementById("comment-input");
       var content = input?.value?.trim();
       if (!content || !currentOfferId) return;
 
+      pendingCommentId = pendingCommentId || crypto.randomUUID();
       try {
         var res = await fetch(apiUrl + "/api/job-offers/" + currentOfferId + "/comments", {
           method: "POST",
@@ -815,7 +821,7 @@ const c = commonTranslations[lang];
             "Content-Type": "application/json",
             Authorization: "Bearer " + currentToken,
           },
-          body: JSON.stringify({ content: content }),
+          body: JSON.stringify({ content: content, commentId: pendingCommentId }),
         });
       } catch (e) {
         showError();
@@ -824,6 +830,7 @@ const c = commonTranslations[lang];
 
       if (res.ok) {
         if (input) input.value = "";
+        pendingCommentId = null;
         var commentsRes = await fetch(apiUrl + "/api/job-offers/" + currentOfferId + "/comments", {
           headers: { Authorization: "Bearer " + currentToken },
         });

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -543,6 +543,9 @@ const t = translations[lang];
       });
     }
 
+    // Reused across retries of the current draft so a resend dedupes into one offer server-side.
+    var pendingOfferId = null;
+
     // Form submission
     document.getElementById("job-offer-form")?.addEventListener("submit", async function (e) {
       e.preventDefault();
@@ -584,8 +587,11 @@ const t = translations[lang];
           return;
         }
 
+        pendingOfferId = pendingOfferId || crypto.randomUUID();
+
         var formData = new FormData();
         formData.append("cf-turnstile-response", turnstileResponse);
+        formData.append("Id", pendingOfferId);
         formData.append("CompanyName", form.companyName.value);
         formData.append("ContactName", form.contactName.value);
         formData.append("ContactEmail", form.contactEmail.value);

--- a/frontend/src/pages/[...lang]/job-offers.astro
+++ b/frontend/src/pages/[...lang]/job-offers.astro
@@ -465,6 +465,8 @@ const c = commonTranslations[lang];
 
     async function showDetail(id, skipHashUpdate) {
       currentOfferId = id;
+      // The retry-dedup comment id must not leak onto a different offer's draft.
+      pendingCommentId = null;
       if (!skipHashUpdate) history.pushState(null, "", "#" + id);
       document.getElementById("offers-list-section")?.classList.add("hidden");
       document.getElementById("offer-detail-section")?.classList.remove("hidden");
@@ -983,12 +985,16 @@ const c = commonTranslations[lang];
       }
     });
 
+    // Reused across retries of the current draft so a resend dedupes into one comment server-side.
+    var pendingCommentId = null;
+
     // Send comment
     async function sendComment() {
       var input = document.getElementById("comment-input");
       var content = input?.value?.trim();
       if (!content || !currentOfferId) return;
 
+      pendingCommentId = pendingCommentId || crypto.randomUUID();
       try {
         var res = await fetch(apiUrl + "/api/job-offers/" + currentOfferId + "/comments", {
           method: "POST",
@@ -996,7 +1002,7 @@ const c = commonTranslations[lang];
             "Content-Type": "application/json",
             Authorization: "Bearer " + currentToken,
           },
-          body: JSON.stringify({ content: content }),
+          body: JSON.stringify({ content: content, commentId: pendingCommentId }),
         });
       } catch (e) {
         showError();
@@ -1005,6 +1011,7 @@ const c = commonTranslations[lang];
 
       if (res.ok) {
         if (input) input.value = "";
+        pendingCommentId = null;
         // Reload comments
         var commentsRes = await fetch(apiUrl + "/api/job-offers/" + currentOfferId + "/comments", {
           headers: { Authorization: "Bearer " + currentToken },

--- a/frontend/src/pages/[...lang]/project.astro
+++ b/frontend/src/pages/[...lang]/project.astro
@@ -15,7 +15,7 @@ import csCommon from "../../i18n/cs/common.json";
 const translations = { en: enStrings, cs: csStrings };
 const commonTranslations = { en: enCommon, cs: csCommon };
 
-export const pageMeta: PageMeta = { updatedDate: "2026-05-23" };
+export const pageMeta: PageMeta = { updatedDate: "2026-07-07" };
 
 export function getStaticPaths() {
   return locales.map((lang) => ({
@@ -376,6 +376,7 @@ const tocItems = [
                 const isFaded = "faded" in version && version.faded;
                 const hasPricing = "pricingTable" in version && version.pricingTable;
                 const hasDetails = "details" in version && version.details;
+                const hasTime = "time" in version && version.time;
                 const hasDates = "dates" in version && version.dates;
 
                 const versionContent = (
@@ -392,15 +393,16 @@ const tocItems = [
                     <h3 class:list={["font-headline text-2xl font-bold text-on-surface", version.done ? "mb-2" : "mb-4"]}>
                       {version.title}
                     </h3>
-                    {"time" in version && version.time && (
+                    {(hasTime || hasDates) && (
                       <p
                         class:list={[
                           "font-label text-xs text-on-surface-variant",
                           "nextTime" in version && version.nextTime ? "mb-1" : "mb-4",
                         ]}
                       >
-                        {version.time}
-                        {hasDates && <span class="text-on-surface-variant"> · {version.dates}</span>}
+                        {hasTime && version.time}
+                        {hasTime && hasDates && " · "}
+                        {hasDates && version.dates}
                       </p>
                     )}
                     {"nextTime" in version && version.nextTime && (


### PR DESCRIPTION
## What

### Part 1 — follow-up to the [review comment on #178](https://github.com/KaliCZ/DemoPage/pull/178#discussion_r3538089374)

The workflow-id dedup (`IdConflictPolicy = UseExisting`) only worked for internal RPC retries, because the offer/comment ids were minted server-side per request — a client resend minted fresh ids and stored duplicates.

- `CreateJobOfferRequest.Id` and `AddCommentRequest.CommentId` are now optional client-supplied ids, mirroring the blog's `PostBlogCommentRequest.CommentId`; the backend mints a GUID only when a caller omits them.
- The hire-me form and both job-offer comment composers generate one `crypto.randomUUID()` per draft, reuse it across retries, and clear it on success (the comment id also resets when switching offers, so a failed draft's id can't leak onto another offer).
- **Foreign-id edge:** submitting an id that already belongs to someone else's offer used to null-deref into a 500 (the store is an idempotent no-op and the detail query hides foreign offers). It now returns 400 `IdAlreadyUsed`.
- **Workflow race fix (all three workflows, blog included):** a retry's update-with-start that attached to an almost-finished workflow was aborted when the workflow closed, surfacing as an RPC error → 500 (Temporal's `TMPRL1102` warning). The workflows now wait for `Workflow.AllHandlersFinished` before closing, exactly as that warning prescribes. Found by the new integration test.

### Part 2 — Temporal is shipped; pages and docs now say so

- **Architecture diagram:** Temporal box promoted to shipped styling (no spinner, no dashed border, full opacity), offset right and slimmed so no arrow crosses it; the API → Temporal arrow is solid; new Temporal → PostgreSQL arrow for workflow persistence. Slack + PostHog stay dashed (still planned).
- **Roadmap (en + cs):** v4 "Background Tasks" is done (Jul 7, 2026) with a "What was done" details list; v3 reworded as partially shipped (emails + Sentry live; Slack, status-change emails, and PostHog remaining); the timeline now renders a date even when no tracked hours exist.
- **Open question resolved:** "Temporal + Supabase Database" removed (the section was never rendered anyway); the outcome — Temporal persists into the same Supabase PostgreSQL (`temporal` + `temporal_visibility`) — recorded as a Supabase lesson. Testing-strategy ADR updated: email is captured and asserted now, not "will be mocked".
- **Docs sweep:** README (Temporal covers job offers too), SETUP.md (`JOB_OFFERS_OWNER_NOTIFICATION_EMAIL` was undocumented; SMTP wording), backend-domain.md (Blog domain + workflows), backend-db.md (Temporal persistence row), backend-testing.md (Temporal dev-server container, `TestEmailSender`, `FakeUserInfoService`, `TestBlogPostCatalog`).

## Testing

- New integration tests: `Create_ResentWithTheSameClientId_IsStoredOnce`, `AddComment_ResentWithTheSameClientId_IsStoredOnce`, `Create_WithAnotherUsersOfferId_Returns400_WithoutLeakingTheOffer`.
- Full suite green: backend 169/169, frontend 22, E2E 17.
- Project page verified in the dev server (both locales): diagram geometry checked programmatically — no arrow intersects any node box; roadmap, lessons, and dates render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)