### PR TITLE
feat(blog): apply a signed-out reaction click automatically after sign-in

### DIFF
--- a/frontend/src/components/blog/BlogReactions.vue
+++ b/frontend/src/components/blog/BlogReactions.vue
@@ -44,13 +44,54 @@ async function authToken(): Promise<string | null> {
   return ((await (window as any).__getAccessToken?.()) as string | null) ?? null;
 }
 
+// A reaction clicked while signed out fires automatically once the sign-in completes.
+// sessionStorage lets the intent survive the Google OAuth redirect.
+const PENDING_REACTION_KEY = "pending-reaction";
+const PENDING_REACTION_TTL_MS = 10 * 60 * 1000;
+
+function rememberPendingReaction(kind: ReactionKind) {
+  try {
+    sessionStorage.setItem(PENDING_REACTION_KEY, JSON.stringify({ slug: props.slug, kind, savedAtUtc: Date.now() }));
+  } catch {
+    // Storage unavailable — the visitor just clicks the reaction again after signing in.
+  }
+}
+
+function takePendingReaction(): ReactionKind | null {
+  try {
+    const raw = sessionStorage.getItem(PENDING_REACTION_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(PENDING_REACTION_KEY);
+    const pending = JSON.parse(raw);
+    const isFresh = Date.now() - pending.savedAtUtc <= PENDING_REACTION_TTL_MS;
+    return pending.slug === props.slug && isFresh ? (pending.kind as ReactionKind) : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearPendingReaction() {
+  try {
+    sessionStorage.removeItem(PENDING_REACTION_KEY);
+  } catch {
+    // Nothing to clear when storage is unavailable.
+  }
+}
+
+// Bumped when a toggle lands so a slower in-flight load can't overwrite fresher state.
+let loadSequence = 0;
+
 async function loadReactions() {
+  const sequence = ++loadSequence;
   try {
     const token = await authToken();
     const res = await fetch(`${props.apiUrl}/api/blog/${props.slug}/reactions`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
-    if (res.ok) applyState(await res.json());
+    if (res.ok) {
+      const data = await res.json();
+      if (sequence === loadSequence) applyState(data);
+    }
   } catch {
     // Counts are decorative on load — a network hiccup just leaves them at zero.
   }
@@ -61,6 +102,7 @@ async function toggle(kind: ReactionKind) {
 
   const token = await authToken();
   if (!token) {
+    rememberPendingReaction(kind);
     (window as any).__openAuthDialog?.();
     return;
   }
@@ -81,6 +123,7 @@ async function toggle(kind: ReactionKind) {
       body: JSON.stringify({ kind }),
     });
     if (!res.ok) throw new Error(`Reaction toggle failed with ${res.status}`);
+    loadSequence++;
     applyState(await res.json());
   } catch {
     counts[kind] += wasMine ? 1 : -1;
@@ -94,13 +137,29 @@ async function toggle(kind: ReactionKind) {
   }
 }
 
-const refresh = () => void loadReactions();
+const onAuthChange = async (event: Event) => {
+  const user = (event as CustomEvent).detail?.user;
+  const pending = user ? takePendingReaction() : null;
+  await loadReactions();
+  // Toggle only when not already reacted — the visitor may have reacted earlier on another device.
+  if (pending && !mine.value.has(pending)) void toggle(pending);
+};
+
+// Dismissing the dialog without signing in withdraws the stored reaction — a sign-in
+// minutes later (e.g. from the navbar) shouldn't fire it unexpectedly.
+const onAuthDialogClose = async () => {
+  if (!(await authToken())) clearPendingReaction();
+};
 
 onMounted(() => {
   void loadReactions();
-  window.addEventListener("auth-change", refresh);
+  window.addEventListener("auth-change", onAuthChange);
+  document.getElementById("auth-dialog")?.addEventListener("close", onAuthDialogClose);
 });
-onUnmounted(() => window.removeEventListener("auth-change", refresh));
+onUnmounted(() => {
+  window.removeEventListener("auth-change", onAuthChange);
+  document.getElementById("auth-dialog")?.removeEventListener("close", onAuthDialogClose);
+});
 </script>
 
 <template>

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -52,6 +52,12 @@ const avatarChangeUser = {
   fullName: "E2E Avatar Change User",
 };
 
+const pendingReactionUser = {
+  email: `e2e-blog-pending-${Date.now()}@test.local`,
+  password: "test-password-123",
+  fullName: "E2E Pending Reaction User",
+};
+
 /** Polls the mail catcher until an email to `to` whose text mentions `containing` arrives. */
 async function waitForEmail(request: import("@playwright/test").APIRequestContext, { to, containing }: { to: string; containing: string }) {
   const query = `to:"${to}" "${containing}"`;
@@ -73,7 +79,7 @@ test.describe("Blog Flow", () => {
   let sharedCommentText = "";
 
   test.beforeAll(async ({ request }) => {
-    for (const user of [testUser, replyingUser, driftUser, avatarChangeUser]) {
+    for (const user of [testUser, replyingUser, driftUser, avatarChangeUser, pendingReactionUser]) {
       const response = await request.post(`${SUPABASE_URL}/auth/v1/admin/users`, {
         headers: {
           Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
@@ -127,6 +133,38 @@ test.describe("Blog Flow", () => {
       data: { content: "anonymous comment" },
     });
     expect(commentResponse.status()).toBe(401);
+  });
+
+  test("a reaction clicked while signed out fires automatically after signing in", async ({ page, request }) => {
+    await page.goto(POST_PATH);
+
+    const reactions = page.locator('section[aria-label="Was this useful?"]');
+    const heart = reactions.getByRole("button", { name: "Love it" });
+
+    // Baseline from the API, not the UI — the rendered count races the island's async fetch.
+    const baseline = await request.get(`${API_URL}/api/blog/${SLUG}/reactions`);
+    const countBefore = (await baseline.json()).counts.heart;
+
+    // Signed out: the click stores the pending reaction and opens the dialog.
+    await heart.click();
+    await expect(page.locator("#auth-dialog")).toBeVisible();
+
+    // Signing in (programmatically — the dialog form path needs a live Turnstile challenge)
+    // must fire the stored reaction without a second click.
+    const toggleSettled = page.waitForResponse((response) => response.url().includes("/reactions/toggle"));
+    await page.evaluate(
+      async ({ email, password }) => {
+        const supabase = await (window as any).__supabaseReady;
+        if (!supabase) throw new Error("Supabase client not available");
+        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) throw new Error(`Sign-in failed: ${error.message}`);
+      },
+      { email: pendingReactionUser.email, password: pendingReactionUser.password },
+    );
+    expect((await toggleSettled).ok()).toBeTruthy();
+
+    await expect(heart).toHaveAttribute("aria-pressed", "true");
+    await expect(heart.locator("span").nth(1)).toHaveText(String(countBefore + 1));
   });
 
   test("signed-in user reacts, comments, replies, and deletes", async ({ page, request }) => {


### PR DESCRIPTION
## Summary

Clicking a reaction while signed out previously just opened the sign-in dialog — after signing in you had to click the reaction again. Now the clicked reaction is stored as a pending intent and fires automatically once sign-in completes.

Behavior details:

- The intent lives in **sessionStorage**, so it survives the full-page **Google OAuth redirect** (email/password sign-in applies it in place via the `auth-change` event).
- It's **scoped to the post** (slug check) and **expires after 10 minutes**, so a stale intent can't fire long after the fact.
- **Dismissing the dialog without signing in withdraws the intent** — signing in later from the navbar won't unexpectedly fire a forgotten reaction.
- After sign-in the island first reloads the account's reaction state and **skips the auto-toggle if that reaction is already active** (e.g. reacted earlier on another device) — the toggle semantics can't silently remove an existing reaction.
- A toggle bumps a load sequence so a slower in-flight anonymous fetch can't overwrite the fresh post-toggle state (the OAuth return path makes that race likely: the island mounts, starts loading, then the sign-in lands).

## Test plan

- New E2E test: click a reaction signed out → dialog opens → sign in with the dialog still open → the reaction toggles on and the count increments **without a second click**. Verified green against the locally running Aspire stack before pushing.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)