### PR TITLE
fix(tests): make notification-email waits deterministic instead of wall-clock

### DIFF
--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/Blog/BlogApiTests.cs
@@ -785,7 +785,7 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         var response = await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content }, Ct);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var email = Assert.Single(await WaitForEmailsAsync(m => m.TextBody.Value.Contains(content), expectedCount: 1));
+        var email = Assert.Single(await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(content)));
         Assert.Equal("author@kalandra.local", email.To.Address);
         Assert.Contains(slug, email.Subject.Value);
         Assert.Contains($"https://www.kalandra.tech/blog/{slug}", email.TextBody.Value);
@@ -804,7 +804,7 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         Authenticate(userId: Guid.NewGuid(), email: "replier@test.com");
         await client.PostAsJsonAsync($"/api/blog/{slug}/comments", new { content = replyContent, parentCommentId = parentId }, Ct);
 
-        var emails = await WaitForEmailsAsync(m => m.TextBody.Value.Contains(replyContent), expectedCount: 2);
+        var emails = await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(replyContent));
         Assert.Equal(2, emails.Length);
         Assert.Contains(emails, m => m.To.Address == "author@kalandra.local");
         var parentNotification = Assert.Single(emails, m => m.To.Address == "parent-author@test.com");
@@ -825,10 +825,7 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
             new { content = replyContent, parentCommentId = parent.GetProperty("id").GetString() },
             Ct);
 
-        var emails = await WaitForEmailsAsync(m => m.TextBody.Value.Contains(replyContent), expectedCount: 1);
-        // Grace period: a wrong extra notification would arrive moments later.
-        await Task.Delay(1500, Ct);
-        emails = [.. factory.EmailSender.Sent.Where(m => m.TextBody.Value.Contains(replyContent))];
+        var emails = await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(replyContent));
 
         var email = Assert.Single(emails);
         Assert.Equal("author@kalandra.local", email.To.Address);
@@ -849,25 +846,10 @@ public class BlogApiTests(TestWebApplicationFactory factory) : IClassFixture<Tes
         var comments = (await ParseJsonAsync(await client.GetAsync($"/api/blog/{slug}/comments", Ct))).GetProperty("comments");
         Assert.Equal(1, comments.GetArrayLength());
 
-        await Task.Delay(1500, Ct);
-        Assert.DoesNotContain(factory.EmailSender.Sent, m => m.TextBody.Value.Contains(content));
+        Assert.Empty(await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(content)));
     }
 
     // ───── Helpers ─────
-
-    private async Task<Kalandra.Infrastructure.Email.EmailMessage[]> WaitForEmailsAsync(
-        Func<Kalandra.Infrastructure.Email.EmailMessage, bool> predicate, int expectedCount)
-    {
-        var deadline = DateTime.UtcNow.AddSeconds(20);
-        while (DateTime.UtcNow < deadline)
-        {
-            var matches = factory.EmailSender.Sent.Where(predicate).ToArray();
-            if (matches.Length >= expectedCount)
-                return matches;
-            await Task.Delay(200, Ct);
-        }
-        return [.. factory.EmailSender.Sent.Where(predicate)];
-    }
 
     /// <summary>Unique per test — the factory shares one database across the class.</summary>
     private static string NewSlug() => $"post-{Guid.NewGuid():N}";

--- a/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Features/JobOffers/JobOfferApiTests.cs
@@ -697,7 +697,7 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var offerId = AssertValidGuid(await ParseJsonAsync(response), "id");
 
-        var email = Assert.Single(await WaitForEmailsAsync(m => m.TextBody.Value.Contains(marker), expectedCount: 1));
+        var email = Assert.Single(await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(marker)));
         Assert.Equal("owner@kalandra.local", email.To.Address);
         Assert.Equal("New job offer: Senior Developer at Acme Corp", email.Subject.Value);
         Assert.Contains("john@acme.com", email.TextBody.Value);
