### PR TITLE
refactor(backend): move shared response contracts and the blog feed into the domain slices

### DIFF
--- a/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
+++ b/backend/src/Kalandra.Api/Features/Blog/BlogController.cs
@@ -3,6 +3,7 @@ using Kalandra.Api.Infrastructure;
 using Kalandra.Api.Infrastructure.Auth;
 using Kalandra.Blog;
 using Kalandra.Blog.Commands;
+using Kalandra.Blog.Contracts;
 using Kalandra.Blog.Entities;
 using Kalandra.Blog.Events;
 using Kalandra.Blog.Queries;

--- a/backend/src/Kalandra.Api/Features/JobOffers/Contracts/ListJobOffersResponse.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/Contracts/ListJobOffersResponse.cs
@@ -1,4 +1,5 @@
 using Kalandra.Api.Infrastructure;
+using Kalandra.JobOffers.Contracts;
 
 namespace Kalandra.Api.Features.JobOffers.Contracts;
 

--- a/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
+++ b/backend/src/Kalandra.Api/Features/JobOffers/JobOffersController.cs
@@ -7,6 +7,7 @@ using Kalandra.Infrastructure.Auth;
 using Kalandra.Infrastructure.Storage;
 using Kalandra.Infrastructure.Turnstile;
 using Kalandra.JobOffers.Commands;
+using Kalandra.JobOffers.Contracts;
 using Kalandra.JobOffers.Entities;
 using Kalandra.JobOffers.Queries;
 using Microsoft.AspNetCore.Authorization;

--- a/backend/src/Kalandra.Api/Features/Mcp/BlogMcpTools.cs
+++ b/backend/src/Kalandra.Api/Features/Mcp/BlogMcpTools.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel;
-using Kalandra.Api.Features.Blog.Contracts;
 using Kalandra.Api.Features.Mcp.Contracts;
 using Kalandra.Api.Infrastructure.Auth;
 using Kalandra.Blog;
 using Kalandra.Blog.Commands;
+using Kalandra.Blog.Contracts;
 using Kalandra.Blog.Entities;
 using Kalandra.Blog.Events;
+using Kalandra.Blog.Feed;
 using Kalandra.Blog.Queries;
 using Kalandra.JobOffers.Queries;
 using ModelContextProtocol;

--- a/backend/src/Kalandra.Api/Features/Mcp/Contracts/GetMyCommentsResponse.cs
+++ b/backend/src/Kalandra.Api/Features/Mcp/Contracts/GetMyCommentsResponse.cs
@@ -1,6 +1,6 @@
-using Kalandra.Api.Features.Blog.Contracts;
-using Kalandra.Api.Features.JobOffers.Contracts;
+using Kalandra.Blog.Contracts;
 using Kalandra.Blog.Queries;
+using Kalandra.JobOffers.Contracts;
 using Kalandra.JobOffers.Queries;
 using StrongTypes;
 

--- a/backend/src/Kalandra.Api/Features/Mcp/JobOfferMcpTools.cs
+++ b/backend/src/Kalandra.Api/Features/Mcp/JobOfferMcpTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
-using Kalandra.Api.Features.JobOffers.Contracts;
 using Kalandra.Api.Infrastructure.Auth;
+using Kalandra.JobOffers.Contracts;
 using Kalandra.JobOffers.Commands;
 using Kalandra.JobOffers.Entities;
 using Kalandra.JobOffers.Queries;

--- a/backend/src/Kalandra.Api/Features/Mcp/McpRegistration.cs
+++ b/backend/src/Kalandra.Api/Features/Mcp/McpRegistration.cs
@@ -1,4 +1,5 @@
 using Kalandra.Api.Infrastructure;
+using Kalandra.Blog.Feed;
 
 namespace Kalandra.Api.Features.Mcp;
 
