### PR TITLE
fix(backend): gate the deploy on liveness so infra outages don't block it

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -439,12 +439,13 @@ jobs:
             systemctl --user stop "kalandra-api-${NEW}.service" || true
             systemctl --user start "kalandra-api-${NEW}.service"
 
-            # ----- 5. Health check the new slot directly (bypassing Caddy) -----
-            # Match the deployed commit, not just any healthy response, so a
-            # stale container from an earlier deploy can't pass this gate.
+            # ----- 5. Liveness-gate the new slot directly (bypassing Caddy) -----
+            # Gate on /health/live (process up + expected commit), not /health: a shared
+            # DB/Temporal outage breaks both slots equally and must not strand a good build.
+            # The commit match still blocks a stale container from an earlier deploy.
             echo "Waiting for new slot on port $NEW_PORT (expecting commit $EXPECTED_SHA)..."
             ATTEMPTS=0
-            until curl -sf "http://localhost:${NEW_PORT}/health" 2>/dev/null | grep -qF "$EXPECTED_SHA"; do
+            until curl -sf "http://localhost:${NEW_PORT}/health/live" 2>/dev/null | grep -qF "$EXPECTED_SHA"; do
               ATTEMPTS=$((ATTEMPTS + 1))
               if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
                 echo "New slot failed to start. Container logs:"
@@ -458,13 +459,13 @@ jobs:
               echo "Attempt $ATTEMPTS/$MAX_ATTEMPTS — waiting 3s..."
               sleep 3
             done
-            echo "New slot is healthy on port $NEW_PORT."
+            echo "New slot is live on port $NEW_PORT (running $EXPECTED_SHA)."
 
-            # Degraded still returns 200 and passes the gate by design (a Temporal outage must
-            # not roll back an API deploy) — but surface it as a pipeline warning, not silence.
-            SLOT_STATUS=$(curl -sf "http://localhost:${NEW_PORT}/health" 2>/dev/null | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+            # The gate is liveness-only, so a slot promotes even while readiness is degraded or
+            # unhealthy (DB/Temporal/Supabase down). Surface the full /health status as a warning.
+            SLOT_STATUS=$(curl -s "http://localhost:${NEW_PORT}/health" 2>/dev/null | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
             if [ "$SLOT_STATUS" != "Healthy" ]; then
-              echo "::warning::New slot passed the gate but reports '${SLOT_STATUS:-unknown}' — check the /health entries (e.g. Temporal)."
+              echo "::warning::New slot is live but /health reports '${SLOT_STATUS:-unknown}' — check its dependencies (DB, Temporal, Supabase)."
             fi
 
             # ----- 6. Point our site at the new port (promotion) and reload -----
@@ -510,7 +511,9 @@ jobs:
       - name: Verify public endpoint
         uses: KaliCZ/verify-deployment@57cf981c4f0d8c4096fcba5308521e85f204da11  # v1
         with:
-          health-url: https://api.kalandra.tech/health
+          # Liveness, matching the deploy gate — confirms Caddy serves the new commit publicly
+          # without failing on a dependency outage that would break either slot.
+          health-url: https://api.kalandra.tech/health/live
           max-attempts: 20
           retry-interval: 5
           expected-content: ${{ github.sha }}

--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseAuthHealthCheck.cs
@@ -8,9 +8,8 @@ namespace Kalandra.Api.Infrastructure;
 /// Verifies that the Supabase Auth admin API is reachable with the configured
 /// service key, catching a missing or revoked key at /health rather than as a
 /// runtime 401 the first time a user touches auth-admin functionality. Failures
-/// report Degraded, not Unhealthy: the blue/green deploy gate fails on a 503
-/// from /health, and a Supabase Auth outage must not roll back an otherwise
-/// healthy API deploy.
+/// report Degraded, not Unhealthy: auth-admin breaks while the rest of the API
+/// keeps serving, so readiness is partial, not down.
 ///
 /// Exercises the same <see cref="IUserInfoService"/> production uses for
 /// fetching user info, so the health check covers the exact client wiring.

--- a/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/SupabaseStorageHealthCheck.cs
@@ -8,9 +8,8 @@ namespace Kalandra.Api.Infrastructure;
 /// Verifies that the Supabase Storage bucket used for job-offer attachments is
 /// reachable with the configured service key. Catches misconfigured project
 /// URLs, revoked service keys, and missing buckets at /health rather than on
-/// the first upload attempt. Failures report Degraded, not Unhealthy: the
-/// blue/green deploy gate fails on a 503 from /health, and a Supabase Storage
-/// outage must not roll back an otherwise healthy API deploy.
+/// the first upload attempt. Failures report Degraded, not Unhealthy: uploads
+/// break while the rest of the API keeps serving, so readiness is partial, not down.
 ///
 /// Exercises the same <see cref="IStorageService"/> the production upload path
 /// uses, so the health check is guaranteed to cover the exact client wiring.

--- a/backend/src/Kalandra.Api/Infrastructure/TemporalHealthCheck.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/TemporalHealthCheck.cs
@@ -6,10 +6,8 @@ namespace Kalandra.Api.Infrastructure;
 /// <summary>
 /// Verifies the Temporal server is reachable over gRPC. Blog-comment and
 /// job-offer submissions run through Temporal workflows, so an unreachable
-/// server breaks those writes while every read path keeps working — which is
-/// why failures report Degraded, not Unhealthy: the blue/green deploy gate
-/// fails on a 503 from /health, and a Temporal outage must not roll back an
-/// unrelated API deploy.
+/// server breaks those writes while every read path keeps working — hence
+/// Degraded, not Unhealthy: readiness is partial, not down.
 /// </summary>
 internal sealed class TemporalHealthCheck(ITemporalClient temporalClient) : IHealthCheck
 {

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -66,12 +66,17 @@ builder.Services.AddResponseCompression(options =>
     options.EnableForHttps = true;
 });
 
+// A background worker faulting (e.g. Temporal unreachable) must not stop the whole API host.
+builder.Services.Configure<HostOptions>(
+    o => o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
+
+// "live" = deploy-gate liveness (process up + build commit, no external deps); "ready" = full readiness.
 builder.Services.AddHealthChecks()
-    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!, timeout: TimeSpan.FromSeconds(5))
-    .AddCheck<CommitHashHealthCheck>("version")
-    .AddCheck<SupabaseAuthHealthCheck>("supabase-auth")
-    .AddCheck<SupabaseStorageHealthCheck>("supabase-storage")
-    .AddCheck<TemporalHealthCheck>("temporal");
+    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!, timeout: TimeSpan.FromSeconds(5), tags: ["ready"])
+    .AddCheck<CommitHashHealthCheck>("version", tags: ["live", "ready"])
+    .AddCheck<SupabaseAuthHealthCheck>("supabase-auth", tags: ["ready"])
+    .AddCheck<SupabaseStorageHealthCheck>("supabase-storage", tags: ["ready"])
+    .AddCheck<TemporalHealthCheck>("temporal", tags: ["ready"]);
 
 var app = builder.Build();
 
@@ -92,6 +97,14 @@ app.MapControllers();
 
 app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
 {
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+});
+
+// Liveness for the blue/green deploy gate: process up + expected commit, no external deps — a
+// shared DB/Temporal outage breaks both slots equally and must not roll back a good build.
+app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("live"),
     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
 });
 


