### PR TITLE
feat(blog): reveal public view/reader counts; drop rollout scaffolding

### DIFF
--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -93,12 +93,7 @@ public class BlogController(
     [ProducesResponseType<RecordBlogPostViewResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<RecordBlogPostViewResponse>> RecordView(
-        string slug,
-        // Temporary: backdates a view so pre-rollout Cloudflare traffic can be seeded past the
-        // 15-minute window. Removed in the follow-up PR once the historical data is in place.
-        [FromQuery] DateTimeOffset? at,
-        CancellationToken ct)
+    public async Task<ActionResult<RecordBlogPostViewResponse>> RecordView(string slug, CancellationToken ct)
     {
         if (postCatalog.Find(slug) is not { } post)
             return NotFound();
@@ -109,7 +104,7 @@ public class BlogController(
             Slug: post.Slug,
             VisitorId: visitorId,
             UserId: currentUser.User?.Id,
-            NowUtc: at ?? timeProvider.GetUtcNow());
+            NowUtc: timeProvider.GetUtcNow());
 
         var result = await recordViewHandler.RecordAndSave(command, ct);
         return new RecordBlogPostViewResponse(result.PreviousViewCount, result.TotalViews, result.UniqueVisitors);

--- a/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
+++ b/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
@@ -58,6 +58,8 @@ public class RecordBlogPostViewHandler(IDocumentSession session)
             : view.ViewCount;
         var postTotal = await session.Query<BlogPostVisitorView>().Where(v => v.Slug == command.Slug).SumAsync(v => v.ViewCount, ct);
         var uniqueVisitors = await session.CountDistinctViewersAsync(command.Slug, ct);
-        return new RecordBlogPostViewResult(readerTotal - 1, postTotal, uniqueVisitors);
+        // A shared browser's view row can already belong to another account, leaving this
+        // reader's total at 0 — clamp so the label never reads "read -1 times".
+        return new RecordBlogPostViewResult(Math.Max(0, readerTotal - 1), postTotal, uniqueVisitors);
     }
 }

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -260,22 +260,6 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Assert.Equal(0, response.GetProperty("previousViewCount").GetInt32());
     }
 
-    [Fact]
-    public async Task RecordView_BackdatedTimestamp_SeedsSeparateVisitsPastTheWindow()
-    {
-        var slug = NewSlug();
-        SignOut();
-        SetVisitor(Guid.NewGuid());
-
-        // Seeding replays one visitor's history with backdated timestamps 30 minutes apart;
-        // clearing the 15-minute window, both count as views.
-        await client.PostAsync($"/api/blog/{slug}/views?at=2026-06-01T20:00:00Z", content: null, Ct);
-        var second = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views?at=2026-06-01T20:30:00Z", content: null, Ct));
-
-        Assert.Equal(2, second.GetProperty("totalViews").GetInt32());
-        Assert.Equal(1, second.GetProperty("uniqueVisitors").GetInt32());
-    }
-
     // ───── Visitor link (anonymous → account attribution) ─────
 
     [Fact]

--- a/frontend/src/components/blog/BlogList.vue
+++ b/frontend/src/components/blog/BlogList.vue
@@ -2,11 +2,8 @@
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { getAccessToken, getCurrentUser } from "../../lib/auth";
 import type { BlogListPost, BlogPostStats, BlogStatsResponse } from "../../lib/blog/types";
-import { SHOW_PUBLIC_STATS } from "../../lib/blog/flags";
 import MaterialIcon from "../icons/MaterialIcon.vue";
 import { materialSymbolPaths as paths } from "../icons/material-symbol-paths";
-
-const showPublicStats = SHOW_PUBLIC_STATS;
 
 type SortKey = "recent" | "reactions" | "views";
 
@@ -122,7 +119,7 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
         >
           <option value="recent">{{ props.t.sortRecent }}</option>
           <option value="reactions">{{ props.t.sortReactions }}</option>
-          <option v-if="showPublicStats" value="views">{{ props.t.sortViews }}</option>
+          <option value="views">{{ props.t.sortViews }}</option>
         </select>
       </label>
       <label v-if="signedIn" id="blog-unread-filter" class="flex items-center gap-2 text-sm font-label text-on-surface cursor-pointer">
@@ -172,19 +169,16 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
             </li>
           </ul>
           <p v-if="statsLoaded" class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-4 text-xs font-label text-on-surface-variant">
