### PR TITLE
fix(blog): refuse a view whose visitor id is claimed by another account (409)

### DIFF
--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -93,6 +93,7 @@ public class BlogController(
     [ProducesResponseType<RecordBlogPostViewResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<RecordBlogPostViewResponse>> RecordView(string slug, CancellationToken ct)
     {
         if (postCatalog.Find(slug) is not { } post)
@@ -107,7 +108,17 @@ public class BlogController(
             NowUtc: timeProvider.GetUtcNow());
 
         var result = await recordViewHandler.RecordAndSave(command, ct);
-        return new RecordBlogPostViewResponse(result.PreviousViewCount, result.TotalViews, result.UniqueVisitors);
+        if (result.Error is { } error)
+        {
+            return error switch
+            {
+                // The visitor id is bound to another account; the client mints a fresh one and retries.
+                RecordBlogPostViewError.VisitorClaimedByAnotherUser => Conflict(),
+            };
+        }
+
+        var view = result.Success!;
+        return new RecordBlogPostViewResponse(view.PreviousViewCount, view.TotalViews, view.UniqueVisitors);
     }
 
     // ───── Stats ─────

--- a/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
+++ b/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
@@ -11,20 +11,34 @@ public record RecordBlogPostViewCommand(string Slug, Guid VisitorId, Guid? UserI
 /// </summary>
 public record RecordBlogPostViewResult(int PreviousViewCount, int TotalViews, int UniqueVisitors);
 
+/// <summary>The visitor id's view row already belongs to a different account, so it can't be reused.</summary>
+public enum RecordBlogPostViewError
+{
+    VisitorClaimedByAnotherUser,
+}
+
 public class RecordBlogPostViewHandler(IDocumentSession session)
 {
     // A refresh inside this window is the same visit; a return after it is a new view.
     public static readonly TimeSpan ViewWindow = TimeSpan.FromMinutes(15);
 
     /// <summary>
-    /// Recording a view has no failure mode, so this returns counts directly instead of a
-    /// Result: the reader's own count before this visit (signed-in readers get their
-    /// cross-device total, anonymous readers just this browser's) plus the post's total.
+    /// Records the visit and returns the reader's own count before it (signed-in readers get their
+    /// cross-device total, anonymous readers just this browser's) plus the post's totals. Fails with
+    /// VisitorClaimedByAnotherUser when the visitor id already belongs to a different account, so the
+    /// caller mints a fresh id instead of landing this view on someone else's row.
     /// </summary>
-    public async Task<RecordBlogPostViewResult> RecordAndSave(RecordBlogPostViewCommand command, CancellationToken ct)
+    public async Task<Result<RecordBlogPostViewResult, RecordBlogPostViewError>> RecordAndSave(
+        RecordBlogPostViewCommand command, CancellationToken ct)
     {
         var id = BlogPostVisitorView.IdFor(command.Slug, command.VisitorId);
         var view = await session.LoadAsync<BlogPostVisitorView>(id, ct);
+
+        // A row owned by another account means this visitor id is shared; refuse rather than count
+        // the visit against someone else's row or echo back their private total.
+        if (view is not null && view.UserId is not null && view.UserId != command.UserId)
+            return RecordBlogPostViewError.VisitorClaimedByAnotherUser;
+
         if (view is null)
         {
             view = new BlogPostVisitorView
@@ -58,10 +72,7 @@ public class RecordBlogPostViewHandler(IDocumentSession session)
             : view.ViewCount;
         var postTotal = await session.Query<BlogPostVisitorView>().Where(v => v.Slug == command.Slug).SumAsync(v => v.ViewCount, ct);
         var uniqueVisitors = await session.CountDistinctViewersAsync(command.Slug, ct);
-        // The current view is in readerTotal only when its row is the reader's own (a shared
-        // browser's row can belong to another account), so subtract it only then.
-        var currentViewCounted = command.UserId is null || view.UserId == command.UserId;
-        var previousViewCount = currentViewCounted ? readerTotal - 1 : readerTotal;
-        return new RecordBlogPostViewResult(previousViewCount, postTotal, uniqueVisitors);
+        // The conflict guard above ensures this row is the reader's own, so it's in readerTotal.
+        return new RecordBlogPostViewResult(readerTotal - 1, postTotal, uniqueVisitors);
     }
 }

--- a/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
+++ b/backend/src/Kalandra.Blog/Commands/RecordBlogPostView.cs
@@ -58,8 +58,10 @@ public class RecordBlogPostViewHandler(IDocumentSession session)
             : view.ViewCount;
         var postTotal = await session.Query<BlogPostVisitorView>().Where(v => v.Slug == command.Slug).SumAsync(v => v.ViewCount, ct);
         var uniqueVisitors = await session.CountDistinctViewersAsync(command.Slug, ct);
-        // A shared browser's view row can already belong to another account, leaving this
-        // reader's total at 0 — clamp so the label never reads "read -1 times".
-        return new RecordBlogPostViewResult(Math.Max(0, readerTotal - 1), postTotal, uniqueVisitors);
+        // The current view is in readerTotal only when its row is the reader's own (a shared
+        // browser's row can belong to another account), so subtract it only then.
+        var currentViewCounted = command.UserId is null || view.UserId == command.UserId;
+        var previousViewCount = currentViewCounted ? readerTotal - 1 : readerTotal;
+        return new RecordBlogPostViewResult(previousViewCount, postTotal, uniqueVisitors);
     }
 }

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -264,16 +264,17 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
     public async Task RecordView_OnBrowserRowOwnedByAnotherAccount_ReportsZeroPriorReads_NotNegative()
     {
         var slug = NewSlug();
-        var sharedVisitor = Guid.NewGuid();
 
-        // Account A reads on this browser, stamping the (slug, visitor) row to A.
+        // The visitor id is the browser's identity; sign-in layers on top and never rotates it (only
+        // sign-out does), so two accounts share one id only via a session swap with no sign-out between.
+        SetVisitor(Guid.NewGuid());
+
+        // A signs in first and reads, stamping this browser's row to A.
         Authenticate(userId: Guid.NewGuid(), email: "shared-owner@test.com");
-        SetVisitor(sharedVisitor);
         await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
 
-        // Account B reads on the SAME visitor id — only reachable via a session swap with no
-        // sign-out, since the UI rotates the id on sign-out. B's view lands on A's row, so B
-        // owns no row for this post: prior reads read as 0 ("not read yet"), never -1.
+        // B swaps in on the same browser and reads: the view lands on A's row, so B owns no row
+        // for this post. Prior reads read as 0 ("not read yet"), never -1.
         Authenticate(userId: Guid.NewGuid(), email: "shared-guest@test.com");
         var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
 
@@ -286,23 +287,21 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         var slug = NewSlug();
         var readerB = Guid.NewGuid();
 
-        // B has read the post once before, on their own browser.
-        Authenticate(userId: readerB, email: "own-device-reader@test.com");
+        // B reads once on their own browser.
         SetVisitor(Guid.NewGuid());
-        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
-
-        // A owns a different browser's row for the same post.
-        var sharedVisitor = Guid.NewGuid();
-        Authenticate(userId: Guid.NewGuid(), email: "other-owner@test.com");
-        SetVisitor(sharedVisitor);
-        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
-
-        // B reads again on A's browser: their genuine prior read still counts, so it reads
-        // "read once" — a plain readerTotal-1 (or a clamp-to-zero) would undercount it to 0.
         Authenticate(userId: readerB, email: "own-device-reader@test.com");
-        SetVisitor(sharedVisitor);
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // On a second, shared browser, A reads first (stamping that browser's row to A), then B
+        // swaps in on the same browser without a sign-out and reads.
+        SetVisitor(Guid.NewGuid());
+        Authenticate(userId: Guid.NewGuid(), email: "other-owner@test.com");
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+        Authenticate(userId: readerB, email: "own-device-reader@test.com");
         var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
 
+        // B's genuine prior read still counts — "read once", not the "not read yet" that a plain
+        // readerTotal-1 (or the old clamp-to-zero) would undercount it to.
         Assert.Equal(1, response.GetProperty("previousViewCount").GetInt32());
     }
 

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -260,6 +260,52 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Assert.Equal(0, response.GetProperty("previousViewCount").GetInt32());
     }
 
+    [Fact]
+    public async Task RecordView_OnBrowserRowOwnedByAnotherAccount_ReportsZeroPriorReads_NotNegative()
+    {
+        var slug = NewSlug();
+        var sharedVisitor = Guid.NewGuid();
+
+        // Account A reads on this browser, stamping the (slug, visitor) row to A.
+        Authenticate(userId: Guid.NewGuid(), email: "shared-owner@test.com");
+        SetVisitor(sharedVisitor);
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // Account B reads on the SAME visitor id — only reachable via a session swap with no
+        // sign-out, since the UI rotates the id on sign-out. B's view lands on A's row, so B
+        // owns no row for this post: prior reads read as 0 ("not read yet"), never -1.
+        Authenticate(userId: Guid.NewGuid(), email: "shared-guest@test.com");
+        var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
+
+        Assert.Equal(0, response.GetProperty("previousViewCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task RecordView_OnBrowserOwnedByAnother_StillCountsTheReadersOwnPriorReads()
+    {
+        var slug = NewSlug();
+        var readerB = Guid.NewGuid();
+
+        // B has read the post once before, on their own browser.
+        Authenticate(userId: readerB, email: "own-device-reader@test.com");
+        SetVisitor(Guid.NewGuid());
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // A owns a different browser's row for the same post.
+        var sharedVisitor = Guid.NewGuid();
+        Authenticate(userId: Guid.NewGuid(), email: "other-owner@test.com");
+        SetVisitor(sharedVisitor);
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // B reads again on A's browser: their genuine prior read still counts, so it reads
+        // "read once" — a plain readerTotal-1 (or a clamp-to-zero) would undercount it to 0.
+        Authenticate(userId: readerB, email: "own-device-reader@test.com");
+        SetVisitor(sharedVisitor);
+        var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
+
+        Assert.Equal(1, response.GetProperty("previousViewCount").GetInt32());
+    }
+
     // ───── Visitor link (anonymous → account attribution) ─────
 
     [Fact]

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -261,28 +261,46 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
     }
 
     [Fact]
-    public async Task RecordView_OnBrowserRowOwnedByAnotherAccount_ReportsZeroPriorReads_NotNegative()
+    public async Task RecordView_SignedInOnBrowserOwnedByAnotherAccount_Returns409()
     {
         var slug = NewSlug();
 
-        // The visitor id is the browser's identity; sign-in layers on top and never rotates it (only
-        // sign-out does), so two accounts share one id only via a session swap with no sign-out between.
+        // The visitor id is the browser's identity; sign-in layers on top and only rotates on
+        // sign-out, so two accounts share one id only via a session swap with no sign-out between.
         SetVisitor(Guid.NewGuid());
 
         // A signs in first and reads, stamping this browser's row to A.
         Authenticate(userId: Guid.NewGuid(), email: "shared-owner@test.com");
         await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
 
-        // B swaps in on the same browser and reads: the view lands on A's row, so B owns no row
-        // for this post. Prior reads read as 0 ("not read yet"), never -1.
+        // B swaps in on the same browser: the backend refuses rather than count B's view against A's
+        // row, signalling the client to mint a fresh visitor id.
         Authenticate(userId: Guid.NewGuid(), email: "shared-guest@test.com");
-        var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
+        var response = await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
 
-        Assert.Equal(0, response.GetProperty("previousViewCount").GetInt32());
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
-    public async Task RecordView_OnBrowserOwnedByAnother_StillCountsTheReadersOwnPriorReads()
+    public async Task RecordView_AnonymousOnBrowserOwnedByAnAccount_Returns409()
+    {
+        var slug = NewSlug();
+        SetVisitor(Guid.NewGuid());
+
+        // The row belongs to a signed-in account.
+        Authenticate(userId: Guid.NewGuid(), email: "row-owner@test.com");
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // An anonymous view on the same id is refused too — otherwise it would count against the
+        // account's row and echo back its private read count.
+        SignOut();
+        var response = await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RecordView_WithAFreshVisitorAfterConflict_CountsTheReadersOwnPriorReads()
     {
         var slug = NewSlug();
         var readerB = Guid.NewGuid();
@@ -292,16 +310,21 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Authenticate(userId: readerB, email: "own-device-reader@test.com");
         await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
 
-        // On a second, shared browser, A reads first (stamping that browser's row to A), then B
-        // swaps in on the same browser without a sign-out and reads.
+        // A owns a second, shared browser's row for the same post.
         SetVisitor(Guid.NewGuid());
         Authenticate(userId: Guid.NewGuid(), email: "other-owner@test.com");
         await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // B reads on that shared browser and is refused (409).
         Authenticate(userId: readerB, email: "own-device-reader@test.com");
+        var conflict = await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+        Assert.Equal(HttpStatusCode.Conflict, conflict.StatusCode);
+
+        // The client mints a fresh id and retries, landing on B's own new row — their one prior read
+        // still counts, so it reads "read once".
+        SetVisitor(Guid.NewGuid());
         var response = await ParseJsonAsync(await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct));
 
-        // B's genuine prior read still counts — "read once", not the "not read yet" that a plain
-        // readerTotal-1 (or the old clamp-to-zero) would undercount it to.
         Assert.Equal(1, response.GetProperty("previousViewCount").GetInt32());
     }
 

--- a/frontend/src/components/blog/BlogReadStatus.vue
+++ b/frontend/src/components/blog/BlogReadStatus.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from "vue";
 import { getAccessToken, getCurrentUser } from "../../lib/auth";
-import { ensureVisitorLinked, visitorHeaders } from "../../lib/visitor";
+import { ensureVisitorLinked, resetVisitorId, visitorHeaders } from "../../lib/visitor";
 import MaterialIcon from "../icons/MaterialIcon.vue";
 import { materialSymbolPaths as paths } from "../icons/material-symbol-paths";
 
@@ -36,10 +36,19 @@ async function recordView(user: any) {
 
   try {
     const token = user ? await getAccessToken() : null;
-    const res = await fetch(`${props.apiUrl}/api/blog/${props.slug}/views`, {
+    let res = await fetch(`${props.apiUrl}/api/blog/${props.slug}/views`, {
       method: "POST",
       headers: visitorHeaders(token),
     });
+    // 409: this visitor id is already bound to another account — mint a fresh one and retry so the
+    // view lands on this reader's own row.
+    if (res.status === 409) {
+      resetVisitorId();
+      res = await fetch(`${props.apiUrl}/api/blog/${props.slug}/views`, {
+        method: "POST",
+        headers: visitorHeaders(token),
+      });
+    }
     if (!res.ok) return;
     const data: { previousViewCount: number; totalViews: number; uniqueVisitors: number } = await res.json();
     totalViews.value = data.totalViews;

--- a/frontend/src/components/blog/BlogReadStatus.vue
+++ b/frontend/src/components/blog/BlogReadStatus.vue
@@ -48,6 +48,12 @@ async function recordView(user: any) {
         method: "POST",
         headers: visitorHeaders(token),
       });
+      // A brand-new visitor id can't already be claimed, so a second failure is a real anomaly.
+      if (!res.ok) {
+        window.observability?.captureException(new Error(`Blog view retry after 409 failed with ${res.status}`), {
+          slug: props.slug,
+        });
+      }
     }
     if (!res.ok) return;
     const data: { previousViewCount: number; totalViews: number; uniqueVisitors: number } = await res.json();

--- a/frontend/src/lib/observability.ts
+++ b/frontend/src/lib/observability.ts
@@ -119,14 +119,20 @@ export function track(event: string, data?: EventData): void {
   });
 }
 
+/** Capture an unexpected error as a Sentry issue, with optional context shown on its `extra` panel. */
+export function captureException(error: unknown, context?: EventData): void {
+  sentryReady?.then((Sentry) => Sentry.captureException(error, context ? { extra: context } : undefined));
+}
+
 // Exposed for `define:vars` inline scripts in Astro pages, which can't import ES modules.
-(window as any).observability = { identifyUser, track };
+(window as any).observability = { identifyUser, track, captureException };
 
 declare global {
   interface Window {
     observability?: {
       identifyUser: typeof identifyUser;
       track: typeof track;
+      captureException: typeof captureException;
     };
   }
 }

--- a/frontend/src/lib/visitor.ts
+++ b/frontend/src/lib/visitor.ts
@@ -28,9 +28,12 @@ export function getVisitorId(): string {
   }
 }
 
-// A fresh anonymous session on sign-out: later activity on a shared computer can't be
-// attributed to the account that just signed out.
-function rotateVisitorId(): void {
+/**
+ * Mints and stores a fresh visitor id, returning it. Used on sign-out (so a shared computer's later
+ * activity isn't attributed to the account that left) and when a write is refused because the id is
+ * already claimed by another account.
+ */
+export function resetVisitorId(): string {
   const id = crypto.randomUUID();
   try {
     localStorage.setItem(VISITOR_ID_KEY, id);
@@ -38,6 +41,7 @@ function rotateVisitorId(): void {
     // No storage — the in-memory fallback still hands the tab a fresh id.
   }
   cachedVisitorId = id;
+  return id;
 }
 
 /** Adds the visitor header (and, when signed in, the bearer token) to a blog API request. */
@@ -86,7 +90,7 @@ if (typeof window !== "undefined" && !(window as any).__blogVisitorRotationWired
   let wasSignedIn = false;
   window.addEventListener("auth-change", (event) => {
     const signedIn = !!(event as CustomEvent).detail?.user;
-    if (wasSignedIn && !signedIn) rotateVisitorId();
+    if (wasSignedIn && !signedIn) resetVisitorId();
     wasSignedIn = signedIn;
   });
 }


### PR DESCRIPTION
## Problem

A blog view row is keyed by `(slug, visitorId)` and stamped to a single account. If a signed-in reader's view lands on a row already owned by a *different* account, the old code would:

- increment **that account's** `ViewCount` (polluting their public count), and
- compute the reader's `previousViewCount` as `readerTotal - 1 = -1` (PR #206 clamped this to hide the `-1`, which also silently undercounted a returning reader).

An anonymous view on such a row would additionally echo back the owner's private read total.

## Reachability

This requires two accounts on one visitor id with **no sign-out between them** — the UI rotates the visitor id on sign-out (`frontend/src/lib/visitor.ts`), so normal account switching never shares an id. It's reachable only via a session swap with no sign-out (a programmatic `signInWithPassword`, an auth callback landing while another account is active, or a stale visitor id against a reset Supabase user). Not reachable through normal UI use — but the handler receives `visitorId`/`userId` as independent inputs and shouldn't trust the frontend to have rotated.

## Fix

Refuse the mismatched write instead of tolerating it:

- **Handler** — before any mutation, if the row's `UserId` is non-null and differs from the requester, return `VisitorClaimedByAnotherUser`. No increment, no leak.
- **Controller** — maps it to **409 Conflict**.
- **Frontend** — on a 409 from `POST …/views`, mints a fresh visitor id and retries once, so the read lands on the reader's own row and the browser self-heals to a clean identity.
- With the mismatch refused before any write, the count reverts to the original `readerTotal - 1` (always correct past the guard). The PR-#206 clamp and my earlier conditional both only treated the symptom.

Scope is views only: signed-in reactions are keyed by `userId`, not `visitorId`, so they don't share this collision.

## Tests

Three integration tests in `BlogApiTests` reproduce the exact condition (two accounts staged on one visitor id):

- signed-in view on another account's row → **409**
- anonymous view on an owned row → **409** (guards the read-total leak)
- after the 409, a fresh visitor id → **200**, and the reader's own prior reads still count (`previousViewCount = 1`)

Full backend suite green (199 tests). Changed frontend files are Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