@@ -13,8 +14,7 @@ public static class McpRegistration
     public static IServiceCollection AddMcp(
         this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
     {
-        BlogFeedConfig.AddSingleton(services, configuration, environment);
-        services.AddHttpClient<BlogFeedClient>();
+        services.AddBlogFeed(configuration, environment);
 
         services.AddMcpServer(options =>
             {

--- a/backend/src/Kalandra.Blog/Contracts/BlogCommentResponse.cs
+++ b/backend/src/Kalandra.Blog/Contracts/BlogCommentResponse.cs
@@ -1,7 +1,7 @@
 using Kalandra.Blog.Entities;
 using Kalandra.Blog.Events;
 
-namespace Kalandra.Api.Features.Blog.Contracts;
+namespace Kalandra.Blog.Contracts;
 
 public record BlogCommentResponse(
     Guid Id,

--- a/backend/src/Kalandra.Blog/Feed/BlogFeedClient.cs
+++ b/backend/src/Kalandra.Blog/Feed/BlogFeedClient.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Xml.Linq;
 
-namespace Kalandra.Api.Features.Mcp;
+namespace Kalandra.Blog.Feed;
 
 public record BlogPostSummary(
     string Slug,

--- a/backend/src/Kalandra.Blog/Feed/BlogFeedConfig.cs
+++ b/backend/src/Kalandra.Blog/Feed/BlogFeedConfig.cs
@@ -1,6 +1,9 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using StrongTypes;
 
-namespace Kalandra.Api.Features.Mcp;
+namespace Kalandra.Blog.Feed;
 
 /// <summary>The published blog's RSS feed — the MCP <c>list_blog_posts</c> tool's source, since the backend holds only slugs, not post titles/summaries.</summary>
 public record BlogFeedConfig(Uri RssUrl)

--- a/backend/src/Kalandra.Blog/Feed/BlogFeedRegistration.cs
+++ b/backend/src/Kalandra.Blog/Feed/BlogFeedRegistration.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Kalandra.Blog.Feed;
+
+public static class BlogFeedRegistration
+{
+    public static IServiceCollection AddBlogFeed(
+        this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
+    {
+        BlogFeedConfig.AddSingleton(services, configuration, environment);
+        services.AddHttpClient<BlogFeedClient>();
+        return services;
+    }
+}

--- a/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
+++ b/backend/src/Kalandra.Blog/Kalandra.Blog.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Kalicz.StrongTypes" Version="1.1.1" />
     <PackageReference Include="Marten" Version="9.12.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Kalandra.JobOffers/Contracts/CommentResponse.cs
+++ b/backend/src/Kalandra.JobOffers/Contracts/CommentResponse.cs
@@ -1,7 +1,7 @@
 using Kalandra.JobOffers.Events;
 using StrongTypes;
 
-namespace Kalandra.Api.Features.JobOffers.Contracts;
+namespace Kalandra.JobOffers.Contracts;
 
 public record CommentResponse(
     Guid Id,

--- a/backend/src/Kalandra.JobOffers/Contracts/GetJobOfferDetailResponse.cs
+++ b/backend/src/Kalandra.JobOffers/Contracts/GetJobOfferDetailResponse.cs
@@ -1,7 +1,7 @@
 using Kalandra.JobOffers.Entities;
 using StrongTypes;
 
-namespace Kalandra.Api.Features.JobOffers.Contracts;
+namespace Kalandra.JobOffers.Contracts;
 
 public record GetJobOfferDetailResponse(
     Guid Id,

--- a/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
@@ -1,5 +1,5 @@
-using Kalandra.Api.Features.Mcp;
 using Kalandra.Blog;
+using Kalandra.Blog.Feed;
 using Kalandra.Infrastructure.Auth;
 using Kalandra.Infrastructure.Email;
 using Kalandra.Infrastructure.Storage;

--- a/backend/tests/Kalandra.Blog.Tests/BlogFeedParseTests.cs
+++ b/backend/tests/Kalandra.Blog.Tests/BlogFeedParseTests.cs
@@ -1,6 +1,6 @@
-using Kalandra.Api.Features.Mcp;
+using Kalandra.Blog.Feed;
 
-namespace Kalandra.Api.IntegrationTests.Features.Mcp;
+namespace Kalandra.Blog.Tests;
 
 public class BlogFeedParseTests
 {

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -33,15 +33,16 @@ Features are vertical slices, not horizontal layers within the API project. A fe
 
 - `{Name}Controller.cs` — the HTTP surface for the feature
 - `Contracts/*Request.cs` — inbound DTOs
-- `Contracts/*Response.cs` — outbound DTOs with a static `Serialize(...)` method
+- `Contracts/*Response.cs` — REST-only outbound DTOs with a static `Serialize(...)` method (see below)
 - `Contracts/*Error.cs` — the API-layer error enum
 
-There is no shared `Controllers/`, `Dtos/`, or `Models/` folder. Cross-feature reuse happens through `Kalandra.Infrastructure` (auth, storage, config) or `Kalandra.JobOffers` (domain handlers), never through a shared API-layer "common" folder.
+There is no shared `Controllers/`, `Dtos/`, or `Models/` folder. Cross-feature reuse happens through `Kalandra.Infrastructure` (auth, storage, config) or `Kalandra.JobOffers` (domain handlers and shared response contracts), never through a shared API-layer "common" folder.
 
 ## Request & response DTOs
 
 - Requests are `record`s with `NonEmptyString` / `Email` properties — invariants live in the type, not in attributes.
-- Responses are `record`s with a static `Serialize(entity, viewer)` method. `viewer` lets the response gate admin-only fields (see `GetJobOfferDetailResponse.Serialize`).
+- Responses are `record`s with a static `Serialize(...)` method.
+- **Response contracts served by more than one front door live in the domain slice.** The shapes both the REST controllers and the MCP tools return (`GetJobOfferDetailResponse`, `CommentResponse`, `BlogCommentResponse`) live in `Kalandra.{Domain}/Contracts/` so every front door serves an identical shape; the domain projects don't reference ASP.NET, so these stay pure `Serialize(entity)` records. REST-only responses — pagination envelopes, edit history, dashboard stats — stay here in the API feature slice.
 - Declare shape with `[ProducesResponseType<T>(...)]` so Swagger documents the contract.
 
 ## Error contracts: the two-enum rule

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -2,8 +2,8 @@
 
 ## The three projects
 
-- **`Kalandra.Api`** — the HTTP boundary. Controllers, request/response DTOs, API error enums, auth pipeline, rate limiting. Handles request validation and mapping. Keeps API contracts stable for the frontend.
-- **Domain projects** (e.g. `Kalandra.JobOffers`) — one project per business domain. Entities, events, command/query handlers, Marten config. Each domain gets its own project with vertical slices. A new domain = a new `Kalandra.{Domain}` project + `Add{Domain}Domain()` extension.
+- **`Kalandra.Api`** — the HTTP boundary. Controllers, request DTOs, API error enums, REST-only response envelopes (pagination, history, stats), auth pipeline, rate limiting. Handles request validation and mapping. Keeps API contracts stable for the frontend.
+- **Domain projects** (e.g. `Kalandra.JobOffers`) — one project per business domain. Entities, events, command/query handlers, Marten config, and the response contracts every front door serves (`Contracts/*Response.cs`). Each domain gets its own project with vertical slices. A new domain = a new `Kalandra.{Domain}` project + `Add{Domain}Domain()` extension.
 - **`Kalandra.Infrastructure`** — cross-cutting concerns. Supabase clients (auth, storage), `CurrentUser`, Turnstile validation, configuration records. Leaf project — depends on nothing else in the repo.
 
 ## Dependency direction
@@ -57,7 +57,8 @@ Notification emails are a side effect of committed events, delivered by Marten e
 | You want to add...                                  | Goes in                                                                |
 |-----------------------------------------------------|------------------------------------------------------------------------|
 | A new HTTP endpoint on an existing domain           | `Kalandra.Api/Features/{Domain}/{Domain}Controller.cs`                 |
-| A new request or response shape                     | `Kalandra.Api/Features/{Domain}/Contracts/`                            |
+| A new request DTO or REST-only response envelope    | `Kalandra.Api/Features/{Domain}/Contracts/`                            |
+| A response contract shared by REST + MCP            | `Kalandra.{Domain}/Contracts/*Response.cs`                            |
 | A new domain error variant exposed on the wire      | Add to the API enum + map it in the controller `switch`               |
 | A new business operation (write)                    | `Kalandra.{Domain}/Commands/{Operation}.cs` (record + enum + handler)  |
 | A new read query                                    | `Kalandra.{Domain}/Queries/{Query}.cs`                                 |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -99,7 +99,7 @@ in the API's environment.
 
 ## Testing
 
-- `Features/Mcp/BlogFeedParseTests` — pure unit tests for RSS parsing.
+- `Kalandra.Blog.Tests/BlogFeedParseTests` — pure unit tests for RSS parsing (the feed reader lives in `Kalandra.Blog/Feed/`).
 - `Features/Mcp/McpToolsTests` — drives the tools directly against the real domain handlers and database
   (`TestWebApplicationFactory`, real Postgres) with a chosen caller: the auth guard, command building, error
   translation, ownership boundaries, and the signed-in read-status enrichment. The factory serves the


### PR DESCRIPTION
## Why

Groundwork for giving the MCP server **its own OAuth-protected host**, separate from the bearer-token REST API. A second host can only serve the same domain if the pieces both front doors share live in **libraries** — not inside `Kalandra.Api` (the web host). This PR relocates exactly those shared pieces; a follow-up PR builds the standalone MCP host + OAuth on top of this clean base.

This is **PR 1 of 2**, deliberately a behaviour-preserving structural move so it can be reviewed as a pure refactor.

## What moves

- **Response contracts served by both REST and MCP** → the domain slices:
  - `GetJobOfferDetailResponse`, `CommentResponse` → `Kalandra.JobOffers/Contracts/`
  - `BlogCommentResponse` / `ListBlogCommentsResponse` → `Kalandra.Blog/Contracts/`
  - They were already pure `Serialize(entity)` records with zero ASP.NET coupling.
- **The RSS-backed blog feed reader** (`BlogFeedClient`, `BlogFeedConfig`, `BlogPostSummary`) → `Kalandra.Blog/Feed/`, behind a small `AddBlogFeed(config, env)` registration (`Microsoft.Extensions.Http` added to the Blog project).
- **The RSS parse unit test** → `Kalandra.Blog.Tests`, next to its moved SUT.

## What stays at the HTTP boundary (`Kalandra.Api`)

Request DTOs, the API error enums (the stable-wire half of the two-enum contract), and REST-only response envelopes (`ListJobOffersResponse` pagination, `JobOfferHistoryResponse`, blog stats/reactions/view-ack). The MCP tools themselves also stay in-process for now — they relocate to the new host in PR 2.

**The rule** (now documented in `docs/backend-architecture.md` + `docs/backend-api.md`): a response contract lives in the domain slice when more than one front door serves it; single-host shapes stay at that host's boundary.

## Verification

- `dotnet build` clean (0 warnings, 0 errors).
- Full backend suite green locally: **229 tests** (Blog 45, JobOffers 41, Infrastructure 27, Api integration 116 — the last drives the `/mcp` route and REST controllers against real Postgres).
- No frontend change; wire shapes are byte-identical, so the JSON contract is unchanged.
- Git tracks all six moves as renames (history preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)