### PR TITLE
ci: boot the API as Production so a missing deploy key fails the PR

### DIFF
--- a/.github/production-boot.env
+++ b/.github/production-boot.env
@@ -1,0 +1,19 @@
+# Fake config for the backend-production-boot job: mirrors, key for key, the env file the deploy
+# writes (the kalandra-api.env heredoc in ci-cd.yml) — production's only config source — so CI boots
+# the API on exactly what production gets. The job diffs both key lists; add a key there, add it here.
+#
+# Values only have to clear the startup guards, never connect: .invalid never resolves (RFC 6761).
+ConnectionStrings__DefaultConnection=Host=db.invalid;Port=5432;Database=kalandra;Username=ci;Password=ci
+Supabase__ProjectUrl=https://ci.supabase.invalid
+Supabase__ServiceKey=ci-service-key
+Turnstile__SecretKey=ci-turnstile-secret-key
+Sentry__Dsn=https://abc123def456@o4507000000000000.ingest.de.sentry.invalid/4507000000000000
+Email__Host=smtp.invalid
+Email__Port=587
+Email__Username=ci
+Email__Password=ci-password
+Email__FromEmail=noreply@kalandra.invalid
+Email__FromName=kalandra.tech
+Blog__AuthorNotificationEmail=author@kalandra.invalid
+JobOffers__OwnerNotificationEmail=owner@kalandra.invalid
+BlogFeed__RssUrl=https://kalandra.invalid/rss.xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,6 +188,79 @@ jobs:
       - name: Test
         run: dotnet test --no-build -c Release
 
+  # Boots the API the way production does — ASPNETCORE_ENVIRONMENT=Production, and only the
+  # config the deploy supplies — so a startup guard demanding a key the deploy never sets fails
+  # here instead of crash-looping the new slot and rolling the release back (#189).
+  backend-production-boot:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Build backend
+        run: dotnet build backend/src/Kalandra.Api -c Release
+
+      # The boot below only proves anything if it runs on the same keys production gets, so the
+      # two lists are compared rather than trusted to be kept in step by hand.
+      - name: Check the fake config still mirrors the deploy's env file
+        run: |
+          deploy_keys=$(
+            awk '/^[[:space:]]*cat > .*kalandra-api\.env/ { inside = 1; next }
+                 inside && /^[[:space:]]*EOF[[:space:]]*$/ { exit }
+                 inside' .github/workflows/ci-cd.yml \
+              | sed -E 's/^[[:space:]]*//' | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' | cut -d= -f1 | sort
+          )
+          fake_keys=$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .github/production-boot.env | cut -d= -f1 | sort)
+
+          if [ -z "$deploy_keys" ]; then
+            echo "::error::Read no keys out of the deploy's kalandra-api.env heredoc. It has changed shape, and this job silently stops guarding the deploy — fix the parse above."
+            exit 1
+          fi
+
+          if ! diff <(echo "$deploy_keys") <(echo "$fake_keys"); then
+            echo "::error::'<' is supplied by the deploy but missing from .github/production-boot.env; '>' is the reverse (this job would boot the API on config production never gets). Both must list the same keys."
+            exit 1
+          fi
+          echo "In step — the deploy and .github/production-boot.env supply the same $(echo "$deploy_keys" | wc -l) keys."
+
+      - name: Load the fake production config
+        run: grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .github/production-boot.env >> "$GITHUB_ENV"
+
+      - name: Start backend as Production
+        run: |
+          # --no-launch-profile: launchSettings.json pins ASPNETCORE_ENVIRONMENT=Development, which
+          # would override the Production below and skip every guard this job exists to run.
+          stdbuf -oL -eL dotnet run --project backend/src/Kalandra.Api -c Release --no-build --no-launch-profile --urls http://localhost:5000 > "$RUNNER_TEMP/api.log" 2>&1 &
+        env:
+          ASPNETCORE_ENVIRONMENT: Production
+
+      # Dependency-free by design (only the live-tagged commit check), so this answers on the fake
+      # config above without any real database, Supabase, or SMTP behind it.
+      - name: Assert /health/live answers
+        uses: KaliCZ/verify-deployment@57cf981c4f0d8c4096fcba5308521e85f204da11  # v1
+        with:
+          health-url: http://localhost:5000/health/live
+          max-attempts: 30
+          retry-interval: 2
+
+      - name: Backend startup logs
+        if: always()
+        run: |
+          echo "===== backend api.log ====="
+          cat "$RUNNER_TEMP/api.log" 2>/dev/null || echo "(no api.log captured)"
+
   frontend-format:
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -259,7 +332,7 @@ jobs:
         working-directory: frontend
 
   backend-deploy:
