### PR TITLE
fix(backend): build every project the API references in the image

### DIFF
--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -6,21 +6,14 @@ ARG COMMIT_SHA=unknown
 ARG TARGETARCH
 WORKDIR /src
 
-# Copy only csproj files first so the restore layer is cached unless a
-# csproj actually changes.
-COPY src/Kalandra.Api/Kalandra.Api.csproj           src/Kalandra.Api/
-COPY src/Kalandra.Infrastructure/Kalandra.Infrastructure.csproj src/Kalandra.Infrastructure/
-COPY src/Kalandra.JobOffers/Kalandra.JobOffers.csproj src/Kalandra.JobOffers/
-
-RUN dotnet restore src/Kalandra.Api/Kalandra.Api.csproj -a $TARGETARCH
-
-# Copy the rest of the context (sources + root config such as .editorconfig, so
-# analyzer severities apply in-container). .dockerignore defines what's excluded.
+# Copy the whole context (.dockerignore is the blacklist of what to leave out)
+# and publish the API, which pulls in every project it references. Publishing the
+# API — not an enumerated project list — is what decides what gets built, so a
+# newly added project needs no change here.
 COPY . .
 RUN dotnet publish src/Kalandra.Api/Kalandra.Api.csproj \
     -c Release \
     -a $TARGETARCH \
-    --no-restore \
     -o /app \
     -p:SourceRevisionId=$COMMIT_SHA
 

--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -6,10 +6,8 @@ ARG COMMIT_SHA=unknown
 ARG TARGETARCH
 WORKDIR /src
 
-# Copy the whole context (.dockerignore is the blacklist of what to leave out)
-# and publish the API, which pulls in every project it references. Publishing the
-# API — not an enumerated project list — is what decides what gets built, so a
-# newly added project needs no change here.
+# Copy everything (.dockerignore is the blacklist) and publish the API — its
+# project references decide what's built, so adding a project needs no change here.
 COPY . .
 RUN dotnet publish src/Kalandra.Api/Kalandra.Api.csproj \
     -c Release \


### PR DESCRIPTION
## Problem

The backend deploy is failing at the Docker **build** step:

```
error NETSDK1004: Assets file '/src/src/Kalandra.Blog/obj/project.assets.json' not found.
```

The Dockerfile's restore layer copied an explicit allowlist of csproj files (`Kalandra.Api`, `Kalandra.Infrastructure`, `Kalandra.JobOffers`). The newly added **`Kalandra.Blog`** project — which `Kalandra.Api` references — was never added to that list, so `dotnet restore` skipped it (`Skipping project "…/Kalandra.Blog…" because it was not found`) and the subsequent `dotnet publish --no-restore` failed because Blog was never restored.

## Fix

Stop maintaining a per-project allowlist. Copy the whole build context and publish the API — its project references decide what gets built — with `.dockerignore` as the blacklist (it already excludes `bin/`, `obj/`, `tests/`, etc.). Adding a project no longer requires touching the Dockerfile.

## Verification

Built the `build` stage locally exactly as CI does (native builder, cross-publish to `arm64`) — all four projects restore and publish, including `Kalandra.Blog`:

```
Restored .../Kalandra.Blog/Kalandra.Blog.csproj
Kalandra.Blog -> .../Kalandra.Blog.dll
Kalandra.Api  -> /app/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)