### PR TITLE
feat(blog): confirm a posted comment with a success snackbar

### DIFF
--- a/frontend/src/components/blog/BlogComments.vue
+++ b/frontend/src/components/blog/BlogComments.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
     placeholder: string;
     submit: string;
     submitting: string;
+    posted: string;
     reply: string;
     replyingTo: string;
     cancel: string;
@@ -173,6 +174,7 @@ async function submit() {
     draft.value = "";
     replyTo.value = null;
     pendingCommentId = null;
+    (window as any).__showSnackbar?.(props.t.posted, "success");
   } catch {
     (window as any).__showSnackbar?.(props.t.postError, "error", 8000);
   } finally {

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -60,6 +60,7 @@
     "placeholder": "Napište komentář…",
     "submit": "Odeslat komentář",
     "submitting": "Odesílání…",
+    "posted": "Komentář odeslán.",
     "reply": "Odpovědět",
     "replyingTo": "Odpověď pro:",
     "cancel": "Zrušit",

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -60,6 +60,7 @@
     "placeholder": "Write a comment…",
     "submit": "Post comment",
     "submitting": "Posting…",
+    "posted": "Comment posted.",
     "reply": "Reply",
     "replyingTo": "Replying to",
     "cancel": "Cancel",

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -266,6 +266,11 @@ test.describe("Blog Flow", () => {
     await expect(commentItem).toBeVisible();
     await expect(commentItem).toContainText(testUser.fullName);
 
+    // A success snackbar confirms the post landed.
+    const snackbar = page.locator("#snackbar");
+    await expect(snackbar).toContainText("Comment posted.");
+    await expect(snackbar.locator("> div")).toHaveClass(/bg-tertiary-container/);
+
     // The same Temporal workflow that stored the comment notifies the blog author —
     // the email must land in the local mail catcher.
     await waitForEmail(request, { to: AUTHOR_EMAIL, containing: commentText });


### PR DESCRIPTION
## What & why

Posting a blog comment gave no explicit confirmation — the new comment just appeared in the thread. This adds the app's standard success snackbar (**"Comment posted."** / **"Komentář odeslán."**) after a successful post, so the reader gets clear positive feedback, matching the confirmation UX already used for profile updates, the QR card, etc.

## Changes

- **`BlogComments.vue`** — fire `__showSnackbar(t.posted, "success")` on a successful post; add the `posted` prop.
- **`en/blog.json` / `cs/blog.json`** — new `comments.posted` string.
- **`blog-flow.spec.ts`** — assert the success snackbar (text + success variant) after the signed-in post.

## Notes

- Reuses the existing **semantic `success` snackbar variant** (design system `tertiary` token — a teal-green). No new color or component, per the "never hardcode a color" rule in `frontend.md`. If a truer green is wanted, that's a follow-up design-token change affecting all success toasts.

## Verification

- `astro build` passes (36 pages, blog posts included).
- Prettier clean on all changed files.
- Live behavior is locked in by the extended blog-flow E2E (runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)