### PR TITLE
feat(blog): repeated-validations hero diagram in the zero-code post

### DIFF
--- a/frontend/src/components/RepeatedValidationsDiagram.astro
+++ b/frontend/src/components/RepeatedValidationsDiagram.astro
@@ -1,0 +1,110 @@
+---
+// Hero diagram for the zero-code-validations blog post: one validation rule
+// written three times because the type carries no proof between layers.
+interface Props {
+  ariaLabel: string;
+  class?: string;
+}
+
+const { ariaLabel, class: className } = Astro.props;
+
+const monoFont = "ui-monospace, 'Cascadia Mono', Menlo, Consolas, monospace";
+---
+
+<div class:list={["overflow-x-auto", className]}>
+  <svg viewBox="0 0 1040 204" xmlns="http://www.w3.org/2000/svg" class="w-full min-w-[640px]" role="img" aria-label={ariaLabel}>
+    <defs>
+      <marker id="rvd-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="var(--color-outline)"></path>
+      </marker>
+    </defs>
+
+    <!-- Check badges: the same rule, counted three times -->
+    <rect x="70" y="16" width="200" height="26" rx="13" fill="var(--color-error-container)"></rect>
+    <text x="170" y="33" text-anchor="middle" fill="var(--color-error)" font-family="var(--font-label)" font-size="11.5" font-weight="700">
+      check #1 · data annotations
+    </text>
+
+    <rect x="422" y="16" width="196" height="26" rx="13" fill="var(--color-error-container)"></rect>
+    <text x="520" y="33" text-anchor="middle" fill="var(--color-error)" font-family="var(--font-label)" font-size="11.5" font-weight="700">
+      check #2 · manual re-check
+    </text>
+
+    <rect x="780" y="16" width="180" height="26" rx="13" fill="var(--color-error-container)"></rect>
+    <text x="870" y="33" text-anchor="middle" fill="var(--color-error)" font-family="var(--font-label)" font-size="11.5" font-weight="700">
+      check #3 · guard clauses
+    </text>
+
+    <!-- Request DTO -->
+    <g>
+      <rect
+        x="20"
+        y="58"
+        width="300"
+        height="100"
+        rx="8"
+        fill="var(--color-surface-container)"
+        stroke="var(--color-outline-variant)"
+        stroke-width="1"></rect>
+      <rect x="20" y="58" width="4" height="100" rx="2" fill="var(--color-error)"></rect>
+      <text x="36" y="84" fill="var(--color-on-surface)" font-family="var(--font-body)" font-size="14" font-weight="600">Request DTO</text>
+      <text x="36" y="112" fill="var(--color-error)" font-family={monoFont} font-size="11.5" font-weight="600">[EmailAddress]</text>
+      <text x="36" y="132" fill="var(--color-on-surface-variant)" font-family={monoFont} font-size="11.5">string CustomerEmail;</text>
+    </g>
+
+    <!-- Arrow: DTO → Controller -->
+    <line x1="320" y1="112" x2="368" y2="112" stroke="var(--color-outline)" stroke-width="1.5" marker-end="url(#rvd-arrow)"></line>
+    <text x="345" y="100" text-anchor="middle" fill="var(--color-on-surface-variant)" font-family={monoFont} font-size="12">string</text>
+
+    <!-- Controller -->
+    <g>
+      <rect
+        x="370"
+        y="58"
+        width="300"
+        height="100"
+        rx="8"
+        fill="var(--color-surface-container)"
+        stroke="var(--color-outline-variant)"
+        stroke-width="1"></rect>
+      <rect x="370" y="58" width="4" height="100" rx="2" fill="var(--color-error)"></rect>
+      <text x="386" y="84" fill="var(--color-on-surface)" font-family="var(--font-body)" font-size="14" font-weight="600">Controller</text>
+      <text x="386" y="112" fill="var(--color-error)" font-family={monoFont} font-size="11.5" font-weight="600">
+        if (!MailAddress.TryCreate(email, …))
+      </text>
+      <text x="406" y="132" fill="var(--color-on-surface-variant)" font-family={monoFont} font-size="11.5">return ValidationProblem();</text
+      >
+    </g>
+
+    <!-- Arrow: Controller → Service -->
+    <line x1="670" y1="112" x2="718" y2="112" stroke="var(--color-outline)" stroke-width="1.5" marker-end="url(#rvd-arrow)"></line>
+    <text x="695" y="100" text-anchor="middle" fill="var(--color-on-surface-variant)" font-family={monoFont} font-size="12">string</text>
+
+    <!-- Service -->
+    <g>
+      <rect
+        x="720"
+        y="58"
+        width="300"
+        height="100"
+        rx="8"
+        fill="var(--color-surface-container)"
+        stroke="var(--color-outline-variant)"
+        stroke-width="1"></rect>
+      <rect x="720" y="58" width="4" height="100" rx="2" fill="var(--color-error)"></rect>
+      <text x="736" y="84" fill="var(--color-on-surface)" font-family="var(--font-body)" font-size="14" font-weight="600">Service</text>
+      <text x="736" y="112" fill="var(--color-error)" font-family={monoFont} font-size="11.5" font-weight="600">
+        if (!MailAddress.TryCreate(email, …))
+      </text>
+      <text x="756" y="132" fill="var(--color-on-surface-variant)" font-family={monoFont} font-size="11.5"
+        >throw new ArgumentException();</text
+      >
+    </g>
+
+    <!-- Punchline -->
+    <text x="20" y="192" fill="var(--color-on-surface-variant)" font-family="var(--font-body)" font-size="13">
+      Three copies of one rule — the value stays a plain <tspan font-family={monoFont} fill="var(--color-error)">string</tspan> between layers,
+      so no layer can trust the one before it.
+    </text>
+  </svg>
+</div>