### PR DESCRIPTION
## Problem

The blue/green deploy gate curls the full `/health` and requires a healthy (200) response containing the build commit. `/health` aggregates **every** dependency, so it 503s whenever any critical one is down.

Marten (event store), Temporal (workflow persistence), and Supabase all sit on the **same Supabase Postgres**, so a Postgres outage sinks a deploy two ways at once:

1. `npgsql` → `Unhealthy` → `/health` 503 → `curl -sf` drops the body → the gate never matches the commit.
2. The Temporal worker `BackgroundService`s fail their **startup** connection and throw; .NET's default `BackgroundServiceExceptionBehavior.StopHost` tears the whole API down (graceful exit 0, ~36s in) — so the new container isn't even alive to answer `/health`.

Net effect: an outage that breaks **both** blue/green slots equally still rolls back an otherwise-good build. Observed in [run 29231697746](https://github.com/KaliCZ/DemoPage/actions/runs/29231697746/job/86758532003) (container `Active: inactive (dead) … status=0/SUCCESS`, `npgsql … Unhealthy`).

## Fix — separate liveness from readiness

- **Keep the host alive on a background-worker fault** (`BackgroundServiceExceptionBehavior.Ignore`). A Temporal outage degrades notifications; it no longer crashes the API.
- **New `/health/live`** endpoint — process up + build commit, **no external dependencies**.
- **Gate the deploy and the public verify on `/health/live`.** `/health` stays full readiness (still 503s when the DB is down) for monitoring.

A genuinely broken *new* build (won't start / wrong commit) still fails the gate — only shared-infra outages stop blocking deploys.

The three Supabase/Temporal health-check comments justified `Degraded` by the now-removed "gate fails on a 503 from /health" coupling, so they're updated to the real readiness-semantics rationale.

## Not in scope

- Doesn't fix the underlying Supabase Postgres outage — real requests still fail while it's down; this only unblocks *deploying*.
- With `Ignore`, a faulted Temporal worker stays down until the next process restart rather than self-healing (moot once Temporal is replaced).

## Test plan

- [x] `dotnet build -c Release` (0 warnings)
- [ ] CI green on this PR (build + tests)
- [ ] On merge to `main`: deploy gate passes on `/health/live` despite the current Temporal/DB outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
