### PR TITLE
feat(blog): cache the index comment counts

### DIFF
--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -9,6 +9,7 @@ using Kalandra.Blog.Queries;
 using Kalandra.Infrastructure.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.AspNetCore.RateLimiting;
 
 namespace Kalandra.Api.Features.Blog;
@@ -126,6 +127,8 @@ public class BlogController(
     /// <summary>Batch stats for the blog index; the absolute route sidesteps the class-level {slug} template.</summary>
     [HttpGet("/api/blog/stats")]
     [AllowAnonymous]
+    // The default policy skips bearer-auth requests, so only viewerViews-null anonymous responses are cached.
+    [OutputCache(Duration = 10)]
     [ProducesResponseType<GetBlogStatsResponse>(StatusCodes.Status200OK)]
     public async Task<ActionResult<GetBlogStatsResponse>> GetStats(
         [FromQuery(Name = "slug")] string[] slugs,

--- a/backend/src/Kalandra.Api/Program.cs
+++ b/backend/src/Kalandra.Api/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddAppDataProtection();
 Auth.Add(builder.Services, supabaseConfig);
 builder.Services.AddAppCors(builder.Environment);
 builder.Services.AddMemoryCache();
+builder.Services.AddOutputCache();
 builder.Services.AddUserInfoCache(builder.Configuration);
 builder.Services.AddStorageServices();
 builder.Services.AddTurnstile(builder.Environment);
@@ -89,6 +90,7 @@ app.UseStatusCodePages();
 RobotsTag.Use(app);
 
 app.UseCors("DefaultPolicy");
+app.UseOutputCache();
 Auth.Use(app);
 RateLimits.Use(app);
 app.MapControllers();

--- a/backend/src/Kalandra.Blog/BlogCommentCountCache.cs
+++ b/backend/src/Kalandra.Blog/BlogCommentCountCache.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Kalandra.Blog;
+
+/// <summary>
+/// Caches each post's live comment count so the blog index doesn't replay the whole comment
+/// stream on every request. A write invalidates the entry, then invalidates it again after a
+/// short delay in case a read already in flight repopulates it with the pre-write count.
+/// </summary>
+public sealed class BlogCommentCountCache(IMemoryCache cache, TimeProvider timeProvider) : IDisposable
+{
+    private static readonly TimeSpan Lifetime = TimeSpan.FromHours(1);
+    private static readonly TimeSpan RewipeDelay = TimeSpan.FromSeconds(20);
+    private readonly CancellationTokenSource shutdown = new();
+
+    public bool TryGet(Guid commentsStreamId, out int count) => cache.TryGetValue(Key(commentsStreamId), out count);
+
+    public void Set(Guid commentsStreamId, int count) => cache.Set(Key(commentsStreamId), count, Lifetime);
+
+    public void Invalidate(Guid commentsStreamId)
+    {
+        var key = Key(commentsStreamId);
+        cache.Remove(key);
+        _ = RewipeAfterDelay(key);
+    }
+
+    // Bound to the cache's lifetime so a pending wipe is cancelled at shutdown rather than firing on a disposed cache.
+    private async Task RewipeAfterDelay(string key)
+    {
+        try
+        {
+            await Task.Delay(RewipeDelay, timeProvider, shutdown.Token);
+            cache.Remove(key);
+        }
+        catch (Exception e) when (e is OperationCanceledException or ObjectDisposedException)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        shutdown.Cancel();
+        shutdown.Dispose();
+    }
+
+    private static string Key(Guid commentsStreamId) => $"blog:comment-count:{commentsStreamId}";
+}

--- a/backend/src/Kalandra.Blog/Commands/DeleteBlogComment.cs
+++ b/backend/src/Kalandra.Blog/Commands/DeleteBlogComment.cs
@@ -11,7 +11,7 @@ public record DeleteBlogCommentCommand(
     CurrentUser User,
     DateTimeOffset Timestamp);
 
-public class DeleteBlogCommentHandler(IDocumentSession session)
+public class DeleteBlogCommentHandler(IDocumentSession session, BlogCommentCountCache commentCountCache)
 {
     public async Task<Result<BlogCommentDeleted, DeleteBlogCommentError>> DeleteAndSave(
         DeleteBlogCommentCommand command, CancellationToken ct)
@@ -27,6 +27,8 @@ public class DeleteBlogCommentHandler(IDocumentSession session)
         var deleted = result.Success!;
         session.Events.Append(streamId, deleted);
         await session.SaveChangesAsync(ct);
+        // A tombstone drops the live count, so the cached value is stale until wiped.
+        commentCountCache.Invalidate(streamId);
         return deleted;
     }
 }

--- a/backend/src/Kalandra.Blog/Commands/PostBlogComment.cs
+++ b/backend/src/Kalandra.Blog/Commands/PostBlogComment.cs
@@ -6,7 +6,7 @@ namespace Kalandra.Blog.Commands;
 
 public record PostBlogCommentCommand(BlogPost Post, BlogCommentPosted Comment);
 
-public class PostBlogCommentHandler(IDocumentSession session)
+public class PostBlogCommentHandler(IDocumentSession session, BlogCommentCountCache commentCountCache)
 {
     /// <summary>
     /// Stores the comment; the notification emails are delivered separately by the
@@ -28,6 +28,7 @@ public class PostBlogCommentHandler(IDocumentSession session)
 
         session.Events.Append(streamId, command.Comment);
         await session.SaveChangesAsync(ct);
+        commentCountCache.Invalidate(streamId);
         return command.Comment;
     }
 }

