### PR TITLE
fix(mcp): challenge misshapen tool calls instead of crashing on them

### DIFF
--- a/backend/src/Kalandra.McpServer/Infrastructure/McpAccountGate.cs
+++ b/backend/src/Kalandra.McpServer/Infrastructure/McpAccountGate.cs
@@ -81,15 +81,15 @@ public static class McpAccountGate
         context.Request.EnableBuffering();
         try
         {
+            // Fail closed: a tools/call is an account call unless it names a public tool. That covers
+            // misshapen calls too (params or name missing or of the wrong kind) — challenging them keeps
+            // them out of the SDK, which answers each with a protocol error only after alerting at Error.
             using var document = await JsonDocument.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
             return document.RootElement is { ValueKind: JsonValueKind.Object } request
                 && request.TryGetProperty("method", out var method)
                 && method.ValueKind == JsonValueKind.String
                 && method.ValueEquals("tools/call")
-                && request.TryGetProperty("params", out var parameters)
-                && parameters.TryGetProperty("name", out var name)
-                && name.GetString() is { } toolName
-                && !PublicTools.Contains(toolName);
+                && !NamesAPublicTool(request);
         }
         catch (JsonException)
         {
@@ -101,4 +101,12 @@ public static class McpAccountGate
             context.Request.Body.Position = 0;
         }
     }
+
+    private static bool NamesAPublicTool(JsonElement request) =>
+        request.TryGetProperty("params", out var parameters)
+        && parameters.ValueKind == JsonValueKind.Object
+        && parameters.TryGetProperty("name", out var name)
+        && name.ValueKind == JsonValueKind.String
+        && name.GetString() is { } toolName
+        && PublicTools.Contains(toolName);
 }

--- a/backend/tests/Kalandra.McpServer.Tests/ToolAuthorizationTests.cs
+++ b/backend/tests/Kalandra.McpServer.Tests/ToolAuthorizationTests.cs
@@ -90,6 +90,26 @@ public class ToolAuthorizationTests(McpServerFactory factory) : IClassFixture<Mc
         Assert.Contains("error=\"invalid_token\"", challenge.Parameter);
     }
 
+    [Theory]
+    // Valid JSON in shapes the protocol never produces: params that aren't an object, a tool name that
+    // isn't a string, no params at all. Scanners send these anonymously, and anything but the gate's own
+    // challenge is noise — a 500 out of the gate, or the SDK alerting at Error before it answers. A call
+    // that names no public tool is an account call, however misshapen (fail closed).
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":null}""")]
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":[]}""")]
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":"get_my_comments"}""")]
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":123}}""")]
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"arguments":{}}}""")]
+    [InlineData("""{"jsonrpc":"2.0","id":6,"method":"tools/call"}""")]
+    public async Task AMisshapenToolCall_WithoutAToken_IsChallengedLikeAnyAccountCall(string jsonRpc)
+    {
+        var response = await factory.PostMcp(jsonRpc);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var challenge = Assert.Single(response.Headers.WwwAuthenticate);
+        Assert.Equal("Bearer", challenge.Scheme);
+    }
+
     [Fact]
     public async Task AFirstVisitWithNoToken_GetsAPlainChallenge_NotAnErrorCode()
     {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -54,9 +54,11 @@ Assistant ──1── POST /mcp (no token)  →  anonymous tier: whole toolset
 - **`McpAccountGate` issues that challenge**, as middleware ahead of the endpoint. It has to sit there: the SDK
   cannot challenge from inside a tool, because by then the response is already a JSON-RPC envelope, and stock
   `RequireAuthorization` would shut the anonymous tier out of the whole endpoint while never seeing the body
-  that says which tool is wanted. It owns the list of public tools, so a new tool is account-only until named
-  there; `ToolAuthorizationTests` calls every listed tool without a token and fails if one answers that
-  shouldn't. `McpToolHelpers.RequireUser` stays as the backstop inside each tool.
+  that says which tool is wanted. It owns the list of public tools and fails closed: an anonymous tools/call
+  is challenged unless it names a public tool, which covers unknown tools, new tools not yet named public, and
+  misshapen calls that name nothing at all — bot traffic that would otherwise reach the SDK and alert at Error
+  on every probe. `ToolAuthorizationTests` calls every listed tool without a token and fails if one answers
+  that shouldn't. `McpToolHelpers.RequireUser` stays as the backstop inside each tool.
 - **The whole toolset is listed to everyone**, each account tool's description prefixed `[Authorized]`. A tool
   the model cannot see is a tool it cannot offer, so hiding them left it unable to tell the user what the site
   can do. The SDK's `AddAuthorizationFilters()` would honor `[Authorize]`/`[AllowAnonymous]` attributes, but


### PR DESCRIPTION
[Sentry issue 131475723](https://kalandra.sentry.io/issues/131475723/?project=4511432522465360) — an unhandled `InvalidOperationException` out of `McpAccountGate` on anonymous `POST /mcp` probes.

## Root cause

`McpAccountGate.IsAccountToolCall` sniffs the JSON-RPC body to decide whether a `tools/call` needs the OAuth challenge. It guarded against malformed JSON (`JsonException`) but not against valid JSON in shapes the protocol never produces:

- `"params": null`, `[]`, or a string → `parameters.TryGetProperty("name", …)` throws `InvalidOperationException` (the element isn't an Object)
- `"params": {"name": 123}` → `name.GetString()` throws the same way

Each such probe — and this endpoint gets scanner traffic; KALANDRA-BE-20 was the same crowd — 500s and lands in Sentry as an error event. A third shape, `tools/call` with no `params` member at all, took a different path to the same dashboard: it slipped past the gate as "not an account call" and reached the SDK, which answers it only after logging `"" threw an unhandled exception` (`McpProtocolException`) at Error. All of this shipped with #233 (merged Jul 16), which matches the issue's window.

## Fix

The gate now fails closed the way #233 already prescribed for unknown tool names ("not public ⇒ account"): **an anonymous `tools/call` is challenged unless it names a public tool**. Misshapen calls name no public tool, so they get the same silent 401 + `WWW-Authenticate` challenge as any account call — nothing reaches the SDK, nothing logs, nothing lands in Sentry. Bona-fide malformed JSON keeps its existing answer (the transport's own 400, which logs nothing).

| Anonymous request | Before | Now |
|---|---|---|
| `tools/call`, `params` null / array / string, or non-string `name` | 500, Sentry error event | 401 + challenge |
| `tools/call`, no `params` at all | answered by the SDK, logged at Error → Sentry | 401 + challenge |
| `tools/call`, unknown string tool name | 401 + challenge | unchanged |
| public tool call · malformed JSON · invalid envelope | served · silent 400 · silent 400 | unchanged |

Signed-in callers are untouched: an authenticated request skips the gate entirely, so a buggy-but-authorized client still gets the SDK's protocol error — which keeps alerting, per #233's "protocol faults keep reporting" rule (`McpToolErrorsTests` still pins that).

## Verification

- New `ToolAuthorizationTests` theory sends the six misshapen shapes anonymously and requires the Bearer challenge for each. Before the fix, four of them reproduced the 500 (`InvalidOperationException` at `McpAccountGate.IsAccountToolCall`) and the params-less one reproduced the SDK's Error log.
- All five non-Docker backend test projects green locally (145 tests), frontend Playwright suite green (29 tests). The API integration tests and E2E stage need Docker/Supabase, which this sandbox doesn't have — leaving those to CI, which I'll watch.

## Caveat

I couldn't read the Sentry issue's content from this session (every Sentry MCP call was declined), so the diagnosis comes from auditing both .NET hosts for anonymously-reachable Warning+/exception paths and reproducing this one — the only unconditionally-triggerable unhandled exception an anonymous request can produce, introduced right in the issue's timeframe. If the Sentry issue turns out to be a different signature, say the word and I'll re-target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013r8TWwNV5xxahRG41nubJt

---
_Generated by [Claude Code](https://claude.ai/code/session_013r8TWwNV5xxahRG41nubJt)_