### PR TITLE
fix(ci): name the container images in the workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,6 +24,8 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  API_IMAGE_NAME: kalicz/demopage/api
+  MCP_IMAGE_NAME: kalicz/demopage/mcp
 
 jobs:
   e2e:
@@ -297,7 +299,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
           tags: |
             type=sha
             type=raw,value=latest
@@ -361,7 +363,7 @@ jobs:
           JOB_OFFERS_OWNER_NOTIFICATION_EMAIL: ${{ vars.JOB_OFFERS_OWNER_NOTIFICATION_EMAIL }}
           # Digest-pinned, not :latest — the exact build verified by this run
           # is what runs and what comes back after a reboot.
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ vars.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           EXPECTED_SHA: ${{ github.sha }}
         with:
           host: ${{ vars.OCI_HOST }}
@@ -546,7 +548,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ vars.MCP_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.MCP_IMAGE_NAME }}
           tags: |
             type=sha
             type=raw,value=latest
@@ -596,7 +598,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.BACKEND_SENTRY_DSN }}
           BLOG_FEED_RSS_URL: https://www.kalandra.tech/rss.xml
           MCP_RESOURCE_URI: https://mcp.kalandra.tech
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ vars.MCP_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.MCP_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           EXPECTED_SHA: ${{ github.sha }}
         with:
           host: ${{ vars.OCI_HOST }}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -114,7 +114,7 @@ rewrites only its own port while the base config glob-imports both. The `mcp-dep
 `backend-deploy` (the API applies the schema first) and gates promotion on `/health/live` reporting the
 deployed commit, exactly like the API.
 
-Requires the `MCP_IMAGE_NAME` repo variable and a `mcp.kalandra.tech` DNS record.
+Deploying needs only the `mcp.kalandra.tech` DNS record and the shared Caddy cert covering the subdomain.
 
 ## Testing
 


### PR DESCRIPTION
## What broke

`mcp-deploy` failed on the merge of #225:

```
--tag ghcr.io/:latest
ERROR: failed to build: invalid tag "ghcr.io/:latest": invalid reference format
```

It read the image name from `vars.MCP_IMAGE_NAME`, which was never set. An unset Actions variable renders as an empty string rather than failing, so buildx dutifully built a nonsense tag.

## The fix

The image name was never environment-specific or secret — we choose it, and it has to match the path the quadlets pin (`ghcr.io/kalicz/demopage/mcp`). Making it a variable bought nothing and added a setting that fails silently when forgotten.

Both hosts' names are now literals in the workflow `env:` block, alongside `REGISTRY` and the domains (`mcp.kalandra.tech`, the RSS URL) that were already hardcoded a few lines away:

```yaml
env:
  REGISTRY: ghcr.io
  API_IMAGE_NAME: kalicz/demopage/api
  MCP_IMAGE_NAME: kalicz/demopage/mcp
```

Verified both resolve to exactly what `infra/quadlet/kalandra-{api,mcp}-{blue,green}.container` pin. The API's value matches the `IMAGE_NAME` production variable it replaces, so its deploy is unchanged.

## Follow-up

The `IMAGE_NAME` variable in the `production` environment is now unused and can be deleted.

## Caveat

`mcp-deploy` only runs on push to `main`, so this PR's CI does not exercise the fixed job. The merge is the real test.