--- a/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
+++ b/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Kalicz.StrongTypes" Version="1.1.1" />
     <PackageReference Include="Marten" Version="9.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Kalandra.Blog/Queries/GetBlogPostStats.cs
+++ b/backend/src/Kalandra.Blog/Queries/GetBlogPostStats.cs
@@ -13,9 +13,9 @@ public record BlogPostStats(string Slug, int TotalViews, int UniqueVisitors, int
 /// Aggregates the blog-index stats for the whole requested batch. Views, reactions and comments each run
 /// on their own Marten session, so the three groups overlap on separate connections instead of summing.
 /// Within a group the queries share one session (a Marten session runs one query at a time). Comment
-/// counts stay a live per-post stream fold — cheap for now, optimizing them is tracked in #221.
+/// counts fold each post's event stream, cached per stream so the fold stays off the hot path.
 /// </summary>
-public class GetBlogPostStatsHandler(IDocumentStore store)
+public class GetBlogPostStatsHandler(IDocumentStore store, BlogCommentCountCache commentCountCache)
 {
     public async Task<IReadOnlyList<BlogPostStats>> List(GetBlogPostStatsQuery query, CancellationToken ct)
     {
@@ -73,12 +73,20 @@ public class GetBlogPostStatsHandler(IDocumentStore store)
         await using var session = store.QuerySession();
         var result = new Dictionary<Guid, int>();
         foreach (var post in posts)
-        {
-            // Omits tombstones, matching the "live discussion" count the endpoint has always reported.
-            var comments = await session.Events.AggregateStreamAsync<BlogPostComments>(post.CommentsStreamId, token: ct);
-            result[post.CommentsStreamId] = comments?.Comments.Count(comment => !comment.IsDeleted) ?? 0;
-        }
+            result[post.CommentsStreamId] = await CommentCountAsync(session, post, ct);
         return result;
+    }
+
+    private async Task<int> CommentCountAsync(IQuerySession session, BlogPost post, CancellationToken ct)
+    {
+        if (commentCountCache.TryGet(post.CommentsStreamId, out var cached))
+            return cached;
+
+        // Omits tombstones, matching the "live discussion" count the endpoint has always reported.
+        var comments = await session.Events.AggregateStreamAsync<BlogPostComments>(post.CommentsStreamId, token: ct);
+        var count = comments?.Comments.Count(comment => !comment.IsDeleted) ?? 0;
+        commentCountCache.Set(post.CommentsStreamId, count);
+        return count;
     }
 
     private static async Task<Dictionary<string, int>> SumViewCountBySlugAsync(

--- a/backend/src/Kalandra.Blog/ServiceRegistration.cs
+++ b/backend/src/Kalandra.Blog/ServiceRegistration.cs
@@ -10,6 +10,7 @@ public static class ServiceRegistration
     {
         // Which slugs are real posts (drives the reactions/comments slug gate).
         services.AddSingleton<IBlogPostCatalog, BlogPostCatalog>();
+        services.AddSingleton<BlogCommentCountCache>();
 
         // Command handlers
         services.AddScoped<ToggleBlogReactionHandler>();

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -464,6 +464,77 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Assert.Equal(1, response.GetProperty("posts").GetArrayLength());
     }
 
+    // ───── Stats caching ─────
+
+    [Fact]
+    public async Task Stats_CommentCount_ReflectsANewCommentAfterTheCountWasCached()
+    {
+        var slug = NewSlug();
+        Authenticate(email: "count-cache-post@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "One" }, Ct);
+
+        // Authenticated reads skip the response cache but still prime the per-post comment-count cache;
+        // the second comment must invalidate it so the follow-up read isn't stuck on the cached 1.
+        var first = await GetPostStats(slug);
+        Assert.Equal(1, first.GetProperty("totalComments").GetInt32());
+
+        await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Two" }, Ct);
+        var second = await GetPostStats(slug);
+        Assert.Equal(2, second.GetProperty("totalComments").GetInt32());
+    }
+
+    [Fact]
+    public async Task Stats_CommentCount_ReflectsADeletionAfterTheCountWasCached()
+    {
+        var slug = NewSlug();
+        Authenticate(email: "count-cache-delete@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Keep" }, Ct);
+        var doomed = await ParseJsonAsync(await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = "Doomed" }, Ct));
+
+        var before = await GetPostStats(slug);
+        Assert.Equal(2, before.GetProperty("totalComments").GetInt32());
+
+        await client.DeleteAsync($"/api/blog/{slug}/comments/{doomed.GetProperty("id").GetString()}", Ct);
+        var after = await GetPostStats(slug);
+        Assert.Equal(1, after.GetProperty("totalComments").GetInt32());
+    }
+
+    [Fact]
+    public async Task Stats_AnonymousResponse_IsServedFromTheOutputCache()
+    {
+        var slug = NewSlug();
+
+        // Prime the response cache anonymously with the empty state.
+        SignOut();
+        Assert.Equal(0, (await GetPostStats(slug)).GetProperty("totalReactions").GetInt32());
+
+        // A reaction lands out of band; within the cache window the anonymous read still serves the primed response.
+        Authenticate(email: "output-cache-warm@test.com");
+        await client.PostAsJsonAsync($"/api/blog/{slug}/reactions/toggle", new { kind = "Heart" }, Ct);
+
+        SignOut();
+        Assert.Equal(0, (await GetPostStats(slug)).GetProperty("totalReactions").GetInt32());
+    }
+
+    [Fact]
+    public async Task Stats_AuthenticatedRead_BypassesTheAnonymousOutputCache()
+    {
+        var slug = NewSlug();
+        var viewerId = Guid.NewGuid();
+
+        Authenticate(userId: viewerId, email: "output-cache-bypass@test.com");
+        SetVisitor(Guid.NewGuid());
+        await client.PostAsync($"/api/blog/{slug}/views", content: null, Ct);
+
+        // Prime the anonymous cache: viewerViews is null for anonymous callers.
+        SignOut();
+        Assert.Equal(JsonValueKind.Null, (await GetPostStats(slug)).GetProperty("viewerViews").ValueKind);
+
+        // The signed-in viewer must compute their own count, never be served the cached anonymous null.
+        Authenticate(userId: viewerId, email: "output-cache-bypass@test.com");
+        Assert.Equal(1, (await GetPostStats(slug)).GetProperty("viewerViews").GetInt32());
+    }
+
     // ───── Comments ─────
 
     [Fact]
@@ -810,6 +881,9 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         }
         throw new InvalidOperationException($"Stats response has no entry for slug '{slug}'");
     }
