### PR TITLE
feat(blog): sign-in CTA below the post discussion

### DIFF
--- a/frontend/src/components/BlogPostLayout.astro
+++ b/frontend/src/components/BlogPostLayout.astro
@@ -120,13 +120,34 @@ const readingTimeLabel = t.post.readingTime.replace("{min}", String(readingMinut
         </p>
       </div>
       <BlogComments client:idle apiUrl={apiUrl} slug={slug} lang={lang} t={t.comments} />
+      <!-- Static markup like the hint above: the comments island hydrates after paint, so it can't own auth-gated UI. -->
+      <section
+        id="blog-signin-cta"
+        class="signed-out-only bg-surface-container rounded-2xl border border-outline-variant/40 p-6 md:p-8 text-center"
+      >
+        <Icon name="material-symbols:forum" class="size-9 text-primary mb-3 mx-auto block" aria-hidden="true" />
+        <h2 class="font-headline text-xl font-bold text-on-surface mb-2">{t.signInCta.title}</h2>
+        <p class="font-body text-sm text-on-surface-variant mb-5">{t.signInCta.description}</p>
+        <button
+          id="blog-signin-cta-button"
+          type="button"
+          class="px-5 py-2.5 rounded-xl text-sm font-semibold font-label bg-primary text-on-primary hover:bg-primary/90 transition-colors cursor-pointer"
+        >
+          {t.signInCta.button}
+        </button>
+      </section>
     </footer>
   </article>
 
   <script>
+    import { openAuthDialog } from "../lib/auth";
+
+    document.getElementById("blog-signin-cta-button")?.addEventListener("click", openAuthDialog);
+
     window.addEventListener("auth-change", (event) => {
-      const hint = document.getElementById("blog-signin-hint");
-      hint?.classList.toggle("hidden", !!(event as CustomEvent).detail?.user);
+      const signedIn = !!(event as CustomEvent).detail?.user;
+      document.getElementById("blog-signin-hint")?.classList.toggle("hidden", signedIn);
+      document.getElementById("blog-signin-cta")?.classList.toggle("hidden", signedIn);
     });
   </script>
 </Layout>

--- a/frontend/src/components/blog/BlogComments.vue
+++ b/frontend/src/components/blog/BlogComments.vue
@@ -20,8 +20,6 @@ const props = defineProps<{
   t: {
     heading: string;
     empty: string;
-    signInPrompt: string;
-    signInCta: string;
     placeholder: string;
     submit: string;
     submitting: string;
@@ -275,19 +273,6 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
           {{ submitting ? props.t.submitting : props.t.submit }}
         </button>
       </div>
-    </div>
-    <div
-      v-else-if="viewerChecked"
-      class="mb-10 flex flex-col sm:flex-row items-center justify-between gap-4 rounded-xl border border-outline-variant/30 bg-surface-container-low px-5 py-4"
-    >
-      <p class="font-body text-sm text-on-surface-variant">{{ props.t.signInPrompt }}</p>
-      <button
-        type="button"
-        class="px-4 py-1.5 rounded-lg text-sm font-semibold font-label bg-primary text-on-primary hover:bg-primary/90 transition-colors cursor-pointer"
-        @click="openSignIn"
-      >
-        {{ props.t.signInCta }}
-      </button>
     </div>
 
     <!-- Thread -->

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -39,8 +39,6 @@
   "comments": {
     "heading": "Komentáře",
     "empty": "Zatím žádné komentáře. Buďte první!",
-    "signInPrompt": "Do diskuze se zapojíte po přihlášení.",
-    "signInCta": "Přihlásit se",
     "placeholder": "Napište komentář…",
     "submit": "Odeslat komentář",
     "submitting": "Odesílání…",
@@ -60,5 +58,10 @@
       "ParentCommentNotFound": "Komentář, na který odpovídáte, už neexistuje.",
       "ParentCommentDeleted": "Komentář, na který odpovídáte, byl smazán."
     }
+  },
+  "signInCta": {
+    "title": "Zapojte se do diskuze",
+    "description": "Přihlaste se a přidejte reakci nebo se podělte o svůj názor v komentářích.",
+    "button": "Přihlásit se"
   }
 }

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -39,8 +39,6 @@
   "comments": {
     "heading": "Comments",
     "empty": "No comments yet. Be the first!",
-    "signInPrompt": "Sign in to join the discussion.",
-    "signInCta": "Sign In",
     "placeholder": "Write a comment…",
     "submit": "Post comment",
     "submitting": "Posting…",
@@ -60,5 +58,10 @@
       "ParentCommentNotFound": "The comment you're replying to no longer exists.",
       "ParentCommentDeleted": "The comment you're replying to was deleted."
     }
+  },
+  "signInCta": {
+    "title": "Join the discussion",
+    "description": "Sign in to leave a reaction or share your thoughts in the comments.",
+    "button": "Sign In"
   }
 }

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -101,12 +101,20 @@ test.describe("Blog Flow", () => {
     // The static signed-out hint renders without any JS or island hydration.
     await expect(page.getByText("Sign in to leave a reaction or comment.")).toBeVisible();
 
-    const comments = page.locator('section[aria-label="Comments"]');
-    await expect(comments.getByRole("button", { name: "Sign In" })).toBeVisible();
+    // The static sign-in CTA below the comments also renders without hydration.
+    const signInCta = page.locator("#blog-signin-cta");
+    await expect(signInCta.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // A signed-out reaction click opens the auth dialog instead of calling the API.
     await reactions.getByRole("button", { name: "Thumbs up" }).click();
     await expect(page.locator("#auth-dialog")).toBeVisible();
+    await page.locator("#auth-dialog-close").click();
+    await expect(page.locator("#auth-dialog")).not.toBeVisible();
+
+    // The CTA button opens the same dialog.
+    await signInCta.getByRole("button", { name: "Sign In" }).click();
+    await expect(page.locator("#auth-dialog")).toBeVisible();
+    await page.locator("#auth-dialog-close").click();
 
     // The API itself refuses anonymous writes.
     const toggleResponse = await request.post(`${API_URL}/api/blog/${SLUG}/reactions/toggle`, {
@@ -158,8 +166,9 @@ test.describe("Blog Flow", () => {
     await expect(reloadedThumbsUp).toHaveAttribute("aria-pressed", "true");
     await expect(reloadedThumbsUp.locator("span").nth(1)).toHaveText(String(countBefore + 1));
 
-    // Signed in, the static hint is gone (Layout's auth-known-in tier hides it).
+    // Signed in, the static hint and the sign-in CTA are gone (Layout's auth-known-in tier hides them).
     await expect(page.getByText("Sign in to leave a reaction or comment.")).not.toBeVisible();
+    await expect(page.locator("#blog-signin-cta")).not.toBeVisible();
 
     // Post a top-level comment.
     const comments = page.locator('section[aria-label="Comments"]');


### PR DESCRIPTION
## Summary

- Signed-out visitors now see a **sign-in CTA card below the comments** on every blog post — same style as the hire-me login prompt, scaled down (smaller icon, heading, and padding). The button opens the auth dialog.
- The CTA is static Astro markup gated by the pre-paint `signed-out-only` tier (plus the `auth-change` wiring script), replacing the comments island's inline sign-in prompt — the island hydrates after paint, so its prompt popped in late; the static card paints immediately.
- Clicking a reaction while signed out **already** opened the auth dialog (since #172) — no change needed there; it remains covered by E2E.

## Test plan

- Verified in the local dev preview: CTA renders in both locales, both the reaction buttons and the CTA button open the auth dialog when signed out, `auth-change` hides/shows the CTA, and the colors resolve from the theme tokens in light and dark mode.
- `blog-flow.spec.ts` updated: the anonymous test asserts the static CTA and that its button opens the dialog; the signed-in test asserts the CTA is hidden.
- Full suite runs in CI (no supabase CLI on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)