--- a/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
+++ b/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
@@ -153,7 +153,7 @@ NonEmptyString? fluent = input.AsNonEmpty();             // same, as an extensio
           pravidlo znovu.
         </p>
 
-        <RepeatedValidationsDiagram ariaLabel="Jedno validační pravidlo napsané třikrát: data annotations na request DTO, ruční kontrola v controlleru a guard clauses ve službě — hodnota mezi vrstvami zůstává obyčejný string" />
+        <RepeatedValidationsDiagram ariaLabel="Jedno pravidlo napsané třikrát" />
 
         <p>Vezmi si tenhle ukázkový endpoint, který zakládá objednávku. Validace probíhá na třech místech:</p>
 
@@ -332,7 +332,7 @@ NonEmptyString? fluent = input.AsNonEmpty();             // same, as an extensio
           down.
         </p>
 
-        <RepeatedValidationsDiagram ariaLabel="One validation rule written three times: data annotations on the request DTO, a manual re-check in the controller, and guard clauses in the service — the value stays a plain string between layers" />
+        <RepeatedValidationsDiagram ariaLabel="One validation rule written three times" />
 
         <p>Take this example endpoint that places an order. Validation is on three places:</p>
 

--- a/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
+++ b/frontend/src/pages/[...lang]/blog/zero-code-validations-in-your-dotnet-api.astro
@@ -1,6 +1,7 @@
 ---
 import BlogCode from "../../../components/BlogCode.astro";
 import BlogPostLayout from "../../../components/BlogPostLayout.astro";
+import RepeatedValidationsDiagram from "../../../components/RepeatedValidationsDiagram.astro";
 import { blogPostStaticPaths, type BlogPostMetadata } from "../../../blog/types";
 import { defaultLocale, localePath, type Locale } from "../../../i18n/utils";
 import { strongTypesDiagrams } from "../../../lib/strong-types-diagrams";
@@ -19,7 +20,7 @@ export const metadata: BlogPostMetadata = {
     },
   },
   pubDate: "2026-07-04",
-  updatedDate: "2026-07-09",
+  updatedDate: "2026-07-10",
   tags: ["dotnet", "csharp", "strong-types", "type-safety", "api-design", "validations"],
 };
 
@@ -151,6 +152,8 @@ NonEmptyString? fluent = input.AsNonEmpty();             // same, as an extensio
           Na jednom z minulých projektů jsem si všiml jednoho problému. Byly to validace. Konkrétně to, kolikrát jsem musel napsat to samé
           pravidlo znovu.
         </p>
+
+        <RepeatedValidationsDiagram ariaLabel="Jedno validační pravidlo napsané třikrát: data annotations na request DTO, ruční kontrola v controlleru a guard clauses ve službě — hodnota mezi vrstvami zůstává obyčejný string" />
 
         <p>Vezmi si tenhle ukázkový endpoint, který zakládá objednávku. Validace probíhá na třech místech:</p>
 
@@ -328,6 +331,8 @@ NonEmptyString? fluent = input.AsNonEmpty();             // same, as an extensio
           On one of my previous projects, I noticed an issue. It was validations. Specifically, how many times I had to write the same rule
           down.
         </p>
+
+        <RepeatedValidationsDiagram ariaLabel="One validation rule written three times: data annotations on the request DTO, a manual re-check in the controller, and guard clauses in the service — the value stays a plain string between layers" />
 
         <p>Take this example endpoint that places an order. Validation is on three places:</p>
 

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -262,7 +262,7 @@ test.describe("Blog", () => {
     // Bilingual post: the Czech URL is a first-class sitemap entry, not just an alternate.
     expect(body).toContain("<loc>https://www.kalandra.tech/cs/blog/zero-code-validations-in-your-dotnet-api</loc>");
     // The post's updatedDate — it wins over pubDate for <lastmod>.
-    expect(body).toContain("<lastmod>2026-07-09</lastmod>");
+    expect(body).toContain("<lastmod>2026-07-10</lastmod>");
     expect(body).toContain('hreflang="cs"');
     expect(body).not.toContain("/profile");
     expect(body).not.toContain("/admin");


### PR DESCRIPTION
## Summary

Adds a simplified hero diagram to the top of the zero-code-validations blog post — a stripped-down take on the StrongTypes impact diagram that shows **just the problem**, without the with/without comparison or the JSON pill:

- Three layer boxes — **Request DTO** (with the \`[EmailAddress]\` data annotation visible), **Controller** (manual \`MailAddress.TryCreate\` re-check), **Service** (the same guard again).
- Red \`check #1/#2/#3\` badges counting the copies of the rule, \`string\` labels on the arrows between layers, and a one-line punchline underneath.

Unlike the diagrams hosted in the StrongTypes repo, this one is blog-specific, so it lives here as an inline-SVG Astro component (`RepeatedValidationsDiagram.astro`) using the design tokens (`var(--color-error)`, surfaces, outline) — it follows light/dark mode automatically, with no dark twin file and no `data-src-dark` wiring. The `aria-label` is localized per language; in-diagram text stays English, matching the existing diagrams.

Also bumps the post's `updatedDate` to 2026-07-10.

## Verification

- Rendered in the dev preview in both light and dark mode, EN and CS variants; no console errors.
- Diagram sits after the intro paragraph, directly above the "validation is on three places" list it illustrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)