### PR TITLE
fix(cv): stop sidebar page break forcing a third page

### DIFF
--- a/frontend/cv/pavel-kalandra-cv.html
+++ b/frontend/cv/pavel-kalandra-cv.html
@@ -213,12 +213,11 @@
         page-break-inside: avoid;
         break-inside: avoid;
       }
-      /* Force DevOps & Quality (and everything after it in the sidebar) onto
-     page 2 — keeps page 1's sidebar focused on tech foundations and pushes
-     the delivery/quality block into the deeper-experience half of the CV. */
+      /* Keep DevOps & Quality together so a page break can't split its list
+     mid-item; it flows naturally to page 2 when it doesn't fit on page 1. */
       .sb-devops {
-        page-break-before: always;
-        break-before: page;
+        page-break-inside: avoid;
+        break-inside: avoid;
       }
       .pm-item {
         margin-bottom: 2mm;


### PR DESCRIPTION
## Problem

The CV rendered as **3 pages** instead of 2. The `.sb-devops` (DevOps & Quality) block in the sidebar carried a hard `page-break-before: always`, which pushed the tail of the sidebar onto page 2 and spilled the document onto a third page.

## Fix

Replaced the forced break with `break-inside: avoid` so the sidebar flows naturally into two pages, guarding only against splitting the block mid-item.

## Verification

Rendered `frontend/cv/pavel-kalandra-cv.html` to PDF via `scripts/generate-cv-pdf.mjs`:
- Before: 3 pages
- After: 2 pages

Visually confirmed both pages in print mode — full-bleed navy sidebar on both pages, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)