-            <!-- View/reader counts are gated until the pre-rollout traffic is seeded. -->
-            <template v-if="showPublicStats">
-              <span class="inline-flex items-center gap-1.5" :title="props.t.statViews">
-                <MaterialIcon :d="paths.visibility" class="size-4" />
-                {{ stats[post.slug]?.totalViews ?? 0 }}
-                <span class="sr-only">{{ props.t.statViews }}</span>
-              </span>
-              <span class="inline-flex items-center gap-1.5" :title="props.t.statPeople">
-                <MaterialIcon :d="paths.person" class="size-4" />
-                {{ stats[post.slug]?.uniqueVisitors ?? 0 }}
-                <span class="sr-only">{{ props.t.statPeople }}</span>
-              </span>
-            </template>
+            <span class="inline-flex items-center gap-1.5" :title="props.t.statViews">
+              <MaterialIcon :d="paths.visibility" class="size-4" />
+              {{ stats[post.slug]?.totalViews ?? 0 }}
+              <span class="sr-only">{{ props.t.statViews }}</span>
+            </span>
+            <span class="inline-flex items-center gap-1.5" :title="props.t.statPeople">
+              <MaterialIcon :d="paths.person" class="size-4" />
+              {{ stats[post.slug]?.uniqueVisitors ?? 0 }}
+              <span class="sr-only">{{ props.t.statPeople }}</span>
+            </span>
             <span class="inline-flex items-center gap-1.5" :title="props.t.statReactions">
               <MaterialIcon :d="paths.favorite" class="size-4" />
               {{ stats[post.slug]?.totalReactions ?? 0 }}

--- a/frontend/src/components/blog/BlogReadStatus.vue
+++ b/frontend/src/components/blog/BlogReadStatus.vue
@@ -2,11 +2,8 @@
 import { onMounted, onUnmounted, ref } from "vue";
 import { getAccessToken, getCurrentUser } from "../../lib/auth";
 import { ensureVisitorLinked, visitorHeaders } from "../../lib/visitor";
-import { SHOW_PUBLIC_STATS } from "../../lib/blog/flags";
 import MaterialIcon from "../icons/MaterialIcon.vue";
 import { materialSymbolPaths as paths } from "../icons/material-symbol-paths";
-
-const showPublicStats = SHOW_PUBLIC_STATS;
 
 const props = defineProps<{
   apiUrl: string;
@@ -72,21 +69,17 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
 </script>
 
 <template>
-  <!-- Public view/reader counts are gated until the pre-rollout traffic is seeded; the reader's own count always shows. -->
-  <template v-if="showPublicStats">
-    <span v-if="!loaded" class="inline-block h-4 w-24 rounded bg-on-surface/10 animate-pulse align-middle" aria-hidden="true" />
-    <span v-else-if="totalViews !== null" class="inline-flex items-center gap-1.5">
-      <MaterialIcon :d="paths.visibility" class="size-4" />
-      {{ totalViews }}
-      <span class="sr-only">{{ props.t.viewsLabel }}</span>
-      <span aria-hidden="true">·</span>
-      <MaterialIcon :d="paths.person" class="size-4" />
-      {{ uniqueVisitors }}
-      <span class="sr-only">{{ props.t.peopleLabel }}</span>
-      <template v-if="readLabel"
-        ><span aria-hidden="true">·</span> <span>{{ readLabel }}</span></template
-      >
-    </span>
-  </template>
-  <span v-else-if="readLabel">{{ readLabel }}</span>
+  <span v-if="!loaded" class="inline-block h-4 w-24 rounded bg-on-surface/10 animate-pulse align-middle" aria-hidden="true" />
+  <span v-else-if="totalViews !== null" class="inline-flex items-center gap-1.5">
+    <MaterialIcon :d="paths.visibility" class="size-4" />
+    {{ totalViews }}
+    <span class="sr-only">{{ props.t.viewsLabel }}</span>
+    <span aria-hidden="true">·</span>
+    <MaterialIcon :d="paths.person" class="size-4" />
+    {{ uniqueVisitors }}
+    <span class="sr-only">{{ props.t.peopleLabel }}</span>
+    <template v-if="readLabel"
+      ><span aria-hidden="true">·</span> <span>{{ readLabel }}</span></template
+    >
+  </span>
 </template>

--- a/frontend/src/lib/blog/flags.ts
+++ b/frontend/src/lib/blog/flags.ts
@@ -1,6 +1,0 @@
-/**
- * Public view/reader counts stay hidden until the pre-rollout Cloudflare traffic is
- * seeded, so the first rollout doesn't show a misleading near-zero. The follow-up PR
- * flips this on (and fixes the reader dedup + removes the seeding time parameter).
- */
-export const SHOW_PUBLIC_STATS = false;


### PR DESCRIPTION
Second rollout stage for anonymous view/reaction tracking (#191): now that the pre-rollout Cloudflare traffic can be seeded, the public counts come out of hiding and the temporary seed scaffolding is removed.

## What changed
- **Show the counts** — removed the `SHOW_PUBLIC_STATS` flag; the view (👁) and reader (👤) counts and the "most views" sort now always render on the blog index and post pages.
- **Drop the seed param** — removed the temporary `?at=` backdating parameter from `POST /api/blog/{slug}/views` (and its integration test).

## ⚠️ Merge ordering
Merge this **after** prod is seeded — removing `?at=` disables the backdating the seed step relies on. Sequence:
1. #192 deploys (tracking live, counts hidden, `?at=` available)
2. seed prod with the pre-rollout Cloudflare numbers
3. merge this → counts revealed, seed scaffolding gone

## Still to add to this PR
- [ ] **Carry-over migration for the one existing prod reaction** — #192 moved reactions from events to documents; a small idempotent migration will re-create that reaction as a `BlogReaction` document. Pending the reactor's `{ slug, userId, kind }` from a prod query.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)