### PR TITLE
fix(backend): export traces to Sentry via OTLP so DB spans nest under requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Personal showcase website at [www.kalandra.tech](https://www.kalandra.tech). Ser
 - **Auth**: Supabase Auth (email/password + Google OAuth)
 - **Database**: PostgreSQL (Supabase in production, Docker locally)
 - **Background notifications**: durable store-and-notify emails for blog comments and job offers, delivered by Marten event subscriptions on the async daemon (no separate infrastructure)
-- **Observability**: [Sentry](https://sentry.io) for errors, traces, and logs (backend via the OpenTelemetry bridge; frontend via the CDN loader script behind a provider-agnostic abstraction)
+- **Observability**: [Sentry](https://sentry.io) for errors, traces, and logs (backend exports its OpenTelemetry traces over OTLP; frontend via the CDN loader script behind a provider-agnostic abstraction)
 - **CI/CD**: GitHub Actions
 
 Architecture decisions, technical roadmap, and the full decision log are documented on the [Project page](https://www.kalandra.tech/project). The page includes goals, an architecture overview diagram, collapsible Architecture Decision Records (ADRs), and a version-by-version roadmap with progress tracking.

--- a/backend/src/Kalandra.Api/Infrastructure/Observability.cs
+++ b/backend/src/Kalandra.Api/Infrastructure/Observability.cs
@@ -1,6 +1,6 @@
 using Npgsql;
 using OpenTelemetry;
-using Sentry.OpenTelemetry;
+using Sentry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -34,9 +34,9 @@ public static class Observability
             options.Dsn = config.Dsn.Value;
             options.Release = AppVersion.InformationalVersion;
 
-            // Bridge with the OTEL pipeline so Sentry receives spans through Sentry.OpenTelemetry.
-            options.UseOpenTelemetry();
-            options.DisableDiagnosticSourceIntegration();
+            // UseOtlp sends traces to Sentry as raw OTel spans (via AddSentryOtlpExporter below) and turns off
+            // the SDK's own request tracing, so the OTel pipeline isn't duplicated on Sentry's side.
+            options.UseOtlp();
             options.DisableSentryHttpMessageHandler = true;
 
             // EnableLogs wires Sentry.AspNetCore's structured logger provider so ILogger calls flow into
@@ -46,7 +46,6 @@ public static class Observability
             options.MinimumEventLevel = LogLevel.Warning;
             options.MinimumBreadcrumbLevel = LogLevel.Information;
 
-            options.TracesSampleRate = 1.0;
             options.SampleRate = 1.0f;
             options.SendDefaultPii = true;
             options.MaxRequestBodySize = Sentry.Extensibility.RequestSize.Medium;
@@ -94,7 +93,7 @@ public static class Observability
                     .AddNpgsql();
 
                 if (sentryConfig is not null)
-                    tracing.AddSentry();
+                    tracing.AddSentryOtlpExporter(sentryConfig.Dsn.Value);
 
                 if (betterStackConfig is not null)
                     tracing.AddOtlpExporter(otlp =>

--- a/backend/src/Kalandra.Api/Kalandra.Api.csproj
+++ b/backend/src/Kalandra.Api/Kalandra.Api.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.3" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
-    <PackageReference Include="Sentry.OpenTelemetry" Version="6.6.0" />
+    <PackageReference Include="Sentry.OpenTelemetry.Exporter" Version="6.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -648,8 +648,9 @@ automatic for the build/push step. The OCI VM also pulls from GHCR — see
 ## 5. Observability
 
 Errors, structured logs, traces, and session replays are sent to
-[Sentry](https://sentry.io). The backend uses `Sentry.AspNetCore` +
-`Sentry.OpenTelemetry` to bridge its existing OTEL pipeline; the frontend uses
+[Sentry](https://sentry.io). The backend uses `Sentry.AspNetCore` for errors
+and logs, and exports its OpenTelemetry traces to Sentry over OTLP via
+`Sentry.OpenTelemetry.Exporter`; the frontend uses
 `@sentry/browser` (npm SDK), dynamic-imported from
 [`src/lib/observability.ts`](../frontend/src/lib/observability.ts) so the
 chunk tree-shakes out when no DSN is configured.


### PR DESCRIPTION
## What & why

Postgres spans in Sentry weren't grouped under their HTTP request — DB queries showed up as loose `marten.connection` / `postgresql` transactions with no ASP.NET parent. This turned out **not** to be missing ASP.NET instrumentation (that's enabled and emitting 3k+ `http.server` spans/day); it's a trace-splitting bug in the deprecated `Sentry.OpenTelemetry` span-processor bridge.

## Root cause

Confirmed from production Sentry traces — the `sdk.name` on the spans is the tell.

**Browser-initiated request** (carries an incoming `sentry-trace` header — every real page visit). The request transaction is absent; DB spans are orphaned:

```
pageload /blog/…                       [sentry.javascript.browser · kalandra-fe]
├─ http.client GET …/comments          [browser]
│    └─ marten.connection              [sentry.dotnet · kalandra-be]   ← no http.server parent
└─ CONNECT postgres / postgresql × N   (floating at the trace root)
```

**Direct hit** (no inbound trace) — nests perfectly:

```
GET api/blog/{slug}/comments   [http.server · sentry.dotnet.aspnetcore]
└─ marten.connection           [sentry.dotnet]
   └─ postgresql
```

The bridge's `SentrySpanProcessor` promotes any span with a **remote parent** to a root transaction. So when the browser propagates its trace, the Marten/Npgsql spans (which inherit that remote parent) each become root transactions in the frontend's trace, while the ASP.NET request transaction lands on a *separate* trace — the two halves of one request are torn apart. Direct hits have no remote parent, so they nest correctly, which masked the bug.

The `Sentry.OpenTelemetry` bridge is **deprecated**; Sentry now recommends OTLP export, precisely because OTLP ingestion preserves the native OpenTelemetry hierarchy without this transaction-conversion step.

## The fix

Move the Sentry **traces** path from the bridge to `Sentry.OpenTelemetry.Exporter` (OTLP) — mirroring the OTLP export this code already does for BetterStack/Aspire:

- `options.UseOtlp()` — sets `Instrumenter.OpenTelemetry` and `DisableSentryTracing = true`, so the SDK no longer creates its own request transactions (no duplicates).
- `tracing.AddSentryOtlpExporter(dsn)` — ships the raw OTel spans to Sentry's OTLP endpoint (endpoint + `X-Sentry-Auth` derived from the DSN) and keeps `SentryPropagator` registered, so frontend↔backend continuity is preserved.

Errors and logs still flow through `Sentry.AspNetCore` unchanged — only the trace transport changes.

## Verification

- `dotnet build` clean (0 warnings / 0 errors); `Sentry.OpenTelemetry.Exporter` restores at 6.6.0, matching the Sentry SDK.
- This path is env-gated on the backend Sentry DSN, which exists only in production, so it first executes on deploy. The blue/green liveness gate auto-rolls-back a failed start.
- **After deploy:** open a blog post and confirm the Sentry trace shows `GET api/blog/{slug}/… → marten.connection → postgresql` nested in one trace, linked to the frontend pageload.

## Notes

- Sentry's OTLP trace ingestion is in open beta (OTel *span events* are dropped on ingest — not used here). Rollback is a straight revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
