### PR TITLE
feat(auth): close the sign-in dialog via backdrop click and a top-right X

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ dotnet build                         # Backend only
 npm --prefix frontend run build      # Frontend only
 ```
 
+**When asked to run the app for manual testing, always start the full stack with `npm run aspire`** — never the frontend dev server alone. Without the backend, every API-backed feature (comments, reactions, job offers) fails with a 502 from the Vite proxy.
+
 **Run `npm test` when a change touches logic or structure.** Content-only changes (blog copy, translations, page text) don't need the suite locally. When you do run tests, run the full suite — no subsets (`dotnet test`, `npm --prefix frontend test`, etc.) as a substitute. Pushing and letting CI run the tests is a viable strategy; what's non-negotiable is a PR left sitting with a failing build — after pushing, check the CI result and fix any failure.
 
 ## Design Principles

--- a/frontend/src/components/AuthDialog.astro
+++ b/frontend/src/components/AuthDialog.astro
@@ -10,6 +10,7 @@
  * Supabase client is a shared singleton from lib/supabase.ts so both this
  * component and Layout.astro use the same instance.
  */
+import { Icon } from "astro-icon/components";
 import IconGoogle from "./icons/IconGoogle.astro";
 import type { Locale } from "../i18n/utils";
 import enCommon from "../i18n/en/common.json";
@@ -27,6 +28,15 @@ const t = lang === "cs" ? csCommon : enCommon;
   id="auth-dialog"
   class="m-auto bg-surface-container-low rounded-2xl border border-outline-variant/10 p-8 max-w-sm w-full backdrop:bg-black/50"
 >
+  <button
+    type="button"
+    id="auth-dialog-close"
+    aria-label={t.auth.close}
+    title={t.auth.close}
+    class="absolute top-3 right-3 rounded-md p-1.5 text-on-surface-variant transition-colors hover:bg-surface-container-high hover:text-on-surface cursor-pointer"
+  >
+    <Icon name="material-symbols:close" class="size-5" aria-hidden="true" />
+  </button>
   <div class="space-y-5">
     <div>
       <h2 id="auth-dialog-title" class="font-headline text-xl font-bold text-on-surface">
@@ -93,14 +103,6 @@ const t = lang === "cs" ? csCommon : enCommon;
     >
       <IconGoogle class="w-5 h-5" />
       {t.auth.continueWithGoogle}
-    </button>
-
-    <button
-      type="button"
-      id="auth-dialog-close"
-      class="w-full px-4 py-2 rounded-xl text-sm font-label text-on-surface-variant hover:text-on-surface transition-colors cursor-pointer"
-    >
-      {t.auth.cancel}
     </button>
   </div>
 </dialog>
@@ -370,6 +372,22 @@ const t = lang === "cs" ? csCommon : enCommon;
   });
   document.getElementById("auth-dialog-close")?.addEventListener("click", () => {
     (document.getElementById("auth-dialog") as HTMLDialogElement)?.close();
+  });
+
+  // Clicks on the backdrop and on the dialog's own padding both target the <dialog>, so hit-test
+  // the rect; the press must also start outside so a text-selection drag can't close it.
+  const authDialogElement = document.getElementById("auth-dialog") as HTMLDialogElement | null;
+  const outsideAuthDialog = (event: MouseEvent) => {
+    if (!authDialogElement) return false;
+    const rect = authDialogElement.getBoundingClientRect();
+    return event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom;
+  };
+  let authDialogPressStartedOutside = false;
+  authDialogElement?.addEventListener("pointerdown", (event) => {
+    authDialogPressStartedOutside = outsideAuthDialog(event);
+  });
+  authDialogElement?.addEventListener("click", (event) => {
+    if (authDialogPressStartedOutside && outsideAuthDialog(event)) authDialogElement.close();
   });
   // Allow Enter key to submit
   document.getElementById("auth-password")?.addEventListener("keydown", (e) => {

--- a/frontend/src/components/AuthDialog.astro
+++ b/frontend/src/components/AuthDialog.astro
@@ -33,9 +33,9 @@ const t = lang === "cs" ? csCommon : enCommon;
     id="auth-dialog-close"
     aria-label={t.auth.close}
     title={t.auth.close}
-    class="absolute top-3 right-3 rounded-md p-1.5 text-on-surface-variant transition-colors hover:bg-surface-container-high hover:text-on-surface cursor-pointer"
+    class="absolute top-4 right-4 rounded-lg p-2.5 text-on-surface-variant transition-colors hover:bg-surface-container-high hover:text-on-surface cursor-pointer"
   >
-    <Icon name="material-symbols:close" class="size-5" aria-hidden="true" />
+    <Icon name="material-symbols:close" class="size-6" aria-hidden="true" />
   </button>
   <div class="space-y-5">
     <div>

--- a/frontend/src/i18n/cs/common.json
+++ b/frontend/src/i18n/cs/common.json
@@ -28,7 +28,7 @@
     "continueWithGoogle": "Pokračovat přes Google",
     "noAccount": "Nemáte účet?",
     "haveAccount": "Již máte účet?",
-    "cancel": "Zrušit",
+    "close": "Zavřít",
     "confirmationSent": "Zkontrolujte svůj e-mail a potvrďte svůj účet.",
     "signingIn": "Dokončuji přihlášení",
     "verifying": "Ověřování…",

--- a/frontend/src/i18n/en/common.json
+++ b/frontend/src/i18n/en/common.json
@@ -28,7 +28,7 @@
     "continueWithGoogle": "Continue with Google",
     "noAccount": "Don't have an account?",
     "haveAccount": "Already have an account?",
-    "cancel": "Cancel",
+    "close": "Close",
     "confirmationSent": "Check your email to confirm your account.",
     "signingIn": "Finishing sign-in",
     "verifying": "Verifying…",

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -105,16 +105,17 @@ test.describe("Blog Flow", () => {
     const signInCta = page.locator("#blog-signin-cta");
     await expect(signInCta.getByRole("button", { name: "Sign In" })).toBeVisible();
 
-    // A signed-out reaction click opens the auth dialog instead of calling the API.
+    // A signed-out reaction click opens the auth dialog; the top-right X closes it.
     await reactions.getByRole("button", { name: "Thumbs up" }).click();
     await expect(page.locator("#auth-dialog")).toBeVisible();
     await page.locator("#auth-dialog-close").click();
     await expect(page.locator("#auth-dialog")).not.toBeVisible();
 
-    // The CTA button opens the same dialog.
+    // The CTA button opens the same dialog; a click on the backdrop closes it.
     await signInCta.getByRole("button", { name: "Sign In" }).click();
     await expect(page.locator("#auth-dialog")).toBeVisible();
-    await page.locator("#auth-dialog-close").click();
+    await page.mouse.click(10, 10);
+    await expect(page.locator("#auth-dialog")).not.toBeVisible();
 
     // The API itself refuses anonymous writes.
     const toggleResponse = await request.post(`${API_URL}/api/blog/${SLUG}/reactions/toggle`, {


### PR DESCRIPTION
## Summary

- **Click outside the sign-in dialog now closes it** (previously only Escape worked). Implementation detail: backdrop clicks and clicks on the dialog's own padding both retarget to the `<dialog>` element, so the handler hit-tests the panel rect instead of comparing event targets, and it only closes when the press *started* outside too — so a text-selection drag that ends outside the panel can't dismiss the dialog.
- **Top-right X close button** (industry-standard placement), labeled "Close"/"Zavřít" for screen readers. It replaces the full-width Cancel button at the bottom — with X + backdrop + Escape, the bottom button was redundant. The X keeps the `auth-dialog-close` id, so the existing wiring and E2E selectors are unchanged.
- `auth.cancel` i18n key replaced by `auth.close` in both locales (it was only used by this dialog).

## Test plan

- Verified in the dev preview: dialog stays centered, X sits top-right and closes; backdrop press+click closes; clicks inside the panel and selection-drags from inside to outside do not close; Czech aria-label renders; no console errors.
- `blog-flow.spec.ts`: the second dialog dismissal now exercises the backdrop click (`page.mouse.click(10, 10)`); the first continues to use `#auth-dialog-close`, which is now the X.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)