### PR TITLE
fix(blog): after signature returns Result in zero-code validations post

### DIFF
--- a/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
+++ b/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
@@ -113,7 +113,7 @@ const signatureSnippet = `// Before: every caller re-checks, every reader wonder
 Task<Order> PlaceAsync(string email, string code, int quantity);
 
 // After: the signature is the contract.
-Task<Order> PlaceAsync(Email email, NonEmptyString code, Positive<int> quantity);`;
+Task<Result<Order, PlaceOrderError>> PlaceAsync(Email email, NonEmptyString code, Positive<int> quantity);`;
 
 const resultSnippet = `public async Task<Result<Order, PlaceOrderError>> PlaceAsync(Email email, NonEmptyString code, Positive<int> quantity)
 {


### PR DESCRIPTION
The *signatures as documentation* snippet in the zero-code validations post still showed the refactored `PlaceAsync` returning `Task<Order>`, but the rest of the post has it return a `Result` — the controller reads `result.Error`/`result.Success`, and `resultSnippet` shows the full body returning `Task<Result<Order, PlaceOrderError>>`.

Updated the "After" line to match. The "Before" line stays `Task<Order>` since in that world the method throws rather than returning a result. Both language versions share the snippet, so this covers Czech and English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)