+
+    private async Task<JsonElement> GetPostStats(string slug) =>
+        FindPostStats((await ParseJsonAsync(await client.GetAsync($"/api/blog/stats?slug={slug}", Ct))).GetProperty("posts"), slug);
 
     private void Authenticate(Guid? userId = null, string email = "test@example.com", bool isAdmin = false)
     {

--- a/backend/tests/Kalandra.Blog.Tests/BlogCommentCountCacheTests.cs
+++ b/backend/tests/Kalandra.Blog.Tests/BlogCommentCountCacheTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kalandra.Blog.Tests;
+
+public class BlogCommentCountCacheTests
+{
+    private static readonly Guid StreamId = new("b1090001-0000-4000-8000-0000000000c0");
+
+    private static (BlogCommentCountCache cache, FakeTimeProvider time) NewCache()
+    {
+        var time = new FakeTimeProvider();
+        return (new BlogCommentCountCache(new MemoryCache(new MemoryCacheOptions()), time), time);
+    }
+
+    [Fact]
+    public void Set_ThenTryGet_ReturnsTheCachedCount()
+    {
+        var (cache, _) = NewCache();
+
+        cache.Set(StreamId, 7);
+
+        Assert.True(cache.TryGet(StreamId, out var count));
+        Assert.Equal(7, count);
+    }
+
+    [Fact]
+    public void TryGet_WhenNothingCached_ReturnsFalse()
+    {
+        var (cache, _) = NewCache();
+
+        Assert.False(cache.TryGet(StreamId, out _));
+    }
+
+    [Fact]
+    public void Invalidate_RemovesTheEntryImmediately()
+    {
+        var (cache, _) = NewCache();
+        cache.Set(StreamId, 3);
+
+        cache.Invalidate(StreamId);
+
+        Assert.False(cache.TryGet(StreamId, out _));
+    }
+
+    [Fact]
+    public async Task Invalidate_WipesAgainAfterTheDelay_ClearingARacingRepopulation()
+    {
+        var (cache, time) = NewCache();
+        cache.Invalidate(StreamId);
+
+        // A read that began before the write lands its pre-write count just after the immediate wipe.
+        cache.Set(StreamId, 3);
+        time.Advance(TimeSpan.FromSeconds(20));
+
+        await AssertEventually(() => !cache.TryGet(StreamId, out _), "cached count was not wiped after the delay");
+    }
+
+    [Fact]
+    public void Dispose_CancelsAPendingRewipe_SoItNeverFiresAfterShutdown()
+    {
+        var (cache, time) = NewCache();
+        cache.Invalidate(StreamId);
+        cache.Set(StreamId, 3);
+
+        cache.Dispose();
+        time.Advance(TimeSpan.FromSeconds(20));
+
+        // Dispose cancels the pending rewipe synchronously, so the entry survives untouched.
+        Assert.True(cache.TryGet(StreamId, out var count));
+        Assert.Equal(3, count);
+    }
+
+    private static async Task AssertEventually(Func<bool> condition, string because)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(5);
+        }
+        Assert.True(condition(), because);
+    }
+}

