### PR TITLE
fix(job-offers): typed IdAlreadyUsed store result; clarify the Temporal completion guard

### DIFF
--- a/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
@@ -106,6 +106,7 @@ public class JobOffersController(
                 CreateJobOfferError.TooManyAttachments => this.ValidationError("attachments", CreateOfferError.TooManyAttachments),
                 CreateJobOfferError.TotalSizeTooLarge => this.ValidationError("attachments", CreateOfferError.TotalSizeTooLarge),
                 CreateJobOfferError.DisallowedContentType => this.ValidationError("attachments", CreateOfferError.DisallowedContentType),
+                CreateJobOfferError.IdAlreadyUsed => this.ValidationError("Id", CreateOfferError.IdAlreadyUsed),
             };
         }
 
@@ -113,14 +114,8 @@ public class JobOffersController(
 
         var query = new GetJobOfferDetailQuery(Id: streamId, User: AppUser);
         var offer = await getDetailHandler.Get(query, ct);
-
-        // Null means the client-supplied id already belongs to someone else's offer: the
-        // store was an idempotent no-op and the detail query hides foreign offers.
-        if (offer == null)
-            return this.ValidationError("Id", CreateOfferError.IdAlreadyUsed);
-
         return CreatedAtAction(nameof(GetDetail), new { id = streamId },
-            GetJobOfferDetailResponse.Serialize(offer));
+            GetJobOfferDetailResponse.Serialize(offer!));
     }
 
     // ───── Edit ─────

--- a/backend/src/Kalandra.Blog/Workflows/BlogCommentWorkflow.cs
+++ b/backend/src/Kalandra.Blog/Workflows/BlogCommentWorkflow.cs
@@ -47,7 +47,8 @@ public class BlogCommentWorkflow
             await Task.WhenAll(sends);
         }
 
-        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        // Temporal's prescribed completion guard (message-passing docs): returning while a
+        // client retry's update is still storing would abort that update with an RPC error.
         await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 

--- a/backend/src/Kalandra.JobOffers/Commands/CreateJobOffer.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/CreateJobOffer.cs
@@ -10,7 +10,7 @@ using Temporalio.Client;
 
 namespace Kalandra.JobOffers.Commands;
 