@@ -713,10 +713,7 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
         var response = await client.PostAsJsonAsync($"/api/job-offers/{id}/comments", new { content = marker }, Ct);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var emails = await WaitForEmailsAsync(m => m.TextBody.Value.Contains(marker), expectedCount: 1);
-        // Grace period: a wrong extra notification would arrive moments later.
-        await Task.Delay(1500, Ct);
-        emails = [.. factory.EmailSender.Sent.Where(m => m.TextBody.Value.Contains(marker))];
+        var emails = await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(marker));
 
         var email = Assert.Single(emails);
         Assert.Equal("owner@kalandra.local", email.To.Address);
@@ -734,10 +731,7 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
         var response = await client.PostAsJsonAsync($"/api/job-offers/{id}/comments", new { content = marker }, Ct);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var emails = await WaitForEmailsAsync(m => m.TextBody.Value.Contains(marker), expectedCount: 1);
-        // Grace period: a wrong extra notification would arrive moments later.
-        await Task.Delay(1500, Ct);
-        emails = [.. factory.EmailSender.Sent.Where(m => m.TextBody.Value.Contains(marker))];
+        var emails = await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(marker));
 
         var email = Assert.Single(emails);
         Assert.Equal("notified-author@test.com", email.To.Address);
@@ -755,7 +749,7 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
         var response = await client.PostAsJsonAsync($"/api/job-offers/{id}/comments", new { content = marker }, Ct);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var emails = await WaitForEmailsAsync(m => m.TextBody.Value.Contains(marker), expectedCount: 2);
+        var emails = await factory.WaitForDeliveredEmailsAsync(m => m.TextBody.Value.Contains(marker));
         Assert.Equal(2, emails.Length);
         Assert.Contains(emails, m => m.To.Address == "owner@kalandra.local");
         Assert.Contains(emails, m => m.To.Address == "watched-author@test.com");
@@ -809,20 +803,6 @@ public class JobOfferApiTests(TestWebApplicationFactory factory) : IClassFixture
     // ───── Helpers ─────
 
     private static readonly Guid AdminUserId = new("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
-    private async Task<Kalandra.Infrastructure.Email.EmailMessage[]> WaitForEmailsAsync(
-        Func<Kalandra.Infrastructure.Email.EmailMessage, bool> predicate, int expectedCount)
-    {
-        var deadline = DateTime.UtcNow.AddSeconds(20);
-        while (DateTime.UtcNow < deadline)
-        {
-            var matches = factory.EmailSender.Sent.Where(predicate).ToArray();
-            if (matches.Length >= expectedCount)
-                return matches;
-            await Task.Delay(200, Ct);
-        }
-        return [.. factory.EmailSender.Sent.Where(predicate)];
-    }
 
     private Guid Authenticate(
         string email = "test@example.com",

--- a/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
+++ b/backend/tests/Kalandra.Api.IntegrationTests/Helpers/TestWebApplicationFactory.cs
@@ -5,6 +5,9 @@ using Kalandra.Infrastructure.Email;
 using Kalandra.Infrastructure.Storage;
 using Kalandra.Infrastructure.Turnstile;
 using Kalandra.Infrastructure.Users;
+using Marten;
+using Marten.Events;
+using Marten.Events.Daemon.Coordination;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -38,9 +41,25 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
     private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:17-alpine")
         .Build();
 
+    // Generous because CI runs Docker and several test hosts in parallel; progress-based waits return
+    // the moment the daemon catches up, so the cap only bites when something is genuinely broken.
+    private static readonly TimeSpan AsyncDaemonTimeout = TimeSpan.FromSeconds(60);
+
     public FakeSupabaseAdminService FakeAdminService { get; } = new();
     public TestEmailSender EmailSender { get; } = new();
     public FakeUserInfoService UserInfoService { get; } = new();
+
+    /// <summary>
+    /// Waits until the async daemon has processed every event committed so far, then returns the sent
+    /// emails matching the predicate. The result is final for those events — a missing or extra
+    /// notification is a real bug, not a race — so callers assert exact counts without sleeping.
+    /// </summary>
+    public async Task<EmailMessage[]> WaitForDeliveredEmailsAsync(Func<EmailMessage, bool> predicate)
+    {
+        var store = Services.GetRequiredService<IDocumentStore>();
+        await store.WaitForNonStaleProjectionDataAsync(AsyncDaemonTimeout);
+        return [.. EmailSender.Sent.Where(predicate)];
+    }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -106,6 +125,29 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
     public async ValueTask InitializeAsync()
     {
         await _postgres.StartAsync();
+        await WaitForNotificationSubscriptionsToStartAsync();
+    }
+
+    // SubscribeFromPresent seeds each subscription at the current high-water mark when its shard starts —
+    // an event committed before that would be skipped, never emailed. Agents register only after seeding,
+    // so waiting for registration while the database is still empty guarantees no test event is missed.
+    private async Task WaitForNotificationSubscriptionsToStartAsync()
+    {
+        var store = (DocumentStore)Services.GetRequiredService<IDocumentStore>();
+        var expectedShards = store.Options.Projections.AllShards().Select(shard => shard.Name.Identity).ToHashSet();
+        var daemon = Services.GetRequiredService<IProjectionCoordinator>().DaemonForMainDatabase();
+
+        using var cancellation = new CancellationTokenSource(AsyncDaemonTimeout);
+        try
+        {
+            while (!expectedShards.IsSubsetOf(daemon.CurrentAgents().Select(agent => agent.Name.Identity)))
+                await Task.Delay(100, cancellation.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new TimeoutException(
+                $"The async daemon did not start subscriptions [{string.Join(", ", expectedShards)}] within {AsyncDaemonTimeout}.");
+        }
     }
 
     public new async ValueTask DisposeAsync()


### PR DESCRIPTION
## Problem

`JobOfferApiTests.Create_NotifiesTheOwner` is flaky under full `npm test` load: it spent ~21s waiting for the job-offer notification, then failed with `Assert.Single() Failure: The collection was empty`, while passing in isolation.

The notification tests polled `factory.EmailSender.Sent` against a fixed 20-second wall-clock deadline. Under load that breaks two distinct ways:

1. **Slow daemon** — with Docker + several parallel test hosts, the async daemon can legitimately take longer than 20s to deliver. The deadline gives up while delivery is still in flight.
2. **A silent-skip race at startup** — the subscriptions register `SubscribeFromPresent`, which seeds each shard''s starting position at the current high-water mark *when the shard starts*. The daemon acquires HotCold leadership in the background after the host already serves requests, so under load an event committed by an early test before the seed is skipped forever — no timeout ever sees that email.

## Fix (test infrastructure only)

- `TestWebApplicationFactory.InitializeAsync` now blocks until every subscription agent is registered with the daemon. Agents register only after their position is seeded, and at fixture init the database is still empty, so no test event can ever land before the subscriptions listen.
- The duplicated per-class `WaitForEmailsAsync` (fixed 20s poll) is replaced by one factory helper that awaits Marten''s `WaitForNonStaleProjectionDataAsync` — it tracks actual daemon progress up to the event-store sequence at call time, with a generous 60s cap that only bites when something is genuinely broken, and rich shard diagnostics on timeout.
- Once the daemon has caught up, delivery for the committed events is final — so the `Task.Delay(1500)` "no extra email" grace sleeps are gone and those assertions are now deterministic (previously a slow daemon delivering a *wrong* extra email after the grace window would falsely pass).

No production code changed.

## Verification

- Full integration suite: 108/108 in ~11s (notification tests are faster without the grace sleeps).
- 3 concurrent runs of the whole integration suite (18 PostgreSQL containers churning): all green.
- Full `npm test` (backend + frontend + E2E): all green; integration suite finished in 12s under that load, where the flake used to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)