### PR TITLE
feat(blog): show comment counts on the blog index

### DIFF
--- a/backend/src/Kalandra.Api/Features/Blog/Contracts/GetBlogStatsResponse.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/Contracts/GetBlogStatsResponse.cs
@@ -2,10 +2,10 @@ using Kalandra.Blog.Queries;
 
 namespace Kalandra.Api.Features.Blog.Contracts;
 
-public record BlogPostStatsResponse(string Slug, int TotalViews, int UniqueVisitors, int TotalReactions, int? ViewerViews);
+public record BlogPostStatsResponse(string Slug, int TotalViews, int UniqueVisitors, int TotalReactions, int TotalComments, int? ViewerViews);
 
 public record GetBlogStatsResponse(IReadOnlyList<BlogPostStatsResponse> Posts)
 {
     public static GetBlogStatsResponse Serialize(IReadOnlyList<BlogPostStats> stats) => new(
-        [.. stats.Select(s => new BlogPostStatsResponse(s.Slug, s.TotalViews, s.UniqueVisitors, s.TotalReactions, s.ViewerViews))]);
+        [.. stats.Select(s => new BlogPostStatsResponse(s.Slug, s.TotalViews, s.UniqueVisitors, s.TotalReactions, s.TotalComments, s.ViewerViews))]);
 }

--- a/backend/src/Kalandra.Blog/Queries/GetBlogPostStats.cs
+++ b/backend/src/Kalandra.Blog/Queries/GetBlogPostStats.cs
@@ -6,7 +6,7 @@ namespace Kalandra.Blog.Queries;
 public record GetBlogPostStatsQuery(IReadOnlyList<BlogPost> Posts, Guid? ViewerId);
 
 /// <summary>ViewerViews is null for anonymous callers — they have no signed-in reading history to report.</summary>
-public record BlogPostStats(string Slug, int TotalViews, int UniqueVisitors, int TotalReactions, int? ViewerViews);
+public record BlogPostStats(string Slug, int TotalViews, int UniqueVisitors, int TotalReactions, int TotalComments, int? ViewerViews);
 
 public class GetBlogPostStatsHandler(IQuerySession session)
 {
@@ -24,6 +24,10 @@ public class GetBlogPostStatsHandler(IQuerySession session)
             var totalReactions = await session.Query<BlogReaction>()
                 .Where(reaction => reaction.Slug == post.Slug).CountAsync(ct);
 
+            // Unlike the on-page thread, this omits tombstones — it's a measure of live discussion.
+            var comments = await session.Events.AggregateStreamAsync<BlogPostComments>(post.CommentsStreamId, token: ct);
+            var totalComments = comments?.Comments.Count(c => !c.IsDeleted) ?? 0;
+
             int? viewerViews = query.ViewerId is { } viewerId
                 ? await session.Query<BlogPostVisitorView>()
                     .Where(v => v.Slug == post.Slug && v.UserId == viewerId).SumAsync(v => v.ViewCount, ct)
@@ -34,6 +38,7 @@ public class GetBlogPostStatsHandler(IQuerySession session)
                 TotalViews: totalViews,
                 UniqueVisitors: uniqueVisitors,
                 TotalReactions: totalReactions,
+                TotalComments: totalComments,
                 ViewerViews: viewerViews));
         }
 

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -383,7 +383,7 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
     // ───── Stats ─────
 
     [Fact]