-public enum CreateJobOfferError { TooManyAttachments, TotalSizeTooLarge, DisallowedContentType }
+public enum CreateJobOfferError { TooManyAttachments, TotalSizeTooLarge, DisallowedContentType, IdAlreadyUsed }
 
 public record CreateJobOfferFile(
     NonEmptyString FileName,
@@ -117,9 +117,12 @@ public class CreateJobOfferHandler(ITemporalClient temporalClient, IStorageServi
 
         // Cancellation frees the request if the client disconnects; the workflow keeps
         // running — durability is the point.
-        await temporalClient.ExecuteUpdateWithStartWorkflowAsync(
+        var outcome = await temporalClient.ExecuteUpdateWithStartWorkflowAsync(
             (JobOfferSubmittedWorkflow workflow) => workflow.StoreJobOfferAsync(input),
             new(startOperation) { Rpc = new() { CancellationToken = ct } });
+
+        if (outcome.Error is { } error)
+            return error;
 
         return streamId;
     }

--- a/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
@@ -1,6 +1,7 @@
 using Kalandra.JobOffers.Entities;
 using Kalandra.JobOffers.Events;
 using Marten;
+using StrongTypes;
 
 namespace Kalandra.JobOffers.Commands;
 
@@ -8,14 +9,17 @@ public record StoreJobOfferCommand(Guid JobOfferId, JobOfferSubmitted Submitted)
 
 public class StoreJobOfferHandler(IDocumentSession session)
 {
-    public async Task StoreAndSave(StoreJobOfferCommand command, CancellationToken ct)
+    public async Task<Result<Guid, CreateJobOfferError>> StoreAndSave(StoreJobOfferCommand command, CancellationToken ct)
     {
-        // Idempotent under Temporal activity retries: an offer that already made
-        // it into the store is never started twice.
-        if (await session.LoadAsync<JobOffer>(command.JobOfferId, ct) != null)
-            return;
+        // Idempotent under Temporal activity retries and client resends: the submitter's
+        // own offer already in the store is a success, never started twice.
+        if (await session.LoadAsync<JobOffer>(command.JobOfferId, ct) is { } existing)
+            return existing.UserId == command.Submitted.UserId
+                ? command.JobOfferId
+                : CreateJobOfferError.IdAlreadyUsed;
 
         session.Events.StartStream<JobOffer>(command.JobOfferId, command.Submitted);
         await session.SaveChangesAsync(ct);
+        return command.JobOfferId;
     }
 }

--- a/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
@@ -11,8 +11,8 @@ public class StoreJobOfferHandler(IDocumentSession session)
 {
     public async Task<Result<Guid, CreateJobOfferError>> StoreAndSave(StoreJobOfferCommand command, CancellationToken ct)
     {
-        // Idempotent under Temporal activity retries and client resends: the submitter's
-        // own offer already in the store is a success, never started twice.
+        // Ids are client-minted per draft, so the same user resending one is a retry of the
+        // same offer (a no-op success) — any other user is claiming an id that isn't theirs.
         if (await session.LoadAsync<JobOffer>(command.JobOfferId, ct) is { } existing)
             return existing.UserId == command.Submitted.UserId
                 ? command.JobOfferId

--- a/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
+++ b/backend/src/Kalandra.JobOffers/Commands/StoreJobOffer.cs
@@ -11,8 +11,8 @@ public class StoreJobOfferHandler(IDocumentSession session)
 {
     public async Task<Result<Guid, CreateJobOfferError>> StoreAndSave(StoreJobOfferCommand command, CancellationToken ct)
     {
-        // Ids are client-minted per draft, so the same user resending one is a retry of the
-        // same offer (a no-op success) — any other user is claiming an id that isn't theirs.
+        // Returning the existing id is silent retry protection — we assume the same user
+        // sending the same id has just submitted the form twice.
         if (await session.LoadAsync<JobOffer>(command.JobOfferId, ct) is { } existing)
             return existing.UserId == command.Submitted.UserId
                 ? command.JobOfferId

--- a/backend/src/Kalandra.JobOffers/Workflows/JobOfferActivities.cs
+++ b/backend/src/Kalandra.JobOffers/Workflows/JobOfferActivities.cs
@@ -16,10 +16,11 @@ public class JobOfferActivities(
     private const string SiteUrl = "https://www.kalandra.tech";
 
     [Activity]
-    public async Task StoreJobOfferAsync(JobOfferSubmittedWorkflowInput input)
+    public async Task<StoreJobOfferOutcome> StoreJobOfferAsync(JobOfferSubmittedWorkflowInput input)
     {
         var ct = ActivityExecutionContext.Current.CancellationToken;
-        await storeOfferHandler.StoreAndSave(new StoreJobOfferCommand(input.JobOfferId, input.Submitted), ct);
+        var result = await storeOfferHandler.StoreAndSave(new StoreJobOfferCommand(input.JobOfferId, input.Submitted), ct);
+        return new StoreJobOfferOutcome(result.Error);
     }
 
     [Activity]

--- a/backend/src/Kalandra.JobOffers/Workflows/JobOfferCommentWorkflow.cs
+++ b/backend/src/Kalandra.JobOffers/Workflows/JobOfferCommentWorkflow.cs
@@ -48,7 +48,8 @@ public class JobOfferCommentWorkflow
             await Task.WhenAll(sends);
         }
 
-        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        // Temporal's prescribed completion guard (message-passing docs): returning while a
+        // client retry's update is still storing would abort that update with an RPC error.
         await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 

--- a/backend/src/Kalandra.JobOffers/Workflows/JobOfferSubmittedWorkflow.cs
+++ b/backend/src/Kalandra.JobOffers/Workflows/JobOfferSubmittedWorkflow.cs
@@ -1,9 +1,12 @@
+using Kalandra.JobOffers.Commands;
 using Kalandra.JobOffers.Events;
 using Temporalio.Workflows;
 
 namespace Kalandra.JobOffers.Workflows;
 
 public record JobOfferSubmittedWorkflowInput(Guid JobOfferId, JobOfferSubmitted Submitted);
+
+public record StoreJobOfferOutcome(CreateJobOfferError? Error);
 
 /// <summary>
 /// One durable flow per submitted job offer: the update handler stores it (the API
@@ -21,35 +24,39 @@ public class JobOfferSubmittedWorkflow
         StartToCloseTimeout = TimeSpan.FromSeconds(30),
     };
 
-    private bool stored;
+    private StoreJobOfferOutcome? storeOutcome;
 
     [WorkflowRun]
     public async Task RunAsync(JobOfferSubmittedWorkflowInput input)
     {
-        await Workflow.WaitConditionAsync(() => stored);
+        await Workflow.WaitConditionAsync(() => storeOutcome != null);
 
-        var recipients = await Workflow.ExecuteActivityAsync(
-            (JobOfferActivities activities) => activities.PlanSubmittedNotifications(input),
-            Options);
+        if (storeOutcome!.Error == null)
+        {
+            var recipients = await Workflow.ExecuteActivityAsync(
+                (JobOfferActivities activities) => activities.PlanSubmittedNotifications(input),
+                Options);
 
-        // One activity per email so a failed send retries on its own instead of re-delivering the rest.
-        var sends = recipients
-            .Select(recipient => Workflow.ExecuteActivityAsync(
-                (JobOfferActivities activities) => activities.SendSubmittedNotificationAsync(recipient, input),
-                Options))
-            .ToList();
-        await Task.WhenAll(sends);
+            // One activity per email so a failed send retries on its own instead of re-delivering the rest.
+            var sends = recipients
+                .Select(recipient => Workflow.ExecuteActivityAsync(
+                    (JobOfferActivities activities) => activities.SendSubmittedNotificationAsync(recipient, input),
+                    Options))
+                .ToList();
+            await Task.WhenAll(sends);
+        }
 
-        // Closing while a late client-retry update is still storing would abort it with an RPC error.
+        // Temporal's prescribed completion guard (message-passing docs): returning while a
+        // client retry's update is still storing would abort that update with an RPC error.
         await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);
     }
 
     [WorkflowUpdate]
-    public async Task StoreJobOfferAsync(JobOfferSubmittedWorkflowInput input)
+    public async Task<StoreJobOfferOutcome> StoreJobOfferAsync(JobOfferSubmittedWorkflowInput input)
     {
-        await Workflow.ExecuteActivityAsync(
+        storeOutcome = await Workflow.ExecuteActivityAsync(
             (JobOfferActivities activities) => activities.StoreJobOfferAsync(input),
             Options);
-        stored = true;
+        return storeOutcome;
     }
 }

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
@@ -133,12 +133,17 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
         var (id, _) = await CreateOfferAs("id-owner@test.com");
 
         Authenticate(email: "id-thief@test.com");
+        var marker = $"Never-stored offer must not notify {Guid.NewGuid():N}";
         var response = await client.PostAsync("/api/job-offers",
-            CreateValidFormContent(overrides: new() { ["Id"] = id }), Ct);
+            CreateValidFormContent(overrides: new() { ["Id"] = id, ["Description"] = marker }), Ct);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var problem = await ParseJsonAsync(response);
         Assert.Equal("IdAlreadyUsed", problem.GetProperty("errors").GetProperty("Id")[0].GetString());
+
+        // Grace period: a notification for the rejected submission would arrive moments later.
+        await Task.Delay(1500, Ct);
+        Assert.DoesNotContain(factory.EmailSender.Sent, m => m.TextBody.Value.Contains(marker));
     }
 
     [Fact]

--- a/docs/backend-domain.md
+++ b/docs/backend-domain.md
@@ -120,7 +120,7 @@ When you need a similar separate stream for a different concept, follow the same
 
 Each feature defines its own error enum next to its handler or entity. Examples:
 
-- `CreateJobOfferError { TooManyAttachments, TotalSizeTooLarge, DisallowedContentType }` — in `Commands/CreateJobOffer.cs`
+- `CreateJobOfferError { TooManyAttachments, TotalSizeTooLarge, DisallowedContentType, IdAlreadyUsed }` — in `Commands/CreateJobOffer.cs`
 - `EditJobOfferError { NotFound, NotAuthorized, NotSubmittedStatus }` — in `Entities/JobOffer.cs` (used by both `JobOffer.Edit` and `EditJobOfferHandler`)
 - `AddCommentError { NotFound, NotAuthorized }` — in `Entities/JobOffer.cs`
 


### PR DESCRIPTION
## What

Follow-ups to the two review comments on #180.

### 1. [Comment on `JobOffersController.Create`](https://github.com/KaliCZ/DemoPage/pull/180#discussion_r3539431977) — "should rather be a Result with an Enum error case"

Done — the null-detail inference is gone and the error is typed end to end:

- `StoreJobOfferHandler.StoreAndSave` now returns `Result<Guid, CreateJobOfferError>`: a resend of the submitter's own offer stays an idempotent success, while an id owned by another user returns the new `CreateJobOfferError.IdAlreadyUsed` variant.
- The store activity carries it back as `StoreJobOfferOutcome` — the same shape the comment flow already uses (`StoreJobOfferCommentOutcome`) — and `CreateJobOfferHandler.Create` propagates it, so the controller maps it in its exhaustive switch like every other domain error. Wire contract is unchanged (400 with `errors.Id = ["IdAlreadyUsed"]`).
- **Bug this flushed out:** `JobOfferSubmittedWorkflow` set `stored = true` unconditionally, so a rejected foreign-id submission still emailed the owner about an offer that was never stored. Notifications are now gated on the store outcome, and `Create_WithAnotherUsersOfferId_Returns400_WithoutLeakingTheOffer` additionally asserts that no notification is delivered for the rejected submission.

### 2. [Comment on `BlogCommentWorkflow`](https://github.com/KaliCZ/DemoPage/pull/180#discussion_r3539532115) — "I don't understand this and it seems fishy"

I re-verified against the Temporal docs — the wait is correct and is literally the pattern Temporal prescribes, not a workaround. From [Message passing — .NET SDK](https://docs.temporal.io/develop/dotnet/message-passing#wait-for-message-handlers):

> `await Workflow.WaitConditionAsync(() => Workflow.AllHandlersFinished);`

is the recommended way to finish a workflow that has update handlers. Without it, the worker logs the "workflow finished while handlers are still running" warning (TMPRL1102), and a client whose update is still in flight gets an `RpcException` "workflow execution already completed" — which is exactly the 500 the integration test caught: a client retry's update-with-start attaches to the almost-finished workflow, the run method returns while that update's store activity is still executing, and the update is aborted.

The behavior is unchanged; the comment above the wait in all three workflows now states this is Temporal's documented completion guard instead of the cryptic one-liner.

## Testing

- Full suite green via `npm test`: backend, frontend, and E2E (17/17).
- Extended integration test proves the foreign-id submission sends no notification email (grace-period pattern used by the existing notification tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)