### PR TITLE
fix(frontend): keyboard-navigate the incomplete-submit dialog

### DIFF
--- a/frontend/src/pages/[...lang]/hire-me.astro
+++ b/frontend/src/pages/[...lang]/hire-me.astro
@@ -264,6 +264,14 @@ const t = translations[lang];
     </div>
   </dialog>
 
+  <style is:global>
+    /* Outline, not a ring: the focus indicator must stay visible against the primary-filled "Submit anyway" button. */
+    #confirm-incomplete-dialog button:focus {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+  </style>
+
   <script
     define:vars={{
       apiUrl: import.meta.env.PUBLIC_API_URL || "",
@@ -530,6 +538,7 @@ const t = translations[lang];
         function cleanup(result) {
           confirmBtn.removeEventListener("click", onConfirm);
           cancelBtn.removeEventListener("click", onCancel);
+          dialog.removeEventListener("keydown", onDialogArrowNav);
           dialog.removeEventListener("close", onClose);
           if (dialog.open) dialog.close();
           resolve(result);
@@ -544,9 +553,22 @@ const t = translations[lang];
           cleanup(false);
         }
 
+        // Roving focus so arrow keys move between the two actions, not only Tab.
+        var actionButtons = [cancelBtn, confirmBtn];
+        function onDialogArrowNav(e) {
+          if (["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].indexOf(e.key) === -1) return;
+          e.preventDefault();
+          var current = actionButtons.indexOf(document.activeElement);
+          if (current === -1) current = 0;
+          var forward = e.key === "ArrowRight" || e.key === "ArrowDown";
+          actionButtons[(current + (forward ? 1 : -1) + actionButtons.length) % actionButtons.length].focus();
+        }
+
         confirmBtn.addEventListener("click", onConfirm);
         cancelBtn.addEventListener("click", onCancel);
+        dialog.addEventListener("keydown", onDialogArrowNav);
         dialog.addEventListener("close", onClose);
+        // Leave the native focus on "Go back" — the safe default, so Enter can't submit by accident.
         dialog.showModal();
       });
     }


### PR DESCRIPTION
## Problem

On the hire-me form, the **"Submit with missing details?"** confirmation dialog had two keyboard problems:

1. **No visible focus indicator** — you couldn't tell which button was focused, so pressing Enter felt like it "always cancelled" (the browser focuses "Go back" by default).
2. **No way to move focus** between the two buttons except Tab.

## Fix

In `hire-me.astro`:

- **Visible focus outline** on the dialog's buttons — an `outline` with an offset (not a Tailwind `ring`), so it stays visible against the primary-filled "Submit anyway" button in both themes.
- **Arrow keys rove between the two buttons** (Left/Up ↔ Right/Down), on top of the existing Tab and Escape.
- **Keep the native default focus on "Go back"** — the safe action, so Enter can't submit by accident.

## Verification

Drove the real built page in a browser with real keystrokes (window focused):

- Dialog opens with focus on **"Go back"**.
- Real ArrowRight → "Submit anyway"; real ArrowLeft → "Go back".
- The focused button renders `outline: solid 2px` primary with a 2px offset (confirmed via computed style under real system focus; `:focus` only matches when the document is focused, which is why an automated probe without system focus reads `none`).
- `astro build` passes (36 pages); Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