--- a/backend/tests/Kalandra.Blog.Tests/Kalandra.Blog.Tests.csproj
+++ b/backend/tests/Kalandra.Blog.Tests/Kalandra.Blog.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Kalicz.StrongTypes" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #221.

`GET /api/blog/stats` folds each post's comment event stream on every request — the one blog-index metric backed by the event store rather than an indexed document aggregate (views/reactions became batched `GROUP BY` queries in #220). This caches it.

## Two layers

**Per-stream comment count** — `BlogCommentCountCache` (in-memory, 1h TTL), keyed by each post's comment-stream id. `GetBlogPostStatsHandler` now folds the stream only on a miss. Invalidated whenever a comment is posted **or** deleted (a tombstone lowers the live count too). Each invalidation wipes immediately and schedules a second wipe after 20s: a read already in flight can repopulate the entry with the pre-commit count just after the wipe, and the delayed wipe clears that. The cache binds those pending re-wipes to its own lifetime and cancels them on shutdown.

**Whole-response output cache** — `[OutputCache(Duration = 10)]` on `/api/blog/stats`. The default policy skips bearer-authenticated requests, so only anonymous responses (which carry `viewerViews: null`) are ever cached — signed-in callers always compute their own per-viewer figures, so there's no cross-user leakage.

## Notes

- Both caches are in memory rather than Redis / `IDistributedCache`, by request — same machine, nothing to coordinate across instances. The immediate-plus-delayed wipe mirrors the evict-again idea the issue references from `CachingUserInfoService`, implemented locally in the blog domain.
- Builds on #220's parallel-session stats handler; the comment group just short-circuits to the cache.

## Testing

- **Unit** (`BlogCommentCountCacheTests`): set/get, immediate + 20s delayed wipe, and dispose cancels a pending re-wipe.
- **Integration**: comment count reflects a post/delete after the count was cached; the anonymous response is served from the output cache; an authenticated read bypasses the anonymous cache and gets its own `viewerViews`.
- Full backend suite green (208 tests); frontend unit tests green. E2E is unaffected — the blog index's only stat assertion (read tracking) runs signed-in, so it bypasses the output cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
