### PR TITLE
perf(frontend): trim blog page load — tree-shake Sentry Replay, lazy Turnstile

### DIFF
--- a/frontend/src/components/blog/BlogReactions.vue
+++ b/frontend/src/components/blog/BlogReactions.vue
@@ -47,10 +47,15 @@ function applyState(data: { counts: Record<string, number>; mine: ReactionKind[]
 // Bumped when a toggle lands so a slower in-flight load can't overwrite fresher state.
 let loadSequence = 0;
 
+// Whether the reactions currently shown were loaded for a signed-in user. Seeded on mount from the
+// persisted-session hint so the confirmatory auth-change after the initial load doesn't refetch.
+let loadedSignedIn: boolean | null = null;
+
 async function loadReactions() {
   const sequence = ++loadSequence;
   try {
     const token = await getAccessToken();
+    loadedSignedIn = !!token;
     const res = await fetch(`${props.apiUrl}/api/blog/${props.slug}/reactions`, {
       headers: visitorHeaders(token),
     });
@@ -101,12 +106,20 @@ async function toggle(kind: ReactionKind) {
 }
 
 const onAuthChange = async (event: Event) => {
+  const user = (event as CustomEvent).detail?.user;
+  // A signed-out reader gets ~two confirmatory auth-changes per load (getSession + onAuthStateChange);
+  // once the signed-out state is loaded there's nothing to re-link or reload. Signed-in transitions —
+  // including the post-sign-in visitor link + reload below — always fall through.
+  if (!user && loadedSignedIn === false) return;
   // Fold anonymous reactions into the account before reloading, so "mine" reflects them.
-  if ((event as CustomEvent).detail?.user) await ensureVisitorLinked(props.apiUrl);
+  if (user) await ensureVisitorLinked(props.apiUrl);
   await loadReactions();
 };
 
 onMounted(() => {
+  // Persisted-session hint from Layout's pre-paint script — a synchronous best guess of the signed-in
+  // state so the first auth-change doesn't refetch before loadReactions() resolves the real token.
+  loadedSignedIn = !!(window as any).__authPrefill;
   void loadReactions();
   window.addEventListener("auth-change", onAuthChange);
 });

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -112,7 +112,6 @@ const canonicalUrl = lang === "cs" ? csUrl : enUrl;
       )
     }
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <title>{title}</title>
 
     {

--- a/frontend/src/lib/observability.ts
+++ b/frontend/src/lib/observability.ts
@@ -20,85 +20,75 @@ type EventData = Record<string, unknown>;
 const sentryDsn = import.meta.env.PUBLIC_SENTRY_DSN;
 const environment = import.meta.env.PUBLIC_SENTRY_ENVIRONMENT || import.meta.env.MODE;
 
-// Resolves to the loaded SDK once init completes; null when no DSN is configured.
-// Calls below chain off this promise so anything fired before the SDK arrives still lands.
-const sentryReady: Promise<typeof import("@sentry/browser")> | null = sentryDsn
-  ? import("@sentry/browser").then((Sentry) => {
-      Sentry.init({
-        dsn: sentryDsn,
-        environment,
-        tracesSampleRate: 1.0,
-        tracePropagationTargets: ["localhost", /^\/api\//, "https://api.kalandra.tech"],
-        // Lets Sentry's ingest server attach the client IP (derived from the connection) to events and logs.
-        // Browser/OS/locale already ride along via the default httpContext and cultureContext integrations.
-        sendDefaultPii: true,
-        // The Logs product doesn't auto-inherit the user/UA/culture context the way events do — it only
-        // carries what's in `log.attributes`. Enrich every log with the current scope's user plus a few
-        // client-side fields so Sentry's UI populates the User panel and lets us search by user.email,
-        // user_agent.original, etc. OTel semantic conventions used where applicable.
-        beforeSendLog(log) {
-          const user = Sentry.getCurrentScope().getUser();
-          log.attributes = {
-            ...log.attributes,
-            ...(user?.id !== undefined && { "user.id": String(user.id) }),
-            ...(user?.email && { "user.email": user.email }),
-            ...(user?.username && { "user.name": user.username }),
-            "user_agent.original": navigator.userAgent,
-            "browser.language": navigator.language,
-            "browser.timezone": Intl.DateTimeFormat().resolvedOptions().timeZone,
-            "url.path": window.location.pathname,
-          };
-          return log;
-        },
-        // Enables Sentry's Logs product — required for `Sentry.logger.*` and `consoleLoggingIntegration`.
-        enableLogs: true,
-        // Session Replay sampling. The SDK only loads at all when PUBLIC_SENTRY_DSN is configured at build
-        // time, so anyone seeing replays is opting into the full observability stack — record everything.
-        replaysSessionSampleRate: 1.0,
-        replaysOnErrorSampleRate: 1.0,
-        integrations: (defaults) => [
-          ...defaults,
-          // v10 dropped browserTracingIntegration from defaults; without it, tracesSampleRate has nothing to sample.
-          // Resource loads (JS chunks, CSS, fonts, images) and stray performance.mark/measure spans from
-          // dependencies like @supabase/auth-js drown out the actual signal — fetches and Web Vitals —
-          // so we silence them. Pageload + navigation transactions and fetch spans still flow normally.
-          Sentry.browserTracingIntegration({
-            ignoreResourceSpans: ["resource.script", "resource.css", "resource.img", "resource.link", "resource.other"],
-            ignorePerformanceApiSpans: [/.*/],
-          }),
-          // Forward the useful console levels to Sentry Logs. Skipping `debug`/`trace`/`assert` —
-          // they're mostly framework/dependency noise that wouldn't help when diagnosing real issues.
-          Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
-          // Session Replay — DOM/network/console recording.
-          // Defaults mask every text node and input, which makes replays unreadable. Relax them: passwords
-          // (`<input type="password">`) are always masked by Sentry regardless of these flags, so the only
-          // way sensitive data leaks is if you put a secret in a regular field. If that ever becomes a
-          // concern for a specific element, add `data-sentry-mask` to it (or extend the `mask` option below).
-          Sentry.replayIntegration({
-            maskAllText: false,
-            maskAllInputs: false,
-            blockAllMedia: false,
-            // Sentry also masks `title`, `placeholder`, `aria-label` by default — that's why every input
-            // placeholder in the replay reads as `*****`. None of those carry PII on this app, so clear it.
-            maskAttributes: [],
-          }),
-        ],
-      });
-      // Deliberate pageview log — fires once per full page load (this is a static Astro site, no SPA nav).
-      // Gives a per-pageview entry in the Logs tab with the user/UA/locale context populated by beforeSendLog.
-      Sentry.logger.info("pageview", {
-        "url.path": window.location.pathname,
-        "url.query": window.location.search,
-        "http.referer": document.referrer,
-      });
-      return Sentry;
-    })
+// Resolves to a minimal SDK surface once init completes; null when no DSN is configured. Calls below
+// chain off this promise so anything fired before the SDK arrives still lands. Pulling only the
+// functions we use off the module by name (rather than the whole `Sentry` namespace) is what lets the
+// bundler tree-shake Session Replay (rrweb) — the SDK's heaviest feature — out of the chunk entirely.
+type SentryApi = Pick<typeof import("@sentry/browser"), "setUser" | "addBreadcrumb" | "logger">;
+// Import eagerly (this module runs in <head>) rather than deferring, so init wins the race against the
+// client:idle islands: their API calls are only traced, and early errors only captured, once init runs.
+const sentryReady: Promise<SentryApi> | null = sentryDsn
+  ? import("@sentry/browser").then(
+      ({ init, browserTracingIntegration, consoleLoggingIntegration, getCurrentScope, setUser, addBreadcrumb, logger }) => {
+        init({
+          dsn: sentryDsn,
+          environment,
+          tracesSampleRate: 1.0,
+          tracePropagationTargets: ["localhost", /^\/api\//, "https://api.kalandra.tech"],
+          // Lets Sentry's ingest server attach the client IP (derived from the connection) to events and logs.
+          // Browser/OS/locale already ride along via the default httpContext and cultureContext integrations.
+          sendDefaultPii: true,
+          // The Logs product doesn't auto-inherit the user/UA/culture context the way events do — it only
+          // carries what's in `log.attributes`. Enrich every log with the current scope's user plus a few
+          // client-side fields so Sentry's UI populates the User panel and lets us search by user.email,
+          // user_agent.original, etc. OTel semantic conventions used where applicable.
+          beforeSendLog(log) {
+            const user = getCurrentScope().getUser();
+            log.attributes = {
+              ...log.attributes,
+              ...(user?.id !== undefined && { "user.id": String(user.id) }),
+              ...(user?.email && { "user.email": user.email }),
+              ...(user?.username && { "user.name": user.username }),
+              "user_agent.original": navigator.userAgent,
+              "browser.language": navigator.language,
+              "browser.timezone": Intl.DateTimeFormat().resolvedOptions().timeZone,
+              "url.path": window.location.pathname,
+            };
+            return log;
+          },
+          // Enables Sentry's Logs product — required for `logger.*` and `consoleLoggingIntegration`.
+          enableLogs: true,
+          integrations: (defaults) => [
+            ...defaults,
+            // v10 dropped browserTracingIntegration from defaults; without it, tracesSampleRate has nothing to sample.
+            // Resource loads (JS chunks, CSS, fonts, images) and stray performance.mark/measure spans from
+            // dependencies like @supabase/auth-js drown out the actual signal — fetches and Web Vitals —
+            // so we silence them. Pageload + navigation transactions and fetch spans still flow normally.
+            browserTracingIntegration({
+              ignoreResourceSpans: ["resource.script", "resource.css", "resource.img", "resource.link", "resource.other"],
+              ignorePerformanceApiSpans: [/.*/],
+            }),
+            // Forward the useful console levels to Sentry Logs. Skipping `debug`/`trace`/`assert` —
+            // they're mostly framework/dependency noise that wouldn't help when diagnosing real issues.
+            consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+          ],
+        });
+        // Deliberate pageview log — fires once per full page load (this is a static Astro site, no SPA nav).
+        // Gives a per-pageview entry in the Logs tab with the user/UA/locale context populated by beforeSendLog.
+        logger.info("pageview", {
+          "url.path": window.location.pathname,
+          "url.query": window.location.search,
+          "http.referer": document.referrer,
+        });
+        return { setUser, addBreadcrumb, logger };
+      },
+    )
   : null;
 
 /** Identify the current user. Call on sign-in and on auth state changes. */
 export function identifyUser(user: AuthUser | null): void {
-  sentryReady?.then((Sentry) =>
-    Sentry.setUser(
+  sentryReady?.then((sentry) =>
+    sentry.setUser(
       user
         ? {
             id: user.id,
@@ -112,10 +102,10 @@ export function identifyUser(user: AuthUser | null): void {
 
 /** Record a named application event with optional metadata. */
 export function track(event: string, data?: EventData): void {
-  sentryReady?.then((Sentry) => {
+  sentryReady?.then((sentry) => {
     // Breadcrumb: visible on captured issues; structured log: visible in the Logs tab regardless.
-    Sentry.addBreadcrumb({ category: "app", message: event, level: "info", data: data ?? {} });
-    Sentry.logger.info(event, data ?? {});
+    sentry.addBreadcrumb({ category: "app", message: event, level: "info", data: data ?? {} });
+    sentry.logger.info(event, data ?? {});
   });
 }
 

--- a/frontend/src/lib/turnstile.ts
+++ b/frontend/src/lib/turnstile.ts
@@ -45,9 +45,25 @@ export function turnstileEnabled(): boolean {
   return !!SITE_KEY;
 }
 
+const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+// Load Cloudflare's Turnstile API on first need rather than on every page. Idempotent: bails if the
+// API is already present or a matching tag is already in the document (a page that needs the widget
+// at load, like hire-me, injects its own).
+function loadTurnstileScript(): void {
+  if (!SITE_KEY || window.turnstile) return;
+  if (document.querySelector(`script[src^="${TURNSTILE_SCRIPT_SRC}"]`)) return;
+  const script = document.createElement("script");
+  script.src = TURNSTILE_SCRIPT_SRC;
+  script.async = true;
+  script.defer = true;
+  document.head.appendChild(script);
+}
+
 export function whenTurnstileReady(): Promise<void> {
   return new Promise((resolve) => {
     if (window.turnstile) return resolve();
+    loadTurnstileScript();
     const iv = setInterval(() => {
       if (window.turnstile) {
         clearInterval(iv);

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -347,6 +347,14 @@ const t = translations[lang];
         cb();
         return;
       }
+      // No longer loaded globally — this form needs the widget, so pull the script in on demand.
+      if (turnstileSiteKey && !document.querySelector('script[src^="https://challenges.cloudflare.com/turnstile"]')) {
+        var s = document.createElement("script");
+        s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+        s.async = true;
+        s.defer = true;
+        document.head.appendChild(s);
+      }
       var iv = setInterval(function () {
         if (window.turnstile) {
           clearInterval(iv);


### PR DESCRIPTION
## Why

Opening a blog post pulled ~1 MB and took a couple of seconds. The perceived weight was inflated by a browser extension (`injected.js`, 431 KB, initiator `inject-content-script`) that isn't part of the site; the real payload (~415 KB transferred) was dominated by client-side JS blog readers don't need up front.

**Why not SSR:** the site is already Astro SSG served from Cloudflare's edge — the fastest HTML delivery there is. SSR would add request-time TTFB and ship the *identical* client JS. The weight is client-side JS + fonts; that's what this PR targets.

> Rebased onto latest `main` (includes #192 per-user read tracking and #206 public-stats reveal). The reactions fix was re-reconciled against #192's reworked `BlogReactions.vue`, which made reactions anonymous (visitor-id keyed).

## Changes

### Sentry — drop Session Replay (`observability.ts`)
- Session Replay (rrweb) ran for **every** visitor (`replaysSessionSampleRate: 1.0`) and was the single biggest chunk. Switched from namespace access (`Sentry.*`, which pins the whole SDK) to **named/destructured imports** resolving a curated API object, so the bundler tree-shakes Replay out entirely. `prod.*.js`: **436 KB → 144 KB** uncompressed (~145 KB → ~45 KB transferred). Verified: no `rrweb`/`replay` strings remain in `dist`.
- Init stays **eager** (the import fires in `<head>`) rather than deferred, so the SDK still wins the race against the `client:idle` islands and is up before their first API calls — those calls are only traced, and early errors only captured, once init runs. (Deferring to `requestIdleCallback` was tried, but reverted: once Replay was gone the remaining ~45 KB core didn't justify losing that head-start.) Errors/traces/logs/breadcrumbs all retained.

### Turnstile — load on demand (`turnstile.ts`, `Layout.astro`, `hire-me.astro`)
- The Cloudflare Turnstile script (~24 KB) was loaded globally in `<head>` on every page, but only the auth dialog and hire-me form use it. Now injected on first use; blog readers who never sign in never fetch it.

### Reactions — one fetch instead of three (`BlogReactions.vue`)
- `auth-change` fires ~twice per load (`getSession` + `onAuthStateChange`), and the island reloaded `/reactions` on each — so a signed-out reader made **3** requests. Now the confirmatory signed-out `auth-change` is skipped (seeded from the persisted-session hint `__authPrefill`), giving **1**. Signed-in transitions always fall through, so #192's visitor-link-then-reload path (folding anonymous reactions into the account on sign-in) is untouched.

## Impact
Excluding the browser-extension noise, the transferred blog-page payload drops ~415 KB → ~290 KB — almost entirely from removing Replay (~100 KB) and dropping Turnstile for readers (~24 KB). Sentry keeps its load timing; it's just ~100 KB lighter.

## Verification
- `astro build` green (36 pages) on the rebased tree; tree-shaking confirmed (144 KB Sentry chunk, no replay in `dist`); Sentry initializes eagerly (`__SENTRY__` active client, no console errors).
- Live dev run: a signed-out blog load makes **1** `reactions` fetch with `auth-change` confirmed firing; the guard skips signed-out confirmatory reloads and is a no-op for signed-in.
- Prettier clean; pre-commit hook passed.

## Follow-ups (not in this PR)
- **Supabase (~52 KB) still loads on every blog page** — the islands request a token on mount. Reaction/view counts are visitor-keyed (public); deferring Supabase until a reader signs in would save it for anonymous visitors.
- **The 3 blog islands hydrate `client:idle`** → Vue runtime (~32 KB) downloads eagerly for below-the-fold content; `client:visible` would defer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
