### PR TITLE
fix(api): bound Supabase profile fetches to 3s so pages can't hang

### DIFF
--- a/backend/src/Kalandra.Infrastructure/Users/SupabaseUserInfoService.cs
+++ b/backend/src/Kalandra.Infrastructure/Users/SupabaseUserInfoService.cs
@@ -5,8 +5,11 @@ namespace Kalandra.Infrastructure.Users;
 
 public class SupabaseUserInfoService(
     IGotrueAdminClient<Supabase.Gotrue.User> adminAuthClient,
-    ILogger<SupabaseUserInfoService> logger) : IUserInfoService
+    ILogger<SupabaseUserInfoService> logger,
+    TimeSpan? fetchTimeout = null) : IUserInfoService
 {
+    private readonly TimeSpan _fetchTimeout = fetchTimeout ?? TimeSpan.FromSeconds(3);
+
     public async Task PingAsync(CancellationToken ct)
     {
         // perPage=1 keeps the round-trip minimal; we only need to confirm the key is accepted.
@@ -22,7 +25,7 @@ public class SupabaseUserInfoService(
         IEnumerable<Guid> userIds, CancellationToken ct)
     {
         var distinct = userIds.Distinct().ToArray();
-        var infos = await Task.WhenAll(distinct.Select(FetchUserInfoAsync));
+        var infos = await Task.WhenAll(distinct.Select(userId => FetchUserInfoAsync(userId, ct)));
 
         var result = new Dictionary<Guid, UserPublicInfo>();
         for (var i = 0; i < distinct.Length; i++)
@@ -35,11 +38,12 @@ public class SupabaseUserInfoService(
     // No cache here — eviction is the caching decorator's job.
     public Task EvictAsync(Guid userId, CancellationToken ct) => Task.CompletedTask;
 
-    private async Task<UserPublicInfo?> FetchUserInfoAsync(Guid userId)
+    private async Task<UserPublicInfo?> FetchUserInfoAsync(Guid userId, CancellationToken ct)
     {
         try
         {
-            var user = await adminAuthClient.GetUserById(userId.ToString());
+            // Gotrue's admin client ignores cancellation, so the timeout is enforced here — a hung Supabase must cost a missing profile, not a stalled page.
+            var user = await adminAuthClient.GetUserById(userId.ToString()).WaitAsync(_fetchTimeout, ct);
             if (user == null)
                 return null;
 
@@ -76,6 +80,10 @@ public class SupabaseUserInfoService(
             displayName ??= user.Email?.Split('@')[0] ?? userId.ToString();
 
             return new UserPublicInfo(displayName, avatarUrl);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/backend/tests/Kalandra.Infrastructure.Tests/SupabaseUserInfoServiceTests.cs
+++ b/backend/tests/Kalandra.Infrastructure.Tests/SupabaseUserInfoServiceTests.cs
@@ -1,0 +1,115 @@
+using Kalandra.Infrastructure.Users;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Interfaces;
+using Supabase.Gotrue.Mfa;
+using Supabase.Gotrue.Responses;
+
+namespace Kalandra.Infrastructure.Tests;
+
+public class SupabaseUserInfoServiceTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>Stand-in Gotrue admin client whose GetUserById is scripted per test; nothing else is called.</summary>
+    private sealed class FakeGotrueAdminClient : IGotrueAdminClient<User>
+    {
+        public required Func<string, Task<User?>> OnGetUserById { get; init; }
+
+        public Task<User?> GetUserById(string userId) => OnGetUserById(userId);
+
+        public Func<Dictionary<string, string>>? GetHeaders { get; set; }
+
+        public Task<User?> CreateUser(AdminUserAttributes attributes) => throw new NotImplementedException();
+        public Task<User?> CreateUser(string email, string password, AdminUserAttributes? attributes = null) => throw new NotImplementedException();
+        public Task<bool> DeleteUser(string uid) => throw new NotImplementedException();
+        public Task<User?> GetUser(string jwt) => throw new NotImplementedException();
+        public Task<bool> InviteUserByEmail(string email, InviteUserByEmailOptions? options = null) => throw new NotImplementedException();
+        public Task<UserList<User>?> ListUsers(string? filter = null, string? sortBy = null, Constants.SortOrder sortOrder = Constants.SortOrder.Descending, int? page = null, int? perPage = null) => throw new NotImplementedException();
+        public Task<User?> Update(UserAttributes attributes) => throw new NotImplementedException();
+        public Task<User?> UpdateUserById(string userId, AdminUserAttributes userData) => throw new NotImplementedException();
+        public Task<GenerateLinkResponse?> GenerateLink(GenerateLinkOptions options) => throw new NotImplementedException();
+        public Task<MfaAdminListFactorsResponse?> ListFactors(MfaAdminListFactorsParams listFactorsParams) => throw new NotImplementedException();
+        public Task<MfaAdminDeleteFactorResponse?> DeleteFactor(MfaAdminDeleteFactorParams deleteFactorParams) => throw new NotImplementedException();
+    }
+
+    private static SupabaseUserInfoService Build(Func<string, Task<User?>> onGetUserById, TimeSpan? fetchTimeout = null) =>
+        new(new FakeGotrueAdminClient { OnGetUserById = onGetUserById },
+            NullLogger<SupabaseUserInfoService>.Instance, fetchTimeout);
+
+    private static User UserWithMetadata(Guid id, string displayName, string? avatarUrl) => new()
+    {
+        Id = id.ToString(),
+        Email = $"{displayName.ToLowerInvariant()}@example.com",
+        UserMetadata = avatarUrl is null
+            ? new Dictionary<string, object> { ["display_name"] = displayName }
+            : new Dictionary<string, object> { ["display_name"] = displayName, ["avatar_url"] = avatarUrl },
+    };
+
+    [Fact]
+    public async Task ResponsiveFetch_MapsNameAndAvatarFromMetadata()
+    {
+        var userId = Guid.NewGuid();
+        var service = Build(_ => Task.FromResult<User?>(UserWithMetadata(userId, "Ada", "https://cdn.test/ada.png")));
+
+        var result = await service.GetUserInfoAsync([userId], Ct);
+
+        Assert.Equal("Ada", result[userId].DisplayName);
+        Assert.Equal(new Uri("https://cdn.test/ada.png"), result[userId].AvatarUrl);
+    }
+
+    [Fact]
+    public async Task HungFetch_TimesOutAndOmitsTheProfile()
+    {
+        var service = Build(_ => new TaskCompletionSource<User?>().Task, fetchTimeout: TimeSpan.FromMilliseconds(50));
+
+        var result = await service.GetUserInfoAsync([Guid.NewGuid()], Ct);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task MixedResponsiveAndHungFetches_ReturnTheResponsiveProfile()
+    {
+        var responsive = Guid.NewGuid();
+        var hung = Guid.NewGuid();
+        var service = Build(
+            id => id == responsive.ToString()
+                ? Task.FromResult<User?>(UserWithMetadata(responsive, "Ada", avatarUrl: null))
+                : new TaskCompletionSource<User?>().Task,
+            fetchTimeout: TimeSpan.FromMilliseconds(50));
+
+        var result = await service.GetUserInfoAsync([responsive, hung], Ct);
+
+        Assert.Equal("Ada", result[responsive].DisplayName);
+        Assert.False(result.ContainsKey(hung));
+    }
+
+    [Fact]
+    public async Task CancelledCaller_PropagatesInsteadOfDegradingToAMissingProfile()
+    {
+        var service = Build(_ => new TaskCompletionSource<User?>().Task);
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetUserInfoAsync([Guid.NewGuid()], cancelled.Token));
+    }
+
+    // Pins the API DI factory's assumption: ActivatorUtilities can construct this service without a registered timeout.
+    [Fact]
+    public void DiActivation_SucceedsWithoutARegisteredTimeout()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGotrueAdminClient<User>>(
+            new FakeGotrueAdminClient { OnGetUserById = _ => Task.FromResult<User?>(null) });
+        services.AddSingleton<ILogger<SupabaseUserInfoService>>(NullLogger<SupabaseUserInfoService>.Instance);
+        using var provider = services.BuildServiceProvider();
+
+        var service = ActivatorUtilities.CreateInstance<SupabaseUserInfoService>(provider);
+
+        Assert.NotNull(service);
+    }
+}


### PR DESCRIPTION
## Why

The Supabase outage exposed a second hang beyond `/health` (#195): every uncached author-profile lookup (`GetUserById`) stalled ~90s because Gotrue's admin client ignores cancellation. Blog-comment pages and `/api/users` hung for that long per request while Supabase was wedged.

## What

- `SupabaseUserInfoService.FetchUserInfoAsync` bounds each `GetUserById` with `WaitAsync(3s, ct)` — the same pattern as the #195 health checks.
- A timed-out fetch flows into the existing degrade path: a comment keeps its stored author name and renders without an avatar; `/api/users` omits the entry.
- Caller cancellation now propagates instead of being swallowed and error-logged as a fetch failure.
- The timeout is a constructor default overridable by tests, mirroring `CachingUserInfoService`'s `secondEvictionDelay` seam. No DI wiring change needed.

## Out of scope

Storage upload/download: the operation is the point of those requests — there is nothing to degrade to, and upload already honors the request's cancellation token.

## Tests

Five new unit tests in `SupabaseUserInfoServiceTests`: metadata mapping, a hung fetch times out and is omitted, a mixed responsive+hung batch still returns the responsive profile, a cancelled caller propagates, and DI activation succeeds without a registered timeout (guards the `ActivatorUtilities` factory in `ServiceCollectionExtensions`).

Follow-up to the review discussion on #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)