### PR TITLE
perf(backend): restore NuGet layer caching in the Docker build

### DIFF
--- a/backend/src/Kalandra.Api/Dockerfile
+++ b/backend/src/Kalandra.Api/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1-labs
+
 # Build on the native builder platform and cross-publish to the target arch.
 # This avoids running dotnet restore/publish under QEMU emulation, which is
 # extremely slow when the CI runner is amd64 and the target is arm64.
@@ -6,12 +8,20 @@ ARG COMMIT_SHA=unknown
 ARG TARGETARCH
 WORKDIR /src
 
+# Restore from project files alone so this layer stays cached across
+# source-only changes; --parents (labs syntax) keeps the src/<Project>/ layout
+# that a plain glob COPY would flatten. Restore targets the same arch as
+# publish, which otherwise rejects the assets file as RID-less.
+COPY --parents src/*/*.csproj ./
+RUN dotnet restore src/Kalandra.Api/Kalandra.Api.csproj -a $TARGETARCH
+
 # Copy everything (.dockerignore is the blacklist) and publish the API — its
 # project references decide what's built, so adding a project needs no change here.
 COPY . .
 RUN dotnet publish src/Kalandra.Api/Kalandra.Api.csproj \
     -c Release \
     -a $TARGETARCH \
+    --no-restore \
     -o /app \
     -p:SourceRevisionId=$COMMIT_SHA
 


### PR DESCRIPTION
## Problem

#181 fixed the missing `Kalandra.Blog` restore by replacing the per-project csproj allowlist with a single `COPY . .` before publish. That fixed correctness but destroyed layer caching: with the whole context copied before restore, any source-only change invalidates the restore layer, and every CI build re-downloads all NuGet packages (~30s) despite `cache-from: type=gha`.

## Fix

Reintroduce the csproj-first restore layer, but glob-based instead of an allowlist:

- `COPY --parents src/*/*.csproj ./` (labs Dockerfile syntax) copies every project file while preserving the `src/<Project>/` layout that a plain glob `COPY` would flatten. New projects are picked up automatically — still nothing to maintain in the Dockerfile.
- `dotnet restore` on the API project restores its references transitively; it passes `-a $TARGETARCH` to match publish, which otherwise rejects the assets file as RID-less under `--no-restore`.
- `COPY . .` + `dotnet publish --no-restore` as before.

Test projects stay out entirely: `.dockerignore` excludes `tests/` and the glob only covers `src/`.

## Verification

Built the `build` stage locally exactly as CI does (native builder, cross-publish to `arm64`):

- Clean build: all four projects restore (including `Kalandra.Blog`) and publish.
- After touching `Program.cs`: the csproj-copy and restore layers report `CACHED`; only the final copy + publish re-run (~4s).

`npm test` doesn't exercise the Dockerfile, so the docker builds above are the verification for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)