### PR TITLE
fix(observability): stop exporting Marten daemon idle-poll spans

### DIFF
--- a/DemoPage.slnx
+++ b/DemoPage.slnx
@@ -8,6 +8,7 @@
   <Project Path="backend/src/Kalandra.McpServer/Kalandra.McpServer.csproj" />
   <Project Path="backend/tests/Kalandra.Api.IntegrationTests/Kalandra.Api.IntegrationTests.csproj" />
   <Project Path="backend/tests/Kalandra.Blog.Tests/Kalandra.Blog.Tests.csproj" />
+  <Project Path="backend/tests/Kalandra.Hosting.Tests/Kalandra.Hosting.Tests.csproj" />
   <Project Path="backend/tests/Kalandra.JobOffers.Tests/Kalandra.JobOffers.Tests.csproj" />
   <Project Path="backend/tests/Kalandra.McpServer.Tests/Kalandra.McpServer.Tests.csproj" />
   <Project Path="backend/tests/Kalandra.Infrastructure.Tests/Kalandra.Infrastructure.Tests.csproj" />

--- a/backend/src/Kalandra.Hosting/DistributedLockPollFilter.cs
+++ b/backend/src/Kalandra.Hosting/DistributedLockPollFilter.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Kalandra.Hosting;
+
+/// <summary>
+/// Unrecords the spans of DistributedLock's leader-election wait loop (savepoint + pg_sleep +
+/// rollback), which the HotCold standby daemon runs around the clock.
+/// </summary>
+public sealed class DistributedLockPollFilter : BaseProcessor<Activity>
+{
+    public override void OnEnd(Activity activity)
+    {
+        if (activity.GetTagItem("db.query.text") is not string statement)
+            return;
+
+        if (statement.Contains("medallion_threading", StringComparison.Ordinal)
+            || statement.Contains("pg_sleep", StringComparison.Ordinal))
+        {
+            activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+        }
+    }
+}

--- a/backend/src/Kalandra.Hosting/MartenDaemonPollSampler.cs
+++ b/backend/src/Kalandra.Hosting/MartenDaemonPollSampler.cs
@@ -1,0 +1,15 @@
+using OpenTelemetry.Trace;
+
+namespace Kalandra.Hosting;
+
+/// <summary>
+/// Root sampler (wrap in <see cref="ParentBasedSampler"/>) that drops the Marten async daemon's
+/// high-water-mark poll — one trace every ~2s around the clock, ~85% of the spans we exported.
+/// </summary>
+public sealed class MartenDaemonPollSampler : Sampler
+{
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        => samplingParameters.Name.EndsWith(".daemon.highwatermark", StringComparison.Ordinal)
+            ? new SamplingResult(SamplingDecision.Drop)
+            : new SamplingResult(SamplingDecision.RecordAndSample);
+}

--- a/backend/src/Kalandra.Hosting/Observability.cs
+++ b/backend/src/Kalandra.Hosting/Observability.cs
@@ -99,7 +99,10 @@ public static class Observability
                                 && !host.EndsWith("ingest.sentry.io", StringComparison.OrdinalIgnoreCase));
                     })
                     .AddSource("Marten")
-                    .AddNpgsql();
+                    .AddNpgsql()
+                    .SetSampler(new ParentBasedSampler(new MartenDaemonPollSampler()))
+                    // Must be registered before the exporters — they enqueue spans on end, so a later filter is too late.
+                    .AddProcessor(new DistributedLockPollFilter());
 
                 if (sentryConfig is not null)
                     tracing.AddSentryOtlpExporter(sentryConfig.Dsn.Value);

--- a/backend/tests/Kalandra.Hosting.Tests/DistributedLockPollFilterTests.cs
+++ b/backend/tests/Kalandra.Hosting.Tests/DistributedLockPollFilterTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+
+namespace Kalandra.Hosting.Tests;
+
+public class DistributedLockPollFilterTests
+{
+    private static Activity NewRecordedActivity(string? statement)
+    {
+        var activity = new Activity("postgresql") { ActivityTraceFlags = ActivityTraceFlags.Recorded };
+
+        if (statement is not null)
+            activity.SetTag("db.query.text", statement);
+
+        return activity;
+    }
+
+    [Theory]
+    [InlineData("SAVEPOINT medallion_threading_postgres_database_connection_sleep")]
+    [InlineData("ROLLBACK TO SAVEPOINT medallion_threading_postgres_database_connection_sleep")]
+    [InlineData("SELECT pg_catalog.pg_sleep(@sleepTimeSeconds)")]
+    public void OnEnd_LockWaitLoopStatement_Unrecords(string statement)
+    {
+        var activity = NewRecordedActivity(statement);
+
+        new DistributedLockPollFilter().OnEnd(activity);
+
+        Assert.False(activity.Recorded);
+    }
+
+    [Theory]
+    [InlineData("select d.data from public.mt_doc_blogreaction as d where d.slug = $1;")]
+    [InlineData("SELECT 1;")]
+    public void OnEnd_RegularStatement_StaysRecorded(string statement)
+    {
+        var activity = NewRecordedActivity(statement);
+
+        new DistributedLockPollFilter().OnEnd(activity);
+
+        Assert.True(activity.Recorded);
+    }
+
+    [Fact]
+    public void OnEnd_NoStatementTag_StaysRecorded()
+    {
+        var activity = NewRecordedActivity(statement: null);
+
+        new DistributedLockPollFilter().OnEnd(activity);
+
+        Assert.True(activity.Recorded);
+    }
+}

