### PR TITLE
perf(api): negative-cache unresolved user profiles

### DIFF
--- a/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
+++ b/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
@@ -7,16 +7,20 @@ namespace Kalandra.Infrastructure.Users;
 /// <summary>
 /// Caches author profiles so a comment thread doesn't re-fetch each one from Supabase on every load.
 /// Profile edits bypass this service, so freshness rests on the TTL plus an explicit <see cref="EvictAsync"/>.
+/// Profiles the source can't resolve are cached briefly too, so a Supabase outage costs one bounded
+/// fetch per author per window instead of one per page load.
 /// </summary>
 public class CachingUserInfoService(
     IUserInfoService source,
     IDistributedCache cache,
     ILogger<CachingUserInfoService> logger,
-    TimeSpan? secondEvictionDelay = null) : IUserInfoService
+    TimeSpan? secondEvictionDelay = null,
+    TimeSpan? negativeTtl = null) : IUserInfoService
 {
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
 
     private readonly TimeSpan _secondEvictionDelay = secondEvictionDelay ?? TimeSpan.FromSeconds(5);
+    private readonly TimeSpan _negativeTtl = negativeTtl ?? TimeSpan.FromMinutes(1);
 
     private static string Key(Guid userId) => $"userinfo:{userId}";
 
@@ -28,19 +32,28 @@ public class CachingUserInfoService(
 
         foreach (var userId in userIds.Distinct())
         {
-            if (await TryReadAsync(userId, ct) is { } cached)
+            var (found, cached) = await TryReadAsync(userId, ct);
+            if (cached is not null)
                 result[userId] = cached;
-            else
+            else if (!found)
                 misses.Add(userId);
+            // found with a null profile = a live negative entry; skip the source until it expires.
         }
 
         if (misses.Count > 0)
         {
             var fetched = await source.GetUserInfoAsync(misses, ct);
-            foreach (var (userId, info) in fetched)
+            foreach (var userId in misses)
             {
-                result[userId] = info;
-                await WriteAsync(userId, info, ct);
+                if (fetched.TryGetValue(userId, out var info))
+                {
+                    result[userId] = info;
+                    await WriteAsync(userId, info, Ttl, ct);
+                }
+                else
+                {
+                    await WriteAsync(userId, info: null, _negativeTtl, ct);
+                }
             }
         }
 
@@ -70,27 +83,27 @@ public class CachingUserInfoService(
 
     public Task PingAsync(CancellationToken ct) => source.PingAsync(ct);
 
-    private async Task<UserPublicInfo?> TryReadAsync(Guid userId, CancellationToken ct)
+    private async Task<(bool Found, UserPublicInfo? Info)> TryReadAsync(Guid userId, CancellationToken ct)
     {
         try
         {
             var bytes = await cache.GetAsync(Key(userId), ct);
-            return bytes is null ? null : JsonSerializer.Deserialize<UserPublicInfo>(bytes);
+            return bytes is null ? (false, null) : (true, JsonSerializer.Deserialize<UserPublicInfo>(bytes));
         }
         catch (Exception ex)
         {
             // A cache hiccup must never fail the request — fall back to the source.
             logger.LogWarning(ex, "User-info cache read failed for {UserId}", userId);
-            return null;
+            return (false, null);
         }
     }
 
-    private async Task WriteAsync(Guid userId, UserPublicInfo info, CancellationToken ct)
+    private async Task WriteAsync(Guid userId, UserPublicInfo? info, TimeSpan ttl, CancellationToken ct)
     {
         try
         {
             var bytes = JsonSerializer.SerializeToUtf8Bytes(info);
-            var options = new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = Ttl };
+            var options = new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = ttl };
             await cache.SetAsync(Key(userId), bytes, options, ct);
         }
         catch (Exception ex)

--- a/backend/tests/Kalandra.Infrastructure.Tests/CachingUserInfoServiceTests.cs
+++ b/backend/tests/Kalandra.Infrastructure.Tests/CachingUserInfoServiceTests.cs
@@ -105,4 +105,51 @@ public class CachingUserInfoServiceTests
         Assert.Equal("Fresh", combined[fresh].DisplayName);
         Assert.Equal(2, source.Calls);
     }
+
+    [Fact]
+    public async Task UnresolvedProfile_IsNotRefetchedWhileTheNegativeEntryLives()
+    {
+        var service = Build(out var source);
+        var unknown = Guid.NewGuid();
+
+        var first = await service.GetUserInfoAsync([unknown], Ct);
+        var second = await service.GetUserInfoAsync([unknown], Ct);
+
+        Assert.Empty(first);
+        Assert.Empty(second);
+        Assert.Equal(1, source.Calls);
+    }
+
+    [Fact]
+    public async Task UnresolvedProfile_IsRefetchedAfterTheNegativeEntryExpires()
+    {
+        var source = new CountingUserInfoService();
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var service = new CachingUserInfoService(source, cache, NullLogger<CachingUserInfoService>.Instance,
+            negativeTtl: TimeSpan.FromMilliseconds(50));
+        var userId = Guid.NewGuid();
+
+        await service.GetUserInfoAsync([userId], Ct);
+        source.Profiles[userId] = new UserPublicInfo("Late Arrival", null);
+        await Task.Delay(200, Ct);
+        var afterExpiry = await service.GetUserInfoAsync([userId], Ct);
+
+        Assert.Equal("Late Arrival", afterExpiry[userId].DisplayName);
+        Assert.Equal(2, source.Calls);
+    }
+
+    [Fact]
+    public async Task Evict_AlsoClearsANegativeEntry()
+    {
+        var service = Build(out var source);
+        var userId = Guid.NewGuid();
+
+        await service.GetUserInfoAsync([userId], Ct);
+        source.Profiles[userId] = new UserPublicInfo("Now Exists", null);
+        await service.EvictAsync(userId, Ct);
+        var afterEvict = await service.GetUserInfoAsync([userId], Ct);
+
+        Assert.Equal("Now Exists", afterEvict[userId].DisplayName);
+        Assert.Equal(2, source.Calls);
+    }
 }

