### PR TITLE
Run locally with the Aspire CLI, not an npm script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ Personal showcase website at [www.kalandra.tech](https://www.kalandra.tech). See
 ## Commands (from repo root)
 
 ```bash
-npm install                          # Root + frontend deps (via postinstall)
-npm run aspire                       # PostgreSQL (Aspire-owned, per-worktree) + local Supabase + backend + frontend, all orchestrated by the Aspire AppHost (dashboard, traces, metrics). Supports parallel worktrees via KALANDRA_PORT_OFFSET.
+npm install                          # Optional — populate node_modules for editors; `aspire run` installs deps itself
+aspire run                           # PostgreSQL (Aspire-owned, per-worktree) + local Supabase + backend + frontend, all orchestrated by the Aspire AppHost (dashboard, traces, metrics). Runs `npm install` itself. Supports parallel worktrees via KALANDRA_PORT_OFFSET.
 npm test                             # All tests: backend + frontend + E2E
 dotnet build                         # Backend only
 npm --prefix frontend run build      # Frontend only
 ```
 
-**When asked to run the app for manual testing, always start the full stack with `npm run aspire`** — never the frontend dev server alone. Without the backend, every API-backed feature (comments, reactions, job offers) fails with a 502 from the Vite proxy.
+**When asked to run the app for manual testing, always start the full stack with `aspire run`** — never the frontend dev server alone. Without the backend, every API-backed feature (comments, reactions, job offers) fails with a 502 from the Vite proxy.
 
 **Run `npm test` when a change touches logic or structure.** Content-only changes (blog copy, translations, page text) don't need the suite locally. When you do run tests, run the full suite — no subsets (`dotnet test`, `npm --prefix frontend test`, etc.) as a substitute. Pushing and letting CI run the tests is a viable strategy; what's non-negotiable is a PR left sitting with a failing build — after pushing, check the CI result and fix any failure.
 

--- a/aspire/Kalandra.AppHost/DevInfrastructure.cs
+++ b/aspire/Kalandra.AppHost/DevInfrastructure.cs
@@ -9,12 +9,8 @@ internal static class DevInfrastructure
     {
         var repoRoot = FindRepoRoot();
 
-        // Skip when launched under `npm run` — the parent npm already ran install.
-        if (Environment.GetEnvironmentVariable("npm_lifecycle_event") is null)
-        {
-            Console.WriteLine("Installing npm dependencies (root + frontend)...");
-            RunNpm(repoRoot, "install");
-        }
+        Console.WriteLine("Installing npm dependencies (root + frontend)...");
+        RunNpm(repoRoot, "install");
 
         Console.WriteLine("Starting Supabase...");
         RunSupabase(repoRoot, "start");
@@ -40,7 +36,7 @@ internal static class DevInfrastructure
             WorkingDirectory = repoRoot,
             UseShellExecute = false,
         };
-        // Inherited npm_* vars from a parent `npm run` can misdirect the nested CLI; strip them.
+        // Strip any inherited npm_* vars so a parent npm process can't misdirect this nested CLI.
         foreach (var key in psi.Environment.Keys.Where(k => k.StartsWith("npm_", StringComparison.OrdinalIgnoreCase)).ToList())
         {
             psi.Environment.Remove(key);

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -52,12 +52,17 @@ For architecture, tech stack, and decision log, see the [Project page](https://w
 ### 1.1 Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- The [Aspire CLI](https://aspire.dev/) — launches the AppHost that orchestrates the whole local stack. Install once as a .NET global tool:
+  ```bash
+  dotnet tool install --global aspire.cli
+  ```
 - [Docker](https://docs.docker.com/get-docker/) (for PostgreSQL + local Supabase)
 - [Node.js 22+](https://nodejs.org/)
 
 ### 1.2 Install Dependencies
 
-Run once after cloning (or when dependencies change):
+No manual step is required — `aspire run` (below) runs `npm install` for you on every start.
+To populate `node_modules` up front for editor tooling, you can still run it by hand:
 
 ```bash
 npm install            # Installs root + frontend dependencies (via postinstall)
@@ -66,10 +71,10 @@ npm install            # Installs root + frontend dependencies (via postinstall)
 ### 1.3 Start Everything
 
 ```bash
-npm run aspire   # Installs deps, starts PostgreSQL + local Supabase, then launches the Aspire AppHost
+aspire run   # Runs npm install, starts PostgreSQL + local Supabase, then launches the AppHost
 ```
 
-The Aspire AppHost orchestrates the API and frontend and exposes the Aspire dashboard with per-resource logs, distributed traces (OpenTelemetry), metrics, and structured logs in one UI. The dashboard and frontend URLs are printed (clickably, in supporting terminals) on startup. Production telemetry is routed to **Sentry** via the OTEL bridge (see [Observability](#observability)); nothing about that changes when running locally under Aspire.
+The Aspire CLI builds and launches the AppHost, which owns the entire local stack: it runs `npm install`, brings up the CLI-managed Supabase stack, and orchestrates the API and frontend. It exposes the Aspire dashboard with per-resource logs, distributed traces (OpenTelemetry), metrics, and structured logs in one UI. The dashboard and frontend URLs are printed (clickably, in supporting terminals) on startup. Production telemetry is routed to **Sentry** via the OTEL bridge (see [Observability](#observability)); nothing about that changes when running locally under Aspire.
 
 Supabase containers stay owned by the Supabase CLI — `Ctrl+C`-ing the AppHost would otherwise leak them. The AppHost surfaces the API / Studio / Mailpit endpoints on the dashboard as external services (display-only, no lifecycle), so you get one-click access without the cleanup risk. Use `supabase stop` to halt the stack, or `supabase stop --no-backup` to discard data.
 
@@ -100,7 +105,7 @@ PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 PUBLIC_TURNSTILE_SITE_KEY=your-real-site-key
 ```
 
-> `PUBLIC_API_URL` is intentionally empty in dev — the Aspire AppHost forces it to `""` so all API calls flow through Vite's `/api` proxy (see [`astro.config.mjs`](../frontend/astro.config.mjs)). Setting it in `.env.local` has no effect under `npm run aspire`. It's only meaningful at production build time (e.g. `https://api.kalandra.tech`).
+> `PUBLIC_API_URL` is intentionally empty in dev — the Aspire AppHost forces it to `""` so all API calls flow through Vite's `/api` proxy (see [`astro.config.mjs`](../frontend/astro.config.mjs)). Setting it in `.env.local` has no effect under `aspire run`. It's only meaningful at production build time (e.g. `https://api.kalandra.tech`).
 
 #### Cloudflare Turnstile (CAPTCHA)
 
@@ -128,7 +133,7 @@ supabase stop --no-backup     # Stop and wipe Supabase state
 
 ### 1.7 Parallel Worktrees
 
-Just run `npm run aspire` in each. The AppHost walks the dashboard / OTLP ports up from their defaults until it finds free ones, so the first instance is at `15036`, the second at `15037`, etc. dcp handles API and frontend ports the same way internally. The startup output prints clickable URLs for the dashboard and frontend.
+Just run `aspire run` in each. The AppHost walks the dashboard / OTLP ports up from their defaults until it finds free ones, so the first instance is at `15036`, the second at `15037`, etc. dcp handles API and frontend ports the same way internally. The startup output prints clickable URLs for the dashboard and frontend.
 
 The application Postgres is per-worktree (Aspire scopes the data volume to the repo-folder name), so each worktree has its own DB state. Supabase is shared (one machine-level instance), so auth users and storage objects are visible across worktrees — that's fine for fixtures.
 
@@ -692,7 +697,7 @@ without needing an `!environment:ci` filter.
 ### 5.3 Local Development
 
 You don't need a Sentry DSN to run the stack locally — but the frontend DSN
-is committed, so by default any `npm run aspire` session will emit
+is committed, so by default any `aspire run` session will emit
 `environment: development` events to Sentry. That's intentional (lets you
 verify changes against real Sentry). To opt out locally, set
 `PUBLIC_SENTRY_DSN=` in `frontend/.env.local`.
@@ -720,5 +725,5 @@ Inputs (see §4.1):
 - `SENTRY_PROJECT` (and optionally `SENTRY_ORG`) repo vars — point the upload at the right Sentry project.
 
 `astro.config.mjs` sets `build.sourcemap: 'hidden'` only when the auth
-token is present, so dev (`npm run aspire`) and CI builds don't generate
+token is present, so dev (`aspire run`) and CI builds don't generate
 `.map` files at all.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "postinstall": "cd frontend && npm install",
     "prepare": "git config core.hooksPath frontend/.githooks",
-    "aspire": "npm install && dotnet run --project aspire/Kalandra.AppHost",
     "test": "dotnet test --verbosity normal && npm --prefix frontend run test:install && npm --prefix frontend test && npm run test:e2e",
     "test:e2e": "docker rm -f kalandra-temporal-e2e && docker run -d --name kalandra-temporal-e2e -p 7233:7233 temporalio/temporal:1.7.2 server start-dev --ip 0.0.0.0 --headless && supabase start && cross-env PUBLIC_API_URL=http://localhost:5000 npm --prefix frontend run build && concurrently --kill-others --success first --names backend,serve,test --prefix-colors blue,yellow,green \"cd backend/src/Kalandra.Api && dotnet run\" \"wait-on http://localhost:5000/health && serve frontend/dist -l 4321\" \"wait-on http://localhost:5000/health && wait-on http://localhost:4321 && npm --prefix frontend run test:e2e\""
   },


### PR DESCRIPTION
## What & why

Make **`aspire run`** the default way to run the stack locally, and drop the `npm run aspire` startup script. The AppHost already owned the entire local environment — it runs `npm install`, brings up the CLI-managed Supabase stack, and orchestrates Postgres, Temporal, the API, and the frontend — so the npm wrapper was just a thin, redundant shell around `dotnet run`. Removing it makes Aspire the single entrypoint and lets `aspire run --isolated`/parallel worktrees be the "one command, isolated environment" story, matching how **hampap** is set up.

## Changes

- **`package.json`** — removed the `aspire` script (`npm install && dotnet run --project aspire/Kalandra.AppHost`). Test scripts (`npm test`, `npm run test:e2e`) and the install hooks (`postinstall`, `prepare`) are untouched.
- **`aspire/Kalandra.AppHost/DevInfrastructure.cs`** — the AppHost now runs `npm install` unconditionally. The old `npm_lifecycle_event` skip existed only so the wrapper's `npm install` wasn't repeated; with no npm wrapper, that branch was dead.
- **`docs/SETUP.md`** — added the **Aspire CLI** as a prerequisite (`dotnet tool install --global aspire.cli`), reframed dependency install as Aspire-owned, and switched every run command to `aspire run`.
- **`CLAUDE.md`** — same command swap in the command table and the manual-testing directive.

## Running it now

```bash
dotnet tool install --global aspire.cli   # one-time
aspire run                                 # installs deps, starts Supabase + the full stack
```

Parallel worktrees: just `aspire run` in each — the AppHost still walks the dashboard/OTLP ports up from their defaults, so instance N gets a free port automatically.

## Why this is safe

The one subtlety: under `aspire run` the CLI talks to the AppHost over a backchannel, but the **AppHost still self-hosts its own dashboard + OTLP endpoints** on its reserved ports (`PortReservation` is unchanged). I verified this empirically — no changes were needed to the port logic, the browser OTLP trace endpoint, or per-worktree isolation.

## Verification

- `dotnet build` of the AppHost — clean.
- `aspire run` end to end: boots the full stack, dashboard at `:15036`, browser OTLP-HTTP endpoint listening at `:19400`, frontend served (HTTP 200). Stopped cleanly via `aspire stop`, no leftover containers.
- Full test suite (`npm test`) is unchanged by this diff and left to CI.

## Out of scope

Test orchestration still runs through npm (`npm test` / `npm run test:e2e`) — this PR only moves the **startup** path onto Aspire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)