### PR TITLE
feat(blog): RSS subscribe link on every post page

### DIFF
--- a/frontend/src/components/BlogPostLayout.astro
+++ b/frontend/src/components/BlogPostLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { Icon } from "astro-icon/components";
 import Layout from "../layouts/Layout.astro";
+import BlogRssLink from "./BlogRssLink.astro";
 import BlogReactions from "./blog/BlogReactions.vue";
 import BlogComments from "./blog/BlogComments.vue";
 import { locales, localePath, type Locale } from "../i18n/utils";
@@ -65,13 +66,16 @@ const readingTimeLabel = t.post.readingTime.replace("{min}", String(readingMinut
 
   <article class="max-w-6xl mx-auto px-4 md:px-8">
     <header class="mb-10">
-      <a
-        href={localePath(lang, "blog")}
-        class="inline-flex items-center gap-1 mb-6 text-sm font-label text-on-surface-variant hover:text-primary transition-colors"
-      >
-        <Icon name="material-symbols:arrow-back" class="size-4" aria-hidden="true" />
-        {t.post.backToBlog}
-      </a>
+      <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+        <a
+          href={localePath(lang, "blog")}
+          class="inline-flex items-center gap-1 text-sm font-label text-on-surface-variant hover:text-primary transition-colors"
+        >
+          <Icon name="material-symbols:arrow-back" class="size-4" aria-hidden="true" />
+          {t.post.backToBlog}
+        </a>
+        <BlogRssLink label={t.rss.label} title={t.rss.title} />
+      </div>
       <h1 class="font-headline text-4xl md:text-5xl font-extrabold tracking-tighter leading-tight mb-4">
         {variant.title}
       </h1>

--- a/frontend/src/components/BlogRssLink.astro
+++ b/frontend/src/components/BlogRssLink.astro
@@ -1,0 +1,21 @@
+---
+import IconRss from "./icons/IconRss.astro";
+import { feed } from "../blog/feeds";
+
+interface Props {
+  label: string;
+  title: string;
+  class?: string;
+}
+
+const { label, title, class: className } = Astro.props;
+---
+
+<a
+  href={feed.path}
+  title={title}
+  class:list={["inline-flex items-center gap-2 text-sm font-label text-on-surface-variant hover:text-primary transition-colors", className]}
+>
+  <IconRss class="w-4 h-4 text-tertiary" />
+  {label}
+</a>

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -9,12 +9,14 @@
     "empty": "Zatím tu žádné články nejsou. První je na cestě.",
     "publishedOn": "Publikováno",
     "updatedOn": "Aktualizováno",
-    "rssLabel": "Odebírat přes RSS",
-    "rssTitle": "RSS kanál všech článků",
     "language": {
       "en": "Anglicky",
       "cs": "Česky"
     }
+  },
+  "rss": {
+    "label": "Odebírat přes RSS",
+    "title": "RSS kanál všech článků"
   },
   "post": {
     "backToBlog": "Všechny články",

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -9,12 +9,14 @@
     "empty": "No posts yet. The first one is on its way.",
     "publishedOn": "Published",
     "updatedOn": "Updated",
-    "rssLabel": "Subscribe via RSS",
-    "rssTitle": "RSS feed of all posts",
     "language": {
       "en": "English",
       "cs": "Czech"
     }
+  },
+  "rss": {
+    "label": "Subscribe via RSS",
+    "title": "RSS feed of all posts"
   },
   "post": {
     "backToBlog": "All posts",

--- a/frontend/src/pages/[...lang]/blog/index.astro
+++ b/frontend/src/pages/[...lang]/blog/index.astro
@@ -1,10 +1,9 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
-import IconRss from "../../../components/icons/IconRss.astro";
+import BlogRssLink from "../../../components/BlogRssLink.astro";
 import { locales, defaultLocale, localePath, type Locale } from "../../../i18n/utils";
 import type { PageMeta } from "../../../lib/page-meta";
 import { publishedPosts, resolveVariant } from "../../../blog/posts";
-import { feed } from "../../../blog/feeds";
 import enStrings from "../../../i18n/en/blog.json";
 import csStrings from "../../../i18n/cs/blog.json";
 
@@ -35,14 +34,7 @@ const formatDate = (date: Date) => date.toLocaleDateString(dateLocale, { year: "
       <p class="font-body text-lg md:text-xl text-on-surface-variant leading-relaxed">
         {t.index.subtitle}
       </p>
-      <a
-        href={feed.path}
-        title={t.index.rssTitle}
-        class="inline-flex items-center gap-2 mt-6 text-sm font-label text-on-surface-variant hover:text-primary transition-colors"
-      >
-        <IconRss class="w-4 h-4 text-tertiary" />
-        {t.index.rssLabel}
-      </a>
+      <BlogRssLink label={t.rss.label} title={t.rss.title} class="mt-6" />
     </div>
 
     {posts.length === 0 && <p class="font-body text-on-surface-variant">{t.index.empty}</p>}

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -210,14 +210,20 @@ test.describe("Blog", () => {
     await expect(page).toHaveURL("/blog");
   });
 
-  test("blog index and footer expose the single RSS feed in both locales", async ({ page }) => {
+  test("blog index, blog posts, and footer expose the single RSS feed in both locales", async ({ page }) => {
     await page.goto("/blog");
     await expect(page.getByRole("link", { name: "Subscribe via RSS" })).toHaveAttribute("href", "/rss.xml");
     await expect(page.getByRole("link", { name: "Subscribe to the blog RSS feed" })).toHaveAttribute("href", "/rss.xml");
 
+    await page.goto("/blog/zero-code-validations-in-your-dotnet-api");
+    await expect(page.getByRole("link", { name: "Subscribe via RSS" })).toHaveAttribute("href", "/rss.xml");
+
     await page.goto("/cs/blog");
     await expect(page.getByRole("link", { name: "Odebírat přes RSS" })).toHaveAttribute("href", "/rss.xml");
     await expect(page.getByRole("link", { name: "Odebírat blog přes RSS" })).toHaveAttribute("href", "/rss.xml");
+
+    await page.goto("/cs/blog/zero-code-validations-in-your-dotnet-api");
+    await expect(page.getByRole("link", { name: "Odebírat přes RSS" })).toHaveAttribute("href", "/rss.xml");
   });
 
   test("every page advertises the one feed for autodiscovery", async ({ page }) => {


### PR DESCRIPTION
## Summary

- The "Subscribe via RSS" link previously appeared only on the blog index; readers landing directly on a post (from the feed, a share, or search) had no visible way to subscribe apart from the small footer icon.
- Extracts the link into a shared `BlogRssLink.astro` component and renders it in every post header, opposite the "All posts" back link — same markup on the index as before.
- Moves the `rssLabel`/`rssTitle` strings from the index-specific translation section to a shared `rss` key in both locales.

## Testing

- Full suite (`npm test`) passed locally: backend, frontend unit, and E2E.
- The E2E RSS test now also asserts the subscribe link on a post page in both locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)