### PR TITLE
fix(frontend): stop canonical URLs from pointing at redirects

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -6,6 +6,8 @@ Astro SSG site with Tailwind CSS, deployed to Cloudflare Pages as static files. 
 
 Every route page lives in `pages/[...lang]/` and uses Astro's rest parameter to handle all locales from a single file. English gets no prefix (`/about`), Czech gets `/cs/about`.
 
+URLs never carry a trailing slash — `trailingSlash: "never"` + `build.format: "file"` in `astro.config.mjs` make Cloudflare Pages serve `/about` directly and 308 `/about/` into it. Home pages are `/` and `/cs`. Build every link, canonical, and sitemap entry through `localePath` so all signals agree on the slash-less form (mismatched signals get duplicate URLs indexed by Google).
+
 **Translation file rules:**
 
 - One JSON file per page per language, plus `common.json` for shared strings (nav, footer, auth, a11y).
@@ -95,7 +97,7 @@ Posts are first-class Astro pages, not a CMS — git is the source of truth.
 
 ## Sitemap
 
-`/sitemap.xml` is a custom endpoint (`src/pages/sitemap.xml.ts`), not an integration. A static page opts in by exporting `pageMeta` (`src/lib/page-meta.ts`); its `updatedDate` becomes the `<lastmod>` — **bump it when you meaningfully edit a page**. Pages without the export (profile, admin, auth callback) stay out of the sitemap. Blog posts contribute `updatedDate ?? pubDate` from their own metadata and emit URLs only for their declared languages (hreflang alternates only when a post declares more than one); the blog index entry tracks the newest post.
+`/sitemap.xml` is a custom endpoint (`src/pages/sitemap.xml.ts`), not an integration. A static page opts in by exporting `pageMeta` (`src/lib/page-meta.ts`); its `updatedDate` becomes the `<lastmod>` — **bump it when you meaningfully edit a page**. Pages without the export (profile, admin, auth callback) stay out of the sitemap; the auth-gated shells among them (profile, admin pages, job-offers detail) additionally pass `noindex` to Layout so crawlers that find them via the CSS-hidden admin nav links don't index them. Blog posts contribute `updatedDate ?? pubDate` from their own metadata and emit URLs only for their declared languages (hreflang alternates only when a post declares more than one); the blog index entry tracks the newest post.
 
 ## Accessibility
 

--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -19,10 +19,13 @@ const sentryProject = process.env.SENTRY_PROJECT;
 
 export default defineConfig({
   site,
+  // Paired with `build.format: "file"` so Cloudflare Pages serves the slash-less URLs that canonicals, sitemap, and links declare.
+  trailingSlash: "never",
   server: {
     port: process.env.PORT ? Number(process.env.PORT) : undefined,
   },
   build: {
+    format: "file",
     inlineStylesheets: "always",
   },
   // The sitemap is a custom endpoint (src/pages/sitemap.xml.ts) fed by per-page

--- a/frontend/src/components/BlogPostLayout.astro
+++ b/frontend/src/components/BlogPostLayout.astro
@@ -19,8 +19,13 @@ const { metadata, lang } = Astro.props;
 const t = lang === "cs" ? csBlog : enBlog;
 
 // The slug is the last path segment — identical for /blog/x and /cs/blog/x —
-// and keys the post's reaction and comment streams in the backend.
-const slug = Astro.url.pathname.replace(/\/$/, "").split("/").pop()!;
+// and keys the post's reaction and comment streams in the backend. At build time
+// `build.format: "file"` makes the segment end in ".html", so strip it.
+const slug = Astro.url.pathname
+  .replace(/\/$/, "")
+  .split("/")
+  .pop()!
+  .replace(/\.html$/, "");
 const pagePath = `blog/${slug}`;
 
 // blogPostStaticPaths only builds routes for declared languages, so the variant exists.

--- a/frontend/src/i18n/utils.ts
+++ b/frontend/src/i18n/utils.ts
@@ -5,16 +5,16 @@ export const defaultLocale: Locale = "en";
 /**
  * Returns the locale-prefixed path for a given page.
  * English (default locale) has no prefix; Czech uses /cs.
+ * Never emits a trailing slash (home is "/" or "/cs") — the site-wide URL convention, see astro.config.mjs.
  */
 export function localePath(lang: Locale, page: string): string {
   const base = lang === "cs" ? "/cs" : "";
-  return page === "home" ? `${base}/` : `${base}/${page}`;
+  return page === "home" ? base || "/" : `${base}/${page}`;
 }
 
 /**
  * Returns the alternate-language URL for the language picker.
  */
 export function alternateLangUrl(targetLang: Locale, activePage: string): string {
-  const base = targetLang === "cs" ? "/cs" : "";
-  return activePage === "home" ? `${base}/` : `${base}/${activePage}`;
+  return localePath(targetLang, activePage);
 }

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import AuthDialog from "../components/AuthDialog.astro";
 import Navbar from "../components/Navbar.astro";
 import Snackbar from "../components/Snackbar.astro";
 import Footer from "../components/Footer.astro";
-import { locales, type Locale } from "../i18n/utils";
+import { locales, localePath, type Locale } from "../i18n/utils";
 import { feed } from "../blog/feeds";
 
 import enCommon from "../i18n/en/common.json";
@@ -56,9 +56,9 @@ const {
 const t = lang === "cs" ? csCommon : enCommon;
 
 const siteUrl = "https://www.kalandra.tech";
-const canonicalPath = pagePath ?? (activePage === "home" ? "" : activePage);
-const enUrl = canonicalPath === "" ? `${siteUrl}/` : `${siteUrl}/${canonicalPath}`;
-const csUrl = canonicalPath === "" ? `${siteUrl}/cs/` : `${siteUrl}/cs/${canonicalPath}`;
+const canonicalPage = pagePath ?? activePage;
+const enUrl = `${siteUrl}${localePath("en", canonicalPage)}`;
+const csUrl = `${siteUrl}${localePath("cs", canonicalPage)}`;
 const canonicalUrl = lang === "cs" ? csUrl : enUrl;
 ---
 

--- a/frontend/src/pages/[...lang]/admin/job-offers.astro
+++ b/frontend/src/pages/[...lang]/admin/job-offers.astro
@@ -25,7 +25,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || "";
 const detailPath = localePath(lang, "admin/job-offers/detail");
 ---
 
-<Layout title={t.meta.title} description={t.meta.description} activePage="admin/job-offers" lang={lang}>
+<Layout title={t.meta.title} description={t.meta.description} activePage="admin/job-offers" lang={lang} noindex>
   <!-- Hero -->
   <section class="max-w-5xl mx-auto px-8 mb-16">
     <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-6">

--- a/frontend/src/pages/[...lang]/admin/job-offers/detail.astro
+++ b/frontend/src/pages/[...lang]/admin/job-offers/detail.astro
@@ -31,6 +31,7 @@ const listPath = localePath(lang, "admin/job-offers");
   activePage="admin/job-offers"
   pagePath="admin/job-offers/detail"
   lang={lang}
+  noindex
 >
   <!-- Hero -->
   <section class="max-w-5xl mx-auto px-8 mb-16">

--- a/frontend/src/pages/[...lang]/admin/test-errors.astro
+++ b/frontend/src/pages/[...lang]/admin/test-errors.astro
@@ -21,7 +21,7 @@ const t = translations[lang];
 const c = commons[lang];
 ---
 
-<Layout title={t.meta.title} description={t.meta.description} activePage="admin/test-errors" lang={lang}>
+<Layout title={t.meta.title} description={t.meta.description} activePage="admin/test-errors" lang={lang} noindex>
   <!-- Hero -->
   <section class="max-w-5xl mx-auto px-8 mb-16">
     <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-6">

--- a/frontend/src/pages/[...lang]/job-offers/detail.astro
+++ b/frontend/src/pages/[...lang]/job-offers/detail.astro
@@ -29,7 +29,14 @@ const apiUrl = import.meta.env.PUBLIC_API_URL || "";
 const listPath = localePath(lang, "job-offers");
 ---
 
-<Layout title={t.detailMeta.title} description={t.detailMeta.description} activePage="job-offers" pagePath="job-offers/detail" lang={lang}>
+<Layout
+  title={t.detailMeta.title}
+  description={t.detailMeta.description}
+  activePage="job-offers"
+  pagePath="job-offers/detail"
+  lang={lang}
+  noindex
+>
   <!-- Hero -->
   <section class="max-w-5xl mx-auto px-8 mb-16">
     <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-6">

--- a/frontend/src/pages/[...lang]/profile.astro
+++ b/frontend/src/pages/[...lang]/profile.astro
@@ -18,7 +18,7 @@ const lang = (Astro.params.lang ?? defaultLocale) as Locale;
 const t = translations[lang];
 ---
 
-<Layout title={t.meta.title} description={t.meta.description} activePage="profile" lang={lang}>
+<Layout title={t.meta.title} description={t.meta.description} activePage="profile" lang={lang} noindex>
   <!-- Hero -->
   <section class="max-w-3xl mx-auto px-8 mb-16">
     <h1 class="font-headline text-5xl md:text-7xl font-extrabold tracking-tighter leading-none mb-6">

--- a/frontend/tests/pages.spec.ts
+++ b/frontend/tests/pages.spec.ts
@@ -9,7 +9,7 @@ test.describe("Page rendering", () => {
   });
 
   test("home page loads in Czech", async ({ page }) => {
-    await page.goto("/cs/");
+    await page.goto("/cs");
     await expect(page).toHaveTitle(/kalandra\.tech/);
     await expect(page.getByRole("link", { name: "Najměte mě" })).toBeVisible();
   });


### PR DESCRIPTION
## Problem

Google Search Console flagged canonical inconsistencies: several pages indexed twice (with and without trailing slash — all the `/cs/*` pages, `/job-offers/detail`, the `?page=1&pageSize=1` variants), the blog post indexed under the slash form, and `/admin/test-errors` + `/profile` indexed at all.

Root cause: Astro's default `build.format: "directory"` emits `about/index.html`, so Cloudflare Pages 308-redirects `/about` → `/about/` — while every signal the site emits (rel=canonical, hreflang, sitemap `<loc>`, internal nav links, RSS) declares the slash-less `/about`. Every canonical pointed at a URL that redirects straight back to the page. Faced with contradictory signals, Google resolved canonicals inconsistently and indexed duplicates.

## Fix

- `trailingSlash: "never"` + `build.format: "file"` — the build now emits `about.html`, so Cloudflare Pages serves `/about` directly (200) and 308s `/about/` into it. Serving finally agrees with every declared signal.
- The Czech home moves from `/cs/` to `/cs`; `Layout` canonicals now derive through `localePath` so canonicals and links can't drift apart again.
- `BlogPostLayout` strips the `.html` suffix that file-format builds leak into `Astro.url.pathname` — it was reaching blog hreflang, the language picker, and the comment/reaction stream keys.
- `noindex` on the auth-gated shells (`profile`, `admin/test-errors`, `admin/job-offers`(+detail), `job-offers/detail`) — crawlers discover them through the CSS-hidden admin nav links present in every page's HTML.

## Verification

- Full suite green locally: 253 backend, 29 frontend Playwright, 21 E2E.
- Built artifacts inspected: sitemap fully slash-less (`/` and `/cs` homes), canonicals + hreflang aligned, `noindex` on all seven shell pages, zero `.html` residue in blog pages.

## After merge

- Verify on production: `curl -sI https://www.kalandra.tech/about/` should now 308 → `/about` (the flipped direction).
- GSC will look worse before better: slash URLs move to "Page with redirect" and duplicates consolidate over a few weeks. That's the healing process, not breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)