-    public async Task Stats_AggregatesViewsAndReactionsPerPost()
+    public async Task Stats_AggregatesViewsReactionsAndCommentsPerPost()
     {
         var slugA = NewSlug();
         var slugB = NewSlug();
@@ -394,11 +394,13 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         await client.PostAsync($"/api/blog/{slugA}/views", content: null, Ct);
         await client.PostAsJsonAsync($"/api/blog/{slugA}/reactions/toggle", new { kind = "Heart" }, Ct);
         await client.PostAsJsonAsync($"/api/blog/{slugA}/reactions/toggle", new { kind = "Rocket" }, Ct);
+        await client.PostAsJsonAsync($"/api/blog/{slugA}/comments", new { content = "First!" }, Ct);
 
-        // A different reader on a different browser adds a second view of the same post.
+        // A different reader on a different browser adds a second view and comment on the same post.
         Authenticate(userId: Guid.NewGuid(), email: "stats-other@test.com");
         SetVisitor(Guid.NewGuid());
         await client.PostAsync($"/api/blog/{slugA}/views", content: null, Ct);
+        await client.PostAsJsonAsync($"/api/blog/{slugA}/comments", new { content = "Nice one" }, Ct);
 
         Authenticate(userId: viewerId, email: "stats-viewer@test.com");
         var response = await client.GetAsync($"/api/blog/stats?slug={slugA}&slug={slugB}", Ct);
@@ -410,13 +412,29 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Assert.Equal(2, statsA.GetProperty("totalViews").GetInt32());
         Assert.Equal(2, statsA.GetProperty("uniqueVisitors").GetInt32());
         Assert.Equal(2, statsA.GetProperty("totalReactions").GetInt32());
+        Assert.Equal(2, statsA.GetProperty("totalComments").GetInt32());
         Assert.Equal(1, statsA.GetProperty("viewerViews").GetInt32());
 
         var statsB = FindPostStats(posts, slugB);
         Assert.Equal(0, statsB.GetProperty("totalViews").GetInt32());
         Assert.Equal(0, statsB.GetProperty("uniqueVisitors").GetInt32());
         Assert.Equal(0, statsB.GetProperty("totalReactions").GetInt32());
+        Assert.Equal(0, statsB.GetProperty("totalComments").GetInt32());
         Assert.Equal(0, statsB.GetProperty("viewerViews").GetInt32());
+    }
+
+    [Fact]
+    public async Task Stats_CommentCount_ExcludesDeletedComments()
+    {
+        var slug = NewSlug();
+        Authenticate(email: "stats-commenter@test.com");
+
+        await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Kept" }, Ct);
+        var doomed = await ParseJsonAsync(await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Doomed" }, Ct));
+        await client.DeleteAsync($"/api/blog/{slug}/comments/{doomed.GetProperty("id").GetString()}", Ct);
+
+        var stats = FindPostStats((await ParseJsonAsync(await client.GetAsync($"/api/blog/stats?slug={slug}", Ct))).GetProperty("posts"), slug);
+        Assert.Equal(1, stats.GetProperty("totalComments").GetInt32());
     }
 
     [Fact]

--- a/frontend/src/components/blog/BlogList.vue
+++ b/frontend/src/components/blog/BlogList.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
     statViews: string;
     statPeople: string;
     statReactions: string;
+    statComments: string;
     paginationPrev: string;
     paginationNext: string;
     /** Contains `{current}` and `{total}` placeholders. */
@@ -184,10 +185,15 @@ onUnmounted(() => window.removeEventListener("auth-change", onAuthChange));
               {{ stats[post.slug]?.totalReactions ?? 0 }}
               <span class="sr-only">{{ props.t.statReactions }}</span>
             </span>
+            <span class="inline-flex items-center gap-1.5" :title="props.t.statComments">
+              <MaterialIcon :d="paths.chat" class="size-4" />
+              {{ stats[post.slug]?.totalComments ?? 0 }}
+              <span class="sr-only">{{ props.t.statComments }}</span>
+            </span>
             <span v-if="readStateLabel(post)">{{ readStateLabel(post) }}</span>
           </p>
           <p v-else class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-4" aria-hidden="true">
-            <span v-for="n in 3" :key="n" class="inline-block h-4 w-12 rounded bg-on-surface/10 animate-pulse" />
+            <span v-for="n in 4" :key="n" class="inline-block h-4 w-12 rounded bg-on-surface/10 animate-pulse" />
           </p>
         </a>
       </li>

--- a/frontend/src/i18n/cs/blog.json
+++ b/frontend/src/i18n/cs/blog.json
@@ -22,6 +22,7 @@
     "statViews": "Zobrazení",
     "statPeople": "Čtenáři",
     "statReactions": "Reakce",
+    "statComments": "Komentáře",
     "paginationPrev": "Předchozí",
     "paginationNext": "Další",
     "paginationPage": "Stránka {current} z {total}"

--- a/frontend/src/i18n/en/blog.json
+++ b/frontend/src/i18n/en/blog.json
@@ -22,6 +22,7 @@
     "statViews": "Views",
     "statPeople": "Readers",
     "statReactions": "Reactions",
+    "statComments": "Comments",
     "paginationPrev": "Previous",
     "paginationNext": "Next",
     "paginationPage": "Page {current} of {total}"

--- a/frontend/src/lib/blog/types.ts
+++ b/frontend/src/lib/blog/types.ts
@@ -20,6 +20,7 @@ export interface BlogPostStats {
   totalViews: number;
   uniqueVisitors: number;
   totalReactions: number;
+  totalComments: number;
   /** null when the caller is anonymous. */
   viewerViews: number | null;
 }

--- a/frontend/src/pages/[...lang]/blog/index.astro
+++ b/frontend/src/pages/[...lang]/blog/index.astro
@@ -81,6 +81,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || "";
             statViews: t.index.statViews,
             statPeople: t.index.statPeople,
             statReactions: t.index.statReactions,
+            statComments: t.index.statComments,
             paginationPrev: t.index.paginationPrev,
             paginationNext: t.index.paginationNext,
             paginationPage: t.index.paginationPage,


### PR DESCRIPTION
## What

Each card on the blog overview now shows a **comment count**, next to the existing views / readers / reactions stats.

## Why

The index already advertises engagement (views, unique readers, reactions) but said nothing about discussion. Comment count is the most direct signal of an active thread, and it rounds out the at-a-glance activity row.

## How

- **Backend** — the batch stats endpoint (`GET /api/blog/stats`) gains a `totalComments` field per post. `GetBlogPostStatsHandler` aggregates each post's comment event stream and counts non-deleted comments; `BlogPostStats` / `BlogPostStatsResponse` carry the value over the wire.
- **Frontend** — `BlogList.vue` renders the count with a chat icon and an `sr-only` label (same pattern as the other stats); the loading skeleton grows from 3 to 4 pills. `totalComments` is added to the `BlogPostStats` type, and `statComments` labels are wired through the page props in both locales ("Comments" / "Komentáře").

## Design note

The count **excludes deleted comments**, so it measures live discussion — consistent with `totalReactions` counting only active reactions. This intentionally diverges from the on-post thread, which still renders tombstoned comments as `[deleted]` rows.

## Testing

- Backend + frontend builds: clean.
- Blog stats integration tests (real PostgreSQL + Temporal via Testcontainers): **4/4 pass**, including an extended aggregation test (asserts `2` on a two-comment post, `0` on an untouched one) and a new `Stats_CommentCount_ExcludesDeletedComments` test (posts 2, deletes 1, asserts `1`).
- Prettier run on the changed frontend files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)