### PR TITLE
fix(api): bound Supabase health checks to 5s so /health can't hang

### DIFF
--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
@@ -13,12 +13,19 @@ namespace Kalandra.Api.Infrastructure;
 /// </summary>
 internal sealed class SupabaseAuthHealthCheck(IUserInfoService userInfoService) : IHealthCheck
 {
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken ct = default)
     {
         try
         {
-            await userInfoService.PingAsync(ct);
+            // Gotrue's admin client ignores cancellation, so the timeout is enforced here, not via the check registration.
+            await userInfoService.PingAsync(ct).WaitAsync(ProbeTimeout, ct);
             return HealthCheckResult.Healthy("Supabase Auth admin API reachable with the configured service key.");
+        }
+        catch (TimeoutException ex)
+        {
+            return HealthCheckResult.Unhealthy($"Supabase Auth admin API did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
         }
         catch (Exception ex)
         {

--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
@@ -14,12 +14,19 @@ namespace Kalandra.Api.Infrastructure;
 /// </summary>
 internal sealed class SupabaseStorageHealthCheck(IStorageService storageService) : IHealthCheck
 {
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken ct = default)
     {
         try
         {
-            await storageService.PingAsync(ct);
+            // Supabase's storage client ignores cancellation, so the timeout is enforced here, not via the check registration.
+            await storageService.PingAsync(ct).WaitAsync(ProbeTimeout, ct);
             return HealthCheckResult.Healthy("Supabase Storage reachable.");
+        }
+        catch (TimeoutException ex)
+        {
+            return HealthCheckResult.Unhealthy($"Supabase Storage did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## What

`supabase-auth` and `supabase-storage` health checks now each bound their probe with `Task.WaitAsync(5s)`.

## Why

The Gotrue admin and Storage clients ignore cancellation, so a degraded Supabase made the auth probe block ~40s — dragging `/health` past caller timeouts (Cloudflare, browsers) so it returned nothing at all. With the 5s bound, `/health` fails fast and reports an explicit "did not respond within 5s" instead of hanging.

The framework's registration `timeout:` doesn't help here — the underlying clients don't observe the `CancellationToken` — so the bound is enforced in the check via `WaitAsync`.

## Testing

- `dotnet build` green (0 warnings, 0 errors).
- Existing `Health_ReturnsOk` integration test still covers the happy path.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)