### PR TITLE
fix(ci): pass BlogFeed__RssUrl to the production API

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -359,6 +359,7 @@ jobs:
           SMTP_FROM_EMAIL: ${{ vars.SMTP_FROM_EMAIL }}
           BLOG_AUTHOR_NOTIFICATION_EMAIL: ${{ vars.BLOG_AUTHOR_NOTIFICATION_EMAIL }}
           JOB_OFFERS_OWNER_NOTIFICATION_EMAIL: ${{ vars.JOB_OFFERS_OWNER_NOTIFICATION_EMAIL }}
+          BLOG_FEED_RSS_URL: https://www.kalandra.tech/rss.xml
           # Digest-pinned, not :latest — the exact build verified by this run
           # is what runs and what comes back after a reboot.
           IMAGE_REF: ${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -367,7 +368,7 @@ jobs:
           host: ${{ vars.OCI_HOST }}
           username: ${{ vars.OCI_USERNAME }}
           key: ${{ secrets.OCI_SSH_KEY }}
-          envs: DB_CONNECTION_STRING,SUPABASE_PROJECT_URL,SUPABASE_SERVICE_ROLE_KEY,TURNSTILE_SECRET_KEY,SENTRY_DSN,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM_EMAIL,BLOG_AUTHOR_NOTIFICATION_EMAIL,JOB_OFFERS_OWNER_NOTIFICATION_EMAIL,IMAGE_REF,EXPECTED_SHA
+          envs: DB_CONNECTION_STRING,SUPABASE_PROJECT_URL,SUPABASE_SERVICE_ROLE_KEY,TURNSTILE_SECRET_KEY,SENTRY_DSN,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM_EMAIL,BLOG_AUTHOR_NOTIFICATION_EMAIL,JOB_OFFERS_OWNER_NOTIFICATION_EMAIL,BLOG_FEED_RSS_URL,IMAGE_REF,EXPECTED_SHA
           script: |
             set -euo pipefail
             MAX_ATTEMPTS=40
@@ -406,6 +407,7 @@ jobs:
             Email__FromName=kalandra.tech
             Blog__AuthorNotificationEmail=${BLOG_AUTHOR_NOTIFICATION_EMAIL}
             JobOffers__OwnerNotificationEmail=${JOB_OFFERS_OWNER_NOTIFICATION_EMAIL}
+            BlogFeed__RssUrl=${BLOG_FEED_RSS_URL}
             EOF
 
             # ----- 1. Determine which slot is currently active -----


### PR DESCRIPTION
## What

Adds the missing `BlogFeed__RssUrl` to the backend deploy's environment, so the production API can start.

## Why

[#189](https://github.com/KaliCZ/DemoPage/pull/189) introduced a production config guard in `BlogFeedConfig` that throws when `BlogFeed:RssUrl` is still the `http://localhost:4321/rss.xml` default — the same fail-fast idiom as the `Supabase`, `Turnstile`, `Sentry`, and DB guards. The deploy supplies a value for every one of those, but never for `BlogFeed`.

So since #189 merged, every push to `main` has:

1. built and pushed the image fine,
2. started the new slot, which threw at startup and crash-looped under `Restart=on-failure`,
3. failed the `/health/live` gate after 40 attempts, rolled back,
4. and skipped `frontend-deploy` (it needs `backend-deploy` to succeed).

Net effect: **main hasn't been published since #189** — not the backend, and not the frontend either.

`docs/mcp-server.md` already documented this as required (*"the only added config is `BlogFeed__RssUrl` in the API's environment"*); the workflow just never got it. That statement is now true.

## Why CI didn't catch it

The `e2e` job runs the API with `ASPNETCORE_ENVIRONMENT: Development`, which short-circuits every production config guard. No job starts the API as `Production`, so a missing production-only config is invisible to CI by construction. Worth closing separately — this class of bug can recur with the next guard added.

## Verification

Ran the real API binary with `ASPNETCORE_ENVIRONMENT=Production` and exactly the env the deploy writes today. It reproduces the production crash:

```
Unhandled exception. System.InvalidOperationException: BlogFeed:RssUrl still points at localhost — a production deploy must set the real feed URL.
   at Kalandra.Blog.Feed.BlogFeedConfig.AddSingleton(...)
   at Kalandra.Api.Features.Mcp.McpRegistration.AddMcp(...)
   at Program.<Main>$(String[] args) in Program.cs:line 61
```

Adding `BlogFeed__RssUrl` — with the database deliberately left unreachable — the app starts and the deploy gate answers:

```
$ curl http://localhost:5199/health/live
HTTP 200
{"status":"Healthy","entries":{"version":{"data":{"commit":"local"},"status":"Healthy","tags":["live","ready"]}}}
```

Healthy despite no DB, confirming the liveness gate is dependency-free as designed and that `BlogFeed` was the only thing blocking promotion.

Also confirmed `https://www.kalandra.tech/rss.xml` serves `200` with the real feed, and that no key in the deploy step's `env:` is missing from the `envs:` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)