--- a/backend/tests/Kalandra.Infrastructure.Tests/SupabaseUserInfoServiceTests.cs
+++ b/backend/tests/Kalandra.Infrastructure.Tests/SupabaseUserInfoServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Kalandra.Infrastructure.Users;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -85,6 +86,21 @@ public class SupabaseUserInfoServiceTests
 
         Assert.Equal("Ada", result[responsive].DisplayName);
         Assert.False(result.ContainsKey(hung));
+    }
+
+    [Fact]
+    public async Task TwentyHungFetches_TimeOutTogetherNotSequentially()
+    {
+        var service = Build(_ => new TaskCompletionSource<User?>().Task, fetchTimeout: TimeSpan.FromMilliseconds(100));
+        var userIds = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+        var stopwatch = Stopwatch.StartNew();
+
+        var result = await service.GetUserInfoAsync(userIds, Ct);
+
+        stopwatch.Stop();
+        Assert.Empty(result);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1),
+            $"20 hung fetches took {stopwatch.Elapsed} — the per-user timeout must apply in parallel, not sequentially.");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Resolves the review discussion on #196: after the fetch bound landed, a Supabase outage still cost every cold comments load the full 3s, because "no profile" was never cached — each page view re-dialed a dead Supabase for the same authors.

## What

- `CachingUserInfoService` now writes a short-lived (60s) negative entry when the source can't resolve a profile. During an outage that's one bounded fetch per author per minute across the whole site, instead of one per page view. The 24h positive TTL is unchanged, and `EvictAsync` clears negative entries the same way (so a profile refresh forces a refetch immediately).
- A new test pins the parallelism guarantee from the review thread: 20 hung fetches must time out together within a single 3s-equivalent bound, not sequentially.

## Behavior recap (from the thread)

Supabase being down cannot break the comments endpoint: each lookup fails independently, comments fall back to the author name/avatar stored on the comment, and the UI falls back to initials. This PR only removes the repeated per-view stall.

## Tests

Four new unit tests (negative entry suppresses refetch, expires on TTL, cleared by evict; parallel timeout pin). Full suite green locally (backend + frontend + E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)