### PR TITLE
refactor(api): review follow-ups from #197 and #198

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -460,6 +460,13 @@ jobs:
             done
             echo "New slot is healthy on port $NEW_PORT."
 
+            # Degraded still returns 200 and passes the gate by design (a Temporal outage must
+            # not roll back an API deploy) — but surface it as a pipeline warning, not silence.
+            SLOT_STATUS=$(curl -sf "http://localhost:${NEW_PORT}/health" 2>/dev/null | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+            if [ "$SLOT_STATUS" != "Healthy" ]; then
+              echo "::warning::New slot passed the gate but reports '${SLOT_STATUS:-unknown}' — check the /health entries (e.g. Temporal)."
+            fi
+
             # ----- 6. Point our site at the new port (promotion) and reload -----
             # We write ONLY our own fragment, /srv/caddy/sites/kalandra.caddy —
             # never the shared /srv/caddy/Caddyfile, which is set up once at host

--- a/backend/src/Kalandra.Api/Infrastructure/TemporalHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/TemporalHealthCheck.cs
@@ -6,7 +6,10 @@ namespace Kalandra.Api.Infrastructure;
 /// <summary>
 /// Verifies the Temporal server is reachable over gRPC. Blog-comment and
 /// job-offer submissions run through Temporal workflows, so an unreachable
-/// server breaks those writes while every read path keeps working.
+/// server breaks those writes while every read path keeps working — which is
+/// why failures report Degraded, not Unhealthy: the blue/green deploy gate
+/// fails on a 503 from /health, and a Temporal outage must not roll back an
+/// unrelated API deploy.
 /// </summary>
 internal sealed class TemporalHealthCheck(ITemporalClient temporalClient) : IHealthCheck
 {
@@ -21,16 +24,15 @@ internal sealed class TemporalHealthCheck(ITemporalClient temporalClient) : IHea
                 .WaitAsync(ProbeTimeout, ct);
             return serving
                 ? HealthCheckResult.Healthy("Temporal server reachable and serving.")
-                : new HealthCheckResult(context.Registration.FailureStatus, "Temporal server reachable but not serving.");
+                : HealthCheckResult.Degraded("Temporal server reachable but not serving.");
         }
         catch (TimeoutException ex)
         {
-            return new HealthCheckResult(context.Registration.FailureStatus,
-                $"Temporal server did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
+            return HealthCheckResult.Degraded($"Temporal server did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
         }
         catch (Exception ex)
         {
-            return new HealthCheckResult(context.Registration.FailureStatus, "Temporal server unreachable.", ex);
+            return HealthCheckResult.Degraded("Temporal server unreachable.", ex);
         }
     }
 }

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -71,8 +71,7 @@ builder.Services.AddHealthChecks()
     .AddCheck<CommitHashHealthCheck>("version")
     .AddCheck<SupabaseAuthHealthCheck>("supabase-auth")
     .AddCheck<SupabaseStorageHealthCheck>("supabase-storage")
-    // Degraded, not Unhealthy: the blue/green gate fails the deploy on a 503 from /health, and a Temporal outage must not roll back an unrelated API deploy.
-    .AddCheck<TemporalHealthCheck>("temporal", failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded);
+    .AddCheck<TemporalHealthCheck>("temporal");
 
 var app = builder.Build();
 

--- a/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
+++ b/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
@@ -30,17 +30,15 @@ public class CachingUserInfoService(
         var result = new Dictionary<Guid, UserPublicInfo>();
         var misses = new List<Guid>();
 
-        // Cache round-trips run concurrently: IDistributedCache has no batch API, but the Redis
-        // client pipelines concurrent commands into shared round-trips (the MGET/MSET effect).
-        var distinct = userIds.Distinct().ToArray();
-        var reads = await Task.WhenAll(distinct.Select(userId => TryReadAsync(userId, ct)));
-        for (var i = 0; i < distinct.Length; i++)
+        // Concurrent, not batched — IDistributedCache has no batch API; overlapping the
+        // single-key calls is what removes the sequential round-trip wait.
+        var reads = await Task.WhenAll(userIds.Distinct().Select(userId => TryReadAsync(userId, ct)));
+        foreach (var (userId, found, cached) in reads)
         {
-            var (found, cached) = reads[i];
             if (cached is not null)
-                result[distinct[i]] = cached;
+                result[userId] = cached;
             else if (!found)
-                misses.Add(distinct[i]);
+                misses.Add(userId);
             // found with a null profile = a live negative entry; skip the source until it expires.
         }
 
@@ -81,18 +79,18 @@ public class CachingUserInfoService(
 
     public Task PingAsync(CancellationToken ct) => source.PingAsync(ct);
 
-    private async Task<(bool Found, UserPublicInfo? Info)> TryReadAsync(Guid userId, CancellationToken ct)
+    private async Task<(Guid UserId, bool Found, UserPublicInfo? Info)> TryReadAsync(Guid userId, CancellationToken ct)
     {
         try
         {
             var bytes = await cache.GetAsync(Key(userId), ct);
-            return bytes is null ? (false, null) : (true, JsonSerializer.Deserialize<UserPublicInfo>(bytes));
+            return bytes is null ? (userId, false, null) : (userId, true, JsonSerializer.Deserialize<UserPublicInfo>(bytes));
         }
         catch (Exception ex)
         {
             // A cache hiccup must never fail the request — fall back to the source.
             logger.LogWarning(ex, "User-info cache read failed for {UserId}", userId);
-            return (false, null);
+            return (userId, false, null);
         }
     }
 

--- a/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
+++ b/backend/src/Kalandra.Infrastructure/Users/CachingUserInfoService.cs
@@ -20,7 +20,7 @@ public class CachingUserInfoService(
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
 
     private readonly TimeSpan _secondEvictionDelay = secondEvictionDelay ?? TimeSpan.FromSeconds(5);
-    private readonly TimeSpan _negativeTtl = negativeTtl ?? TimeSpan.FromMinutes(1);
+    private readonly TimeSpan _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(10);
 
     private static string Key(Guid userId) => $"userinfo:{userId}";
 
@@ -30,31 +30,29 @@ public class CachingUserInfoService(
         var result = new Dictionary<Guid, UserPublicInfo>();
         var misses = new List<Guid>();
 
-        foreach (var userId in userIds.Distinct())
+        // Cache round-trips run concurrently: IDistributedCache has no batch API, but the Redis
+        // client pipelines concurrent commands into shared round-trips (the MGET/MSET effect).
+        var distinct = userIds.Distinct().ToArray();
+        var reads = await Task.WhenAll(distinct.Select(userId => TryReadAsync(userId, ct)));
+        for (var i = 0; i < distinct.Length; i++)
         {
-            var (found, cached) = await TryReadAsync(userId, ct);
+            var (found, cached) = reads[i];
             if (cached is not null)
-                result[userId] = cached;
+                result[distinct[i]] = cached;
             else if (!found)
-                misses.Add(userId);
+                misses.Add(distinct[i]);
             // found with a null profile = a live negative entry; skip the source until it expires.
         }
 
         if (misses.Count > 0)
         {
             var fetched = await source.GetUserInfoAsync(misses, ct);
-            foreach (var userId in misses)
-            {
-                if (fetched.TryGetValue(userId, out var info))
-                {
-                    result[userId] = info;
-                    await WriteAsync(userId, info, Ttl, ct);
-                }
-                else
-                {
-                    await WriteAsync(userId, info: null, _negativeTtl, ct);
-                }
-            }
+            foreach (var (userId, info) in fetched)
+                result[userId] = info;
+
+            await Task.WhenAll(misses.Select(userId => fetched.TryGetValue(userId, out var info)
+                ? WriteAsync(userId, info, Ttl, ct)
+                : WriteAsync(userId, info: null, _negativeTtl, ct)));
         }
 
         return result;


### PR DESCRIPTION
Resolves the review comments on #197 and #198.

## What

- **Temporal check owns its status** (#197 comment): every failure path returns `HealthCheckResult.Degraded(...)` directly — that's exactly the overload for "impaired, not dead" — so Program.cs no longer needs the `failureStatus:` mapping. The deploy-gate rationale moved into the check's summary.
- **Degraded promotions warn in the pipeline** (#197 comment): after the SHA gate passes, the deploy script curls `/health` once more and emits a `::warning::` annotation when the slot reports anything but `Healthy`. A Temporal outage still doesn't block the deploy — it just stops being silent.
- **Concurrent cache round-trips** (#198 comment) — to be precise: Redis itself has batch APIs (`MGET`; pipelined `SET .. EX` for TTL'd writes), but `IDistributedCache` doesn't expose them, so this change is **not** batching. The read and write loops now issue their single-key calls concurrently via `Task.WhenAll`, which removes the sequential round-trip wait but still sends N commands. Literal one-round-trip batching would require depending on `IConnectionMultiplexer` directly, at the cost of a Redis-specific code path beside the in-memory one.
- **Negative TTL 60s → 10s** per review.

## Tests

Existing suite covers all changed behavior (negative-cache tests use an explicit TTL or two immediate calls, so the 10s default doesn't affect them). Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)