--- a/backend/tests/Kalandra.Hosting.Tests/GlobalUsings.cs
+++ b/backend/tests/Kalandra.Hosting.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/backend/tests/Kalandra.Hosting.Tests/Kalandra.Hosting.Tests.csproj
+++ b/backend/tests/Kalandra.Hosting.Tests/Kalandra.Hosting.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kalandra.Hosting\Kalandra.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/Kalandra.Hosting.Tests/MartenDaemonPollSamplerTests.cs
+++ b/backend/tests/Kalandra.Hosting.Tests/MartenDaemonPollSamplerTests.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Kalandra.Hosting.Tests;
+
+public class MartenDaemonPollSamplerTests
+{
+    private static TracerProvider NewProvider(string sourceName) =>
+        Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new ParentBasedSampler(new MartenDaemonPollSampler()))
+            .Build();
+
+    [Fact]
+    public void ShouldSample_HighWaterMarkPoll_DropsTheRootAndItsChildren()
+    {
+        using var source = new ActivitySource("test-hwm-poll");
+        using var provider = NewProvider(source.Name);
+
+        using var poll = source.StartActivity("marten.daemon.highwatermark");
+        Assert.NotNull(poll);
+        Assert.False(poll.Recorded);
+
+        // The SDK doesn't even create children of a dropped root — nothing reaches the exporters.
+        using var databaseQuery = source.StartActivity("db query under the poll");
+        Assert.Null(databaseQuery);
+    }
+
+    [Fact]
+    public void ShouldSample_OtherRoots_RecordsThemAndTheirChildren()
+    {
+        using var source = new ActivitySource("test-hwm-other");
+        using var provider = NewProvider(source.Name);
+
+        using var request = source.StartActivity("GET api/blog/{slug}/comments");
+        Assert.NotNull(request);
+        Assert.True(request.Recorded);
+
+        using var databaseQuery = source.StartActivity("db query under the request");
+        Assert.NotNull(databaseQuery);
+        Assert.True(databaseQuery.Recorded);
+    }
+
+    [Fact]
+    public void ShouldSample_OtherDaemonActivities_RecordsThem()
+    {
+        using var source = new ActivitySource("test-hwm-daemon");
+        using var provider = NewProvider(source.Name);
+
+        using var projectionPage = source.StartActivity("marten.blogcommentnotificationsubscription.all.page.execution");
+        Assert.NotNull(projectionPage);
+        Assert.True(projectionPage.Recorded);
+    }
+}


### PR DESCRIPTION
## Problem

kalandra-be sent **~742k spans to Sentry over the past week**. Breaking it down in Sentry's trace explorer:

| Source | Spans | Share |
|---|---|---|
| `marten.daemon.highwatermark` — async daemon high-water-mark poll, one 2-span trace every ~2s, 24/7 | 632k | ~85% |
| Medallion DistributedLock leader-lock wait loop (`SAVEPOINT medallion_threading…` / `pg_sleep` / `ROLLBACK`, single-span traces) | 32k | ~4% |
| Actual traffic + connection telemetry | ~78k | ~11% |

Neither idle loop carries any signal — the poll runs regardless of whether there are events to process. JasperFx offers no toggle for the poll activity, so the noise is cut in our OTel pipeline instead, keeping all useful Marten telemetry (sessions, connections, projection/subscription runs).

## Change

- **`MartenDaemonPollSampler`** — root sampler (inside a `ParentBasedSampler`, which otherwise preserves the default sampling behavior) that drops root activities named `*.daemon.highwatermark`. The SDK then never even creates the poll's child spans.
- **`DistributedLockPollFilter`** — processor registered ahead of the exporters that unrecords spans whose `db.query.text` is the lock-wait loop (`medallion_threading` savepoints, `pg_sleep`).
- New `Kalandra.Hosting.Tests` project covering both.

This applies to every trace exporter (Sentry, BetterStack, Aspire dashboard) — the loops are noise in all of them. Expected span volume drops by ~90%.

## Verification

Beyond unit tests (and the full `npm test` suite passing locally), verified end-to-end by running the API with its OTLP exporter pointed at a local capture sink for ~3.5 minutes with the daemon leader active (`Started HighWaterAgent` logged):

- `daemon.highwatermark` spans exported: **0** (~100 poll cycles suppressed)
- Still exported: `GET api/blog/…` request traces, `marten.connection` spans, Npgsql spans with statements, subscription progress writes
- Only residue: 2 one-off `postgresql` spans from the startup-time high-water-mark detection that runs outside the poll activity — per app start, not per poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)