### PR TITLE
fix(backend): keep a Supabase outage from failing the deploy gate

### DIFF
--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
@@ -6,8 +6,11 @@ namespace Kalandra.Api.Infrastructure;
 
 /// <summary>
 /// Verifies that the Supabase Auth admin API is reachable with the configured
-/// service key. A missing or revoked service key surfaces as Unhealthy instead
-/// of a runtime 401 the first time a user touches auth-admin functionality.
+/// service key, catching a missing or revoked key at /health rather than as a
+/// runtime 401 the first time a user touches auth-admin functionality. Failures
+/// report Degraded, not Unhealthy: the blue/green deploy gate fails on a 503
+/// from /health, and a Supabase Auth outage must not roll back an otherwise
+/// healthy API deploy.
 ///
 /// Exercises the same <see cref="IUserInfoService"/> production uses for
 /// fetching user info, so the health check covers the exact client wiring.
@@ -26,11 +29,11 @@ internal sealed class SupabaseAuthHealthCheck(IUserInfoService userInfoService) 
         }
         catch (TimeoutException ex)
         {
-            return HealthCheckResult.Unhealthy($"Supabase Auth admin API did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
+            return HealthCheckResult.Degraded($"Supabase Auth admin API did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
         }
         catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy(
+            return HealthCheckResult.Degraded(
                 "Supabase Auth admin API rejected the request. Verify Supabase:ProjectUrl and Supabase:ServiceKey.",
                 ex);
         }

--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
@@ -8,7 +8,9 @@ namespace Kalandra.Api.Infrastructure;
 /// Verifies that the Supabase Storage bucket used for job-offer attachments is
 /// reachable with the configured service key. Catches misconfigured project
 /// URLs, revoked service keys, and missing buckets at /health rather than on
-/// the first upload attempt.
+/// the first upload attempt. Failures report Degraded, not Unhealthy: the
+/// blue/green deploy gate fails on a 503 from /health, and a Supabase Storage
+/// outage must not roll back an otherwise healthy API deploy.
 ///
 /// Exercises the same <see cref="IStorageService"/> the production upload path
 /// uses, so the health check is guaranteed to cover the exact client wiring.
@@ -27,11 +29,11 @@ internal sealed class SupabaseStorageHealthCheck(IStorageService storageService)
         }
         catch (TimeoutException ex)
         {
-            return HealthCheckResult.Unhealthy($"Supabase Storage did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
+            return HealthCheckResult.Degraded($"Supabase Storage did not respond within {ProbeTimeout.TotalSeconds:0}s.", ex);
         }
         catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy(
+            return HealthCheckResult.Degraded(
                 "Supabase Storage unreachable. Verify Supabase:ProjectUrl, Supabase:ServiceKey, and that the bucket exists.",
                 ex);
         }

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -67,7 +67,7 @@ builder.Services.AddResponseCompression(options =>
 });
 
 builder.Services.AddHealthChecks()
-    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)
+    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!, timeout: TimeSpan.FromSeconds(5))
     .AddCheck<CommitHashHealthCheck>("version")
     .AddCheck<SupabaseAuthHealthCheck>("supabase-auth")
     .AddCheck<SupabaseStorageHealthCheck>("supabase-storage")


### PR DESCRIPTION
## Why

A production deploy rolled back because the blue/green gate got a **503** from `/health` — Supabase was down, so `supabase-auth`, `supabase-storage`, and `npgsql` all reported `Unhealthy`. Any `Unhealthy` entry makes `/health` return 503, and the gate (`curl -sf … | grep $SHA`) treats that as a failed slot.

## What

- **`supabase-auth` and `supabase-storage` now report `Degraded`, not `Unhealthy`** on failure. Degraded still returns **200** from `/health`, so a Supabase Auth/Storage outage no longer fails the deploy gate — every read path keeps working without them. This mirrors the existing `TemporalHealthCheck`, which already does exactly this for the same reason. Each class's doc comment now records the rationale.
- **The Postgres probe is capped at 5s** (was 15s) via `AddNpgSql(…, timeout: 5s)`, so a slow or unreachable event store fails fast instead of dragging every `/health` call out to 15s.

## Deliberately *not* changed

`npgsql` still reports `Unhealthy` on failure. The app's main DB is the Supabase Postgres, and it is the one hard dependency — the API cannot serve reads without its event store, so a genuine DB outage *should* fail the gate and roll back. The 5s cap just makes each of the gate's retry attempts fail fast, giving a connection storm time to subside between tries.

## Testing

Build passes clean (0 warnings). The `Health_ReturnsOk` / `Health_ReportsTemporalHealthy` integration tests exercise the happy path (fakes' `PingAsync` succeed → status stays Healthy/200), so the failure-path change doesn't affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