-    needs: [e2e, backend-test, frontend-format, frontend-test]
+    needs: [e2e, backend-test, backend-production-boot, frontend-format, frontend-test]
     if: |
       always() &&
       (
@@ -267,6 +340,7 @@ jobs:
           github.event_name == 'push' &&
           needs.e2e.result == 'success' &&
           needs.backend-test.result == 'success' &&
+          needs.backend-production-boot.result == 'success' &&
           needs.frontend-format.result == 'success' &&
           needs.frontend-test.result == 'success'
         ) ||
@@ -393,6 +467,8 @@ jobs:
 
             # App secrets, read by both slots via EnvironmentFile. Rewritten
             # every deploy so rotated secrets propagate when a slot (re)starts.
+            # backend-production-boot parses these keys and boots the API against
+            # them — a key added here also belongs in .github/production-boot.env.
             cat > "$APP_DIR/kalandra-api.env" << EOF
             ConnectionStrings__DefaultConnection=${DB_CONNECTION_STRING}
             Supabase__ProjectUrl=${SUPABASE_PROJECT_URL}
@@ -523,7 +599,7 @@ jobs:
           expected-content: ${{ github.sha }}
 
   frontend-deploy:
-    needs: [e2e, backend-test, frontend-format, frontend-test, backend-deploy]
+    needs: [e2e, backend-test, backend-production-boot, frontend-format, frontend-test, backend-deploy]
     if: |
       always() &&
       (
@@ -532,6 +608,7 @@ jobs:
           github.event_name == 'push' &&
           needs.e2e.result == 'success' &&
           needs.backend-test.result == 'success' &&
+          needs.backend-production-boot.result == 'success' &&
           needs.frontend-format.result == 'success' &&
           needs.frontend-test.result == 'success' &&
           needs.backend-deploy.result == 'success'

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -52,6 +52,18 @@ Notification emails are a side effect of committed events, delivered by Marten e
 - **Deploy safety**: both subscriptions are registered `SubscribeFromPresent` so a first deploy processes only new events (never replaying — and re-emailing — history); the daemon runs in `HotCold` mode so only one instance delivers during a blue/green overlap.
 - **Email**: `IEmailSender` (`Kalandra.Infrastructure/Email/`). The real SMTP sender is registered whenever the `Email` config section exists; a logging no-op is allowed only in Development without config — production refuses to start unconfigured.
 
+## Production config guards
+
+`appsettings.json` carries dev defaults — a localhost database, the local mail catcher, Cloudflare's shared Turnstile test key, `.local` notification addresses. Production overrides each one through `kalandra-api.env`, the file the deploy writes and both slots read. So the config records end with a guard that throws at startup when a dev default survives outside Development: a misconfigured deploy dies loudly rather than quietly mailing into a catcher nobody reads or rubber-stamping every captcha. `SupabaseConfig`, `TurnstileConfig`, `EmailConfig`, `BlogFeedConfig`, `BlogNotificationsConfig`, `JobOffersNotificationsConfig`, `Observability` (Sentry) and `AddAppMarten` (the database) each have one.
+
+**A new guard is only half the change — the deploy has to supply the key it demands.** Otherwise the new container throws on startup, crash-loops, fails the `/health/live` gate and rolls back, and every later push to `main` does the same, so the site quietly stops publishing until someone notices (that was #189). A new guard means touching:
+
+- the `kalandra-api.env` heredoc in `.github/workflows/ci-cd.yml` — what production actually gets;
+- `.github/production-boot.env` — the same key with a fake value;
+- `docs/SETUP.md` §4.1, when the value comes from a GitHub secret or variable.
+
+The `backend-production-boot` CI job keeps the first two honest. It boots the built API with `ASPNETCORE_ENVIRONMENT=Production` against exactly the keys the deploy supplies and fails unless `/health/live` answers, so a guard that outruns its deploy entry fails on the PR instead of on main.
+
 ## Where to put new code
 
 | You want to add...                                  | Goes in                                                                |
@@ -66,6 +78,7 @@ Notification emails are a side effect of committed events, delivered by Marten e
 | A new aggregate field that needs filtering          | Property on the entity + `Duplicate(j => j.Field)` in `MartenConfiguration` |
 | A new business domain                               | New `Kalandra.{Domain}/` project + `Add{Domain}Domain()` extension     |
 | A new external HTTP integration                     | `Kalandra.Infrastructure/{Concern}/` + typed `HttpClient` registration |
+| A new config key production must supply             | Config record + guard, the `kalandra-api.env` heredoc in `ci-cd.yml`, and `.github/production-boot.env` |
 | A new background notification                       | `Kalandra.{Domain}/Notifications/` + a subscription registered in `AddAppMarten` |
 | A new MCP tool                                      | `Kalandra.Api/Features/Mcp/` + call the domain handler directly (see `docs/mcp-server.md`) |
 | A new role                                          | Add to `UserRole` enum + `RequireRole` policy                          |


### PR DESCRIPTION
## What

Adds `backend-production-boot`: a CI job that boots the built API with `ASPNETCORE_ENVIRONMENT=Production` against fake-but-non-localhost values for exactly the keys the deploy supplies, and asserts `GET /health/live` returns 200. Both deploy jobs now require it.

## Why

`Program.cs` registers eight config guards that throw at startup only outside Development — `Observability` (Sentry), `SupabaseConfig`, `TurnstileConfig`, `AddAppMarten` (the database), `BlogFeedConfig`, `EmailConfig`, `BlogNotificationsConfig` and `JobOffersNotificationsConfig`. The `e2e` job is the only one that boots the API, and it sets `ASPNETCORE_ENVIRONMENT: Development`, which short-circuits all of them. **A key production requires but the deploy never supplies was invisible to CI by construction.**

That is [#189](https://github.com/KaliCZ/DemoPage/pull/189): it added the `BlogFeed:RssUrl` guard and documented the key in `docs/mcp-server.md`, but never added it to the deploy. CI was fully green while every push to `main` crash-looped the new container, failed the `/health/live` gate, rolled back and skipped `frontend-deploy` — main went unpublished for ~20 hours across 3 merges before anyone noticed. [#229](https://github.com/KaliCZ/DemoPage/pull/229) fixed the missing key; this closes the gap that hid it.

No infrastructure needed: `/health/live` is dependency-free (only the `live`-tagged `CommitHashHealthCheck`), so it answers 200 with an unreachable database. Every fake value points at `.invalid`, which never resolves (RFC 6761), so a boot sends no traffic — notably none to Sentry, matching what the Playwright jobs already do with `PUBLIC_SENTRY_DSN=""`.

## Keeping it honest

Booting on a hand-maintained env list would re-open the same gap the moment the two drift, so the job **diffs its key list against the deploy's `kalandra-api.env` heredoc** instead. That heredoc is the authoritative list — the quadlet unit reads that file as the API's only config source. Deriving from it means the job needs no knowledge of the guards at all: if the API refuses to start on exactly what the deploy writes, the deploy is broken.

It fails in both directions, which matters — a fake config that drifts *ahead* of the deploy is what silently re-opens the gap:

| Tampering | Result |
|---|---|
| Untouched | passes, `same 14 keys` |
| Deploy gains a key the fake config lacks | fails, names the key |
| Fake config gains a key the deploy lacks | fails, names the key |
| Heredoc reworded so the parse misses it | fails loudly (`Read no keys out of the deploy's heredoc`) — never a silent pass |

The parse is read-only, so the deploy path is byte-identical apart from one comment pointing back here. I considered factoring the heredoc into a script shared by the deploy and this job — a stronger single source, no parsing — but it puts the production deploy path at risk to test it, and that path is exactly what just broke.

I did **not** add a check that every `env:` var reaches the `envs:` allowlist (hand-verified in #229's description): the deploy script runs under `set -euo pipefail`, so an unlisted var is an unbound variable that aborts the deploy loudly, before it touches the running slot. That one already fails closed.

## Verification

Ran the real binary locally in three configurations:

**The job would have failed #189** — dropping `BlogFeed__RssUrl` from the fake config reproduces the production crash exactly, and the process exits:

```
--- /health/live -> PROCESS_EXITED
Unhandled exception. System.InvalidOperationException: BlogFeed:RssUrl still points at localhost — a production deploy must set the real feed URL.
   at Kalandra.Blog.Feed.BlogFeedConfig.AddSingleton(...)
```

**The full config boots and the gate answers**, with `Host=db.invalid` deliberately unreachable:

```
--- /health/live -> 200
{"status":"Healthy","entries":{"version":{"data":{"commit":"local"},"status":"Healthy","tags":["live","ready"]}}}
--- hosting environment line:  Hosting environment: Production
```

**The `--no-launch-profile` trap is real.** Without it, `launchSettings.json` pins `ASPNETCORE_ENVIRONMENT=Development`, and the same run reports:

```
--- /health/live -> 200
--- hosting environment line:  Hosting environment: Development
```

A green job that tested nothing. Hence the flag, and a comment on it.

## Docs

`docs/backend-architecture.md` gains a **Production config guards** section: what the guards are and why they exist, the rule that a new guard is only half the change (the deploy must supply the key, or main quietly stops publishing), the three sites that move together, and a row in the "Where to put new code" table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)