### PR TITLE
feat(frontend): collapse and expand blog comment threads

### DIFF
--- a/frontend/src/components/blog/BlogComments.vue
+++ b/frontend/src/components/blog/BlogComments.vue
@@ -25,6 +25,8 @@ const props = defineProps<{
     submitting: string;
     reply: string;
     replyingTo: string;
+    hideReplies: string;
+    showReplies: string;
     cancel: string;
     delete: string;
     deleteConfirm: string;
@@ -55,6 +57,7 @@ const replyTo = ref<CommentDto | null>(null);
 const submitting = ref(false);
 const confirmingDeleteId = ref<string | null>(null);
 const composer = ref<HTMLTextAreaElement | null>(null);
+const collapsed = ref<Set<string>>(new Set());
 
 /** Depth-first flattening of the reply tree — keeps the template a single v-for. */
 const thread = computed(() => {
@@ -65,11 +68,21 @@ const thread = computed(() => {
     byParent.get(key)!.push(comment);
   }
 
-  const flat: { comment: CommentDto; depth: number }[] = [];
+  const replyCounts = new Map<string, number>();
+  const countDescendants = (id: string): number => {
+    let total = 0;
+    for (const child of byParent.get(id) ?? []) total += 1 + countDescendants(child.id);
+    replyCounts.set(id, total);
+    return total;
+  };
+  for (const root of byParent.get(null) ?? []) countDescendants(root.id);
+
+  const flat: { comment: CommentDto; depth: number; replies: number; isCollapsed: boolean }[] = [];
   const walk = (parentId: string | null, depth: number) => {
     for (const comment of byParent.get(parentId) ?? []) {
-      flat.push({ comment, depth });
-      walk(comment.id, depth + 1);
+      const isCollapsed = collapsed.value.has(comment.id);
+      flat.push({ comment, depth, replies: replyCounts.get(comment.id) ?? 0, isCollapsed });
+      if (!isCollapsed) walk(comment.id, depth + 1);
     }
   };
   walk(null, 0);
@@ -129,6 +142,11 @@ function startReply(comment: CommentDto) {
   composer.value?.focus();
 }
 
+function toggleCollapse(id: string) {
+  if (collapsed.value.has(id)) collapsed.value.delete(id);
+  else collapsed.value.add(id);
+}
+
 // Reused across retries of the current draft so a resend dedupes into one comment server-side.
 let pendingCommentId: string | null = null;
 
@@ -170,6 +188,8 @@ async function submit() {
     }
     const created: CommentDto = await res.json();
     comments.value = [...comments.value, created];
+    // Expand the parent so a reply posted into a collapsed thread stays visible.
+    if (created.parentCommentId) collapsed.value.delete(created.parentCommentId);
     draft.value = "";
     replyTo.value = null;
     pendingCommentId = null;
@@ -282,7 +302,7 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
     </p>
     <ul v-else class="space-y-5" role="list">
       <li
-        v-for="{ comment, depth } in thread"
+        v-for="{ comment, depth, replies, isCollapsed } in thread"
         :key="comment.id"
         :style="{ marginLeft: `${Math.min(depth, 4) * 1.25}rem` }"
         :class="depth > 0 ? 'border-l-2 border-outline-variant/30 pl-4' : ''"
@@ -325,33 +345,53 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
             </p>
             <p v-else class="font-body text-sm italic text-on-surface-variant/60 mt-1">{{ props.t.deleted }}</p>
 
-            <div v-if="!comment.isDeleted" class="flex items-center gap-4 mt-2">
+            <div v-if="!comment.isDeleted || replies > 0" class="flex items-center gap-4 mt-2">
               <button
-                v-if="viewerId"
+                v-if="replies > 0"
                 type="button"
-                class="text-xs font-label text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
-                @click="startReply(comment)"
+                class="flex items-center gap-1 text-xs font-label text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
+                :aria-expanded="!isCollapsed"
+                @click="toggleCollapse(comment.id)"
               >
-                {{ props.t.reply }}
-              </button>
-              <template v-if="canDelete(comment)">
-                <button
-                  v-if="confirmingDeleteId !== comment.id"
-                  type="button"
-                  class="text-xs font-label text-on-surface-variant hover:text-error transition-colors cursor-pointer"
-                  @click="confirmingDeleteId = comment.id"
+                <svg
+                  viewBox="0 0 24 24"
+                  class="size-3.5 transition-transform"
+                  :class="{ '-rotate-90': isCollapsed }"
+                  fill="currentColor"
+                  aria-hidden="true"
                 >
-                  {{ props.t.delete }}
+                  <path d="M7 10l5 5 5-5z" />
+                </svg>
+                <span>{{ isCollapsed ? `${props.t.showReplies} (${replies})` : props.t.hideReplies }}</span>
+              </button>
+              <template v-if="!comment.isDeleted">
+                <button
+                  v-if="viewerId"
+                  type="button"
+                  class="text-xs font-label text-on-surface-variant hover:text-primary transition-colors cursor-pointer"
+                  @click="startReply(comment)"
+                >
+                  {{ props.t.reply }}
                 </button>
-                <span v-else class="flex items-center gap-2 text-xs font-label">
-                  <span class="text-on-surface-variant">{{ props.t.deleteConfirm }}</span>
-                  <button type="button" class="text-error hover:underline cursor-pointer" @click="removeComment(comment)">
-                    {{ props.t.deleteYes }}
+                <template v-if="canDelete(comment)">
+                  <button
+                    v-if="confirmingDeleteId !== comment.id"
+                    type="button"
+                    class="text-xs font-label text-on-surface-variant hover:text-error transition-colors cursor-pointer"
+                    @click="confirmingDeleteId = comment.id"
+                  >
+                    {{ props.t.delete }}
                   </button>
-                  <button type="button" class="text-on-surface-variant hover:underline cursor-pointer" @click="confirmingDeleteId = null">
-                    {{ props.t.deleteNo }}
-                  </button>
-                </span>
+                  <span v-else class="flex items-center gap-2 text-xs font-label">
+                    <span class="text-on-surface-variant">{{ props.t.deleteConfirm }}</span>
+                    <button type="button" class="text-error hover:underline cursor-pointer" @click="removeComment(comment)">
+                      {{ props.t.deleteYes }}
+                    </button>
+                    <button type="button" class="text-on-surface-variant hover:underline cursor-pointer" @click="confirmingDeleteId = null">
+                      {{ props.t.deleteNo }}
+                    </button>
+                  </span>
+                </template>
               </template>
             </div>
           </div>

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -62,6 +62,8 @@
     "submitting": "Odesílání…",
     "reply": "Odpovědět",
     "replyingTo": "Odpověď pro:",
+    "hideReplies": "Skrýt odpovědi",
+    "showReplies": "Zobrazit odpovědi",
     "cancel": "Zrušit",
     "delete": "Smazat",
     "deleteConfirm": "Smazat tento komentář?",

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -62,6 +62,8 @@
     "submitting": "Posting…",
     "reply": "Reply",
     "replyingTo": "Replying to",
+    "hideReplies": "Hide replies",
+    "showReplies": "Show replies",
     "cancel": "Cancel",
     "delete": "Delete",
     "deleteConfirm": "Delete this comment?",

--- a/frontend/tests/e2e/blog-flow.spec.ts
+++ b/frontend/tests/e2e/blog-flow.spec.ts
@@ -281,6 +281,12 @@ test.describe("Blog Flow", () => {
     // Self-reply: the blog author is notified, the parent author (same user) is not.
     await waitForEmail(request, { to: AUTHOR_EMAIL, containing: replyText });
 
+    // Collapsing the parent hides its replies; expanding brings them back.
+    await commentItem.getByRole("button", { name: "Hide replies" }).click();
+    await expect(replyItem).toBeHidden();
+    await commentItem.getByRole("button", { name: /^Show replies/ }).click();
+    await expect(replyItem).toBeVisible();
+
     // Delete the reply — inline confirm, then the tombstone placeholder takes its place.
     await replyItem.getByRole("button", { name: "Delete" }).click();
     await replyItem.getByRole("button", { name: "Delete" }).click();


### PR DESCRIPTION
## What & why

Adds UI to collapse and expand comment threads on blog posts, so readers can scan top-level comments and expand only the threads they care about.

## Behavior

- Any comment **with replies** gets a chevron toggle. Expanded shows **Hide replies**; collapsed shows **Show replies (N)**, where N is the total number of hidden descendants.
- Collapsing works at **any depth** — a top-level toggle folds the whole thread; a nested toggle folds just that sub-thread.
- A **deleted** comment that still has replies keeps its toggle, so a tombstoned parent's thread can still be folded.
- Posting a reply **auto-expands** its parent, so a new reply can never land inside a collapsed thread.
- Pure view control — available to all readers, no sign-in required.

## Implementation

- The existing `thread` computed (depth-first flatten) now counts descendants per comment and stops the walk at collapsed nodes, so hidden rows are simply omitted from the single `v-for`. Collapse state is a `Set<string>` of comment ids.
- Accessibility: the toggle carries `aria-expanded`, the chevron is `aria-hidden`, and the visible label is its accessible name.
- i18n: `hideReplies` / `showReplies` added in English and Czech.

## Testing

- Prettier clean; `astro build` compiles the island and all pages; 25/25 frontend page tests pass.
- Extended the blog-flow E2E: collapse the parent, assert the reply hides, expand, assert it returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)