### PR TITLE
feat(frontend): submit forms with Ctrl/Cmd+Enter

### DIFF
--- a/frontend/src/components/AuthDialog.astro
+++ b/frontend/src/components/AuthDialog.astro
@@ -389,10 +389,12 @@ const t = lang === "cs" ? csCommon : enCommon;
   authDialogElement?.addEventListener("click", (event) => {
     if (authDialogPressStartedOutside && outsideAuthDialog(event)) authDialogElement.close();
   });
-  // Allow Enter key to submit
-  document.getElementById("auth-password")?.addEventListener("keydown", (e) => {
+  // Allow Enter key to submit from either field
+  const submitOnEnter = (e: KeyboardEvent) => {
     if (e.key === "Enter") authDialogSubmit();
-  });
+  };
+  document.getElementById("auth-email")?.addEventListener("keydown", submitOnEnter);
+  document.getElementById("auth-password")?.addEventListener("keydown", submitOnEnter);
 
   // Expose opener so Layout's header sign-in buttons can trigger the dialog
   // without duplicating the dialog markup.

--- a/frontend/src/components/job-offers/JobOfferDetail.vue
+++ b/frontend/src/components/job-offers/JobOfferDetail.vue
@@ -371,6 +371,8 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
           rows="2"
           :placeholder="props.t.userActions.cancelReason"
           class="w-full px-4 py-2 rounded-xl bg-surface-container border border-outline-variant/20 text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/30 resize-y mb-4"
+          @keydown.enter.ctrl.prevent="confirmCancel"
+          @keydown.enter.meta.prevent="confirmCancel"
         ></textarea>
         <button
           id="confirm-cancel"
@@ -406,6 +408,8 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
             rows="2"
             :placeholder="props.t.admin.notesPlaceholder"
             class="flex-1 px-4 py-2 rounded-xl bg-surface-container border border-outline-variant/20 text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/30 resize-y"
+            @keydown.enter.ctrl.prevent="saveStatus"
+            @keydown.enter.meta.prevent="saveStatus"
           ></textarea>
           <button
             id="save-status"

--- a/frontend/src/components/job-offers/JobOfferEditForm.vue
+++ b/frontend/src/components/job-offers/JobOfferEditForm.vue
@@ -120,6 +120,8 @@ function borderClass(name: TextFieldName): string {
       novalidate
       class="bg-surface-container-low rounded-2xl border border-outline-variant/10 p-8 md:p-12 space-y-6"
       @submit.prevent="submit"
+      @keydown.enter.ctrl.prevent="submit"
+      @keydown.enter.meta.prevent="submit"
     >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>

--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -488,6 +488,14 @@ const t = translations[lang];
           if (field.parentElement.querySelector(".field-error")) validateField(field);
         });
       });
+
+      // Ctrl/Cmd+Enter submits from any field, including the textareas where a bare Enter inserts a newline.
+      formEl.addEventListener("keydown", function (e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+          e.preventDefault();
+          if (!document.getElementById("submit-btn")?.disabled) formEl.requestSubmit();
+        }
+      });
     }
 
     // Ask the user to confirm when optional fields or attachments are empty.

--- a/frontend/src/pages/[...lang]/profile.astro
+++ b/frontend/src/pages/[...lang]/profile.astro
@@ -505,13 +505,13 @@ const t = translations[lang];
     });
 
     // --- Save display name ---
-    document.getElementById("save-name-btn")?.addEventListener("click", async function () {
+    async function saveName() {
       var btn = document.getElementById("save-name-btn");
       var feedback = document.getElementById("name-feedback");
       var nameInput = document.getElementById("display-name");
       var newName = nameInput?.value.trim();
 
-      if (!newName) return;
+      if (!newName || btn.disabled) return;
 
       btn.textContent = strings.displayName.saving;
       btn.disabled = true;
@@ -535,6 +535,10 @@ const t = translations[lang];
         btn.textContent = strings.displayName.save;
         btn.disabled = false;
       }
+    }
+    document.getElementById("save-name-btn")?.addEventListener("click", saveName);
+    document.getElementById("display-name")?.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") saveName();
     });
 
     // --- Save email ---


### PR DESCRIPTION
## What

Ctrl/Cmd+Enter now submits **every** form on the site. The trigger was the profile **Display Name** field, which had no keyboard submit at all.

## Why

> On the profile page, when changing Display Name, Ctrl+Enter must submit. Actually, make sure this works on all the forms.

## Changes

- **Profile → Display Name** (`profile.astro`): extracted the save handler into `saveName()` and wired Enter / Ctrl+Enter on the input; guards against a double-submit from rapid presses.
- **Hire-me job-offer form** (`hire-me.astro`): form-level Ctrl/Cmd+Enter → `requestSubmit()`, so the textareas submit too (a bare Enter in a textarea stays a newline). Respects the disabled submit button, matching native Enter.
- **Job-offer edit form** (`JobOfferEditForm.vue`): `@keydown.enter.ctrl/.meta.prevent="submit"` on the form.
- **Auth dialog** (`AuthDialog.astro`): Enter now submits from the email field, not just password.
- **Job-offer cancel + admin status** (`JobOfferDetail.vue`): Ctrl/Cmd+Enter on the reason / notes textareas submits.

Already handled Ctrl/Cmd+Enter, no change: profile email/password, blog comments, job-offer comments.

## Verification

- `astro build` passes — all 36 pages built, Vue islands compile.
- Drove the built site in a browser against the **real shipped code**:
  - Profile Display Name: Ctrl+Enter *and* plain Enter call `updateUser` with the typed name + success snackbar.
  - Hire-me: Ctrl+Enter and Cmd+Enter from the description **textarea** fire submit; plain Enter does not (newline preserved).
- Full Playwright E2E suite not run locally (needs the Aspire